### PR TITLE
Real-time trace streaming via WebSocket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,4 +128,57 @@ jobs:
           test "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3000/traces)" = "200"
           # Redirect has Location header
           curl -sI http://127.0.0.1:3000/ | grep -i '^location:' | grep -q '/traces'
-          docker rm -f synaptic-ci
+      - name: Cleanup container
+        if: always()
+        run: docker rm -f synaptic-ci || true
+
+  e2e:
+    name: E2E browser tests (Playwright)
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: packages/dashboard/package-lock.json
+      - name: Install dashboard deps
+        working-directory: packages/dashboard
+        run: npm install --no-audit --no-fund
+      - name: Install Playwright browsers
+        working-directory: packages/dashboard
+        run: npx playwright install --with-deps chromium
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build container (cache hit from docker job)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          tags: zistica/synaptic:e2e
+          cache-from: type=gha
+      - name: Start container
+        run: |
+          docker run -d --name synaptic-e2e -p 3000:3000 -p 8000:8000 zistica/synaptic:e2e
+          for i in $(seq 1 30); do
+            sleep 1
+            curl -sf http://127.0.0.1:8000/health >/dev/null 2>&1 && break
+          done
+      - name: Run Playwright tests
+        working-directory: packages/dashboard
+        run: npm run test:e2e
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            packages/dashboard/playwright-report/
+            packages/dashboard/test-results/
+          retention-days: 7
+      - name: Cleanup
+        if: always()
+        run: docker rm -f synaptic-e2e || true

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ dist/
 build/
 *.tar.gz
 *.zip
+/package-lock.json

--- a/packages/api/main.py
+++ b/packages/api/main.py
@@ -4,10 +4,11 @@ import os
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 
-from fastapi import FastAPI
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 from db import Database, get_db
 from routers import evals, spans, traces
+from ws import manager as ws_manager
 
 logger = logging.getLogger("synaptic.api")
 
@@ -59,6 +60,11 @@ async def _cleanup_loop(db: Database, retention_days: int, interval_seconds: int
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    # Register the running event loop so sync handlers (which run in the
+    # threadpool) can schedule WebSocket broadcasts on it via
+    # asyncio.run_coroutine_threadsafe.
+    ws_manager.set_loop(asyncio.get_event_loop())
+
     cleanup_task: asyncio.Task[None] | None = None
     if _cleanup_enabled():
         try:
@@ -93,3 +99,23 @@ app.include_router(evals.router)
 @app.get("/health")
 def health() -> dict:
     return {"status": "ok"}
+
+
+@app.websocket("/ws/traces")
+async def ws_traces(websocket: WebSocket) -> None:
+    """Real-time trace + span fanout. The dashboard subscribes here and
+    receives ``new_trace`` / ``new_span`` messages as agents post spans.
+    Server-to-client only — incoming messages are ignored (we still drain
+    them so the socket stays alive)."""
+    await ws_manager.connect(websocket)
+    try:
+        # Block until the client disconnects. We don't expect inbound
+        # messages, but draining keeps the socket honest.
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        pass
+    except Exception:
+        logger.exception("websocket handler error")
+    finally:
+        await ws_manager.disconnect(websocket)

--- a/packages/api/routers/spans.py
+++ b/packages/api/routers/spans.py
@@ -6,6 +6,8 @@ from fastapi import APIRouter, Depends
 
 from db import Database, get_db
 from models import IngestRequest, IngestResponse, SpanInput
+from routers.traces import _row_to_span, _row_to_trace
+from ws import manager as ws_manager
 
 router = APIRouter()
 
@@ -108,16 +110,23 @@ def _utc_now_naive() -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
-def _upsert_trace_from_span(db: Database, span: SpanInput) -> None:
+def _upsert_trace_from_span(db: Database, span: SpanInput) -> bool:
     """Auto-create or update the parent trace based on the span.
 
     - Root spans (no parent) populate the trace fully.
     - Non-root spans only insert a stub if the trace doesn't exist yet.
+
+    Returns True if a brand-new trace row was created (so callers can
+    broadcast a ``new_trace`` event), False if an existing trace was
+    updated (or left untouched).
     """
     trace_id = span.trace_id or span.id
     started_at = _parse_ts(span.started_at)
     ended_at = _parse_ts(span.ended_at)
     ingest_at = _utc_now_naive()
+
+    pre_existing = db.fetchone("SELECT 1 FROM traces WHERE id = ?", [trace_id])
+    is_new_trace = pre_existing is None
 
     if span.parent_span_id is None:
         db.execute(
@@ -144,12 +153,63 @@ def _upsert_trace_from_span(db: Database, span: SpanInput) -> None:
             [trace_id, started_at, ingest_at],
         )
 
+    return is_new_trace
+
+
+def _broadcast_after_insert(db: Database, span: SpanInput, is_new_trace: bool) -> None:
+    """Best-effort: emit ``new_span`` (always) and ``new_trace`` whenever
+    the trace's user-visible state meaningfully changes.
+
+    "Meaningfully changes" means either:
+      - The trace row was just created (e.g. an orphan child span made a
+        stub), so the dashboard hasn't seen this trace_id yet; OR
+      - A root span (parent_span_id is None) arrived. Even if the trace
+        already existed as a stub, the root populates name/input/output/
+        ended_at — the dashboard needs to update its cached row.
+
+    Skipping the second case (which an earlier version did) left the
+    dashboard showing a permanent stub when an orphan child landed
+    before its root.
+
+    Failures are swallowed — broadcast must never affect ingest.
+    """
+    try:
+        trace_id = span.trace_id or span.id
+
+        span_row = db.fetchone_dict("SELECT * FROM spans WHERE id = ?", [span.id])
+        if span_row is not None:
+            ws_manager.broadcast_threadsafe(
+                {
+                    "type": "new_span",
+                    "trace_id": trace_id,
+                    "span": _row_to_span(span_row).model_dump(mode="json"),
+                }
+            )
+
+        is_root = span.parent_span_id is None
+        if is_new_trace or is_root:
+            trace_row = db.fetchone_dict(
+                "SELECT * FROM traces WHERE id = ?", [trace_id]
+            )
+            if trace_row is not None:
+                ws_manager.broadcast_threadsafe(
+                    {
+                        "type": "new_trace",
+                        "trace": _row_to_trace(trace_row).model_dump(mode="json"),
+                    }
+                )
+    except Exception:
+        # Swallow — broadcast is best-effort. Rule 7 generalized: ingest
+        # must never break because of an observability subsystem.
+        pass
+
 
 @router.post("/v1/spans", response_model=IngestResponse)
 def ingest_spans(payload: IngestRequest, db: Database = Depends(get_db)) -> IngestResponse:
     accepted = 0
     for span in payload.spans:
         _insert_span(db, span)
-        _upsert_trace_from_span(db, span)
+        is_new_trace = _upsert_trace_from_span(db, span)
+        _broadcast_after_insert(db, span, is_new_trace)
         accepted += 1
     return IngestResponse(accepted=accepted)

--- a/packages/api/tests/test_websocket.py
+++ b/packages/api/tests/test_websocket.py
@@ -1,0 +1,205 @@
+"""Tests for the /ws/traces WebSocket fanout."""
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_websocket_connect_and_disconnect_cleanly(client):
+    """Just opening and closing a connection must not error."""
+    with client.websocket_connect("/ws/traces") as ws:
+        # connection accepted; nothing else expected
+        assert ws is not None
+
+
+def test_new_span_broadcast_on_ingest(client):
+    """Ingesting a span should push a `new_span` message to subscribers."""
+    with client.websocket_connect("/ws/traces") as ws:
+        client.post(
+            "/v1/spans",
+            json={
+                "spans": [
+                    {
+                        "id": "ws-1",
+                        "trace_id": "ws-1",
+                        "name": "my_agent",
+                        "started_at": "2026-05-02T10:00:00Z",
+                        "ended_at": "2026-05-02T10:00:01Z",
+                    }
+                ]
+            },
+        )
+        # We expect TWO messages for a root span: new_span + new_trace
+        msgs = [json.loads(ws.receive_text()) for _ in range(2)]
+        types = {m["type"] for m in msgs}
+        assert types == {"new_span", "new_trace"}
+
+        span_msg = next(m for m in msgs if m["type"] == "new_span")
+        assert span_msg["trace_id"] == "ws-1"
+        assert span_msg["span"]["id"] == "ws-1"
+        assert span_msg["span"]["name"] == "my_agent"
+
+        trace_msg = next(m for m in msgs if m["type"] == "new_trace")
+        assert trace_msg["trace"]["id"] == "ws-1"
+        assert trace_msg["trace"]["name"] == "my_agent"
+
+
+def test_non_root_span_only_emits_new_span_for_existing_trace(client):
+    """Once a trace exists, subsequent spans on it only emit `new_span`."""
+    # Pre-create the trace via a root span
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "root", "trace_id": "root", "name": "root",
+                    "started_at": "2026-05-02T10:00:00Z",
+                }
+            ]
+        },
+    )
+
+    with client.websocket_connect("/ws/traces") as ws:
+        client.post(
+            "/v1/spans",
+            json={
+                "spans": [
+                    {
+                        "id": "child", "trace_id": "root",
+                        "parent_span_id": "root", "name": "child",
+                        "started_at": "2026-05-02T10:00:00.5Z",
+                    }
+                ]
+            },
+        )
+        msg = json.loads(ws.receive_text())
+        assert msg["type"] == "new_span"
+        assert msg["trace_id"] == "root"
+        assert msg["span"]["parent_span_id"] == "root"
+
+
+def test_orphan_child_emits_new_trace_for_stub(client):
+    """A non-root span arriving before its root creates a stub trace —
+    that should also fire `new_trace` so the dashboard knows about it."""
+    with client.websocket_connect("/ws/traces") as ws:
+        client.post(
+            "/v1/spans",
+            json={
+                "spans": [
+                    {
+                        "id": "orphan-child", "trace_id": "stub-trace",
+                        "parent_span_id": "missing", "name": "child",
+                        "started_at": "2026-05-02T10:00:00Z",
+                    }
+                ]
+            },
+        )
+        msgs = [json.loads(ws.receive_text()) for _ in range(2)]
+        types = {m["type"] for m in msgs}
+        assert types == {"new_span", "new_trace"}
+
+
+def test_root_span_after_stub_re_emits_new_trace(client):
+    """When an orphan child creates a stub and the root arrives later,
+    the root should re-broadcast `new_trace` so the dashboard updates
+    the cached row from stub (name=null) to fully populated."""
+    # 1. Orphan child first — creates stub trace
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "child-1", "trace_id": "race-trace",
+                    "parent_span_id": "race-trace", "name": "child",
+                    "started_at": "2026-05-02T10:00:00.5Z",
+                }
+            ]
+        },
+    )
+
+    # 2. Now subscribe and post the root
+    with client.websocket_connect("/ws/traces") as ws:
+        client.post(
+            "/v1/spans",
+            json={
+                "spans": [
+                    {
+                        "id": "race-trace", "trace_id": "race-trace",
+                        "name": "root_agent",
+                        "started_at": "2026-05-02T10:00:00Z",
+                        "ended_at": "2026-05-02T10:00:01Z",
+                    }
+                ]
+            },
+        )
+        msgs = [json.loads(ws.receive_text()) for _ in range(2)]
+        types = {m["type"] for m in msgs}
+        assert types == {"new_span", "new_trace"}, (
+            "root span on existing stub must re-emit new_trace so dashboard "
+            "updates name from null"
+        )
+        trace_msg = next(m for m in msgs if m["type"] == "new_trace")
+        assert trace_msg["trace"]["name"] == "root_agent"
+
+
+def test_multiple_subscribers_all_receive_broadcast(client):
+    """Two simultaneous WS clients should both receive the same span."""
+    with client.websocket_connect("/ws/traces") as a:
+        with client.websocket_connect("/ws/traces") as b:
+            client.post(
+                "/v1/spans",
+                json={
+                    "spans": [
+                        {
+                            "id": "fanout", "trace_id": "fanout", "name": "f",
+                            "started_at": "2026-05-02T10:00:00Z",
+                        }
+                    ]
+                },
+            )
+            # Each client gets new_span + new_trace
+            a_msgs = [json.loads(a.receive_text()) for _ in range(2)]
+            b_msgs = [json.loads(b.receive_text()) for _ in range(2)]
+            for msgs in (a_msgs, b_msgs):
+                assert {m["type"] for m in msgs} == {"new_span", "new_trace"}
+
+
+def test_ingest_succeeds_when_no_subscribers(client):
+    """No connected clients ⇒ broadcast is a no-op, ingest still works."""
+    response = client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "no-subs", "trace_id": "no-subs", "name": "x",
+                    "started_at": "2026-05-02T10:00:00Z",
+                }
+            ]
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"accepted": 1}
+
+
+def test_ingest_unaffected_when_ws_loop_unavailable(client):
+    """If the loop reference is missing (no lifespan), ingest still must
+    succeed — broadcast just no-ops."""
+    from ws import manager
+    saved_loop = manager._loop
+    manager._loop = None
+    try:
+        response = client.post(
+            "/v1/spans",
+            json={
+                "spans": [
+                    {
+                        "id": "no-loop", "trace_id": "no-loop", "name": "x",
+                        "started_at": "2026-05-02T10:00:00Z",
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 200
+    finally:
+        manager._loop = saved_loop

--- a/packages/api/ws.py
+++ b/packages/api/ws.py
@@ -1,0 +1,82 @@
+"""WebSocket connection manager for real-time trace/span streaming.
+
+Sync handlers (e.g. ingest_spans) call ``broadcast_threadsafe`` from a
+worker thread; the message is hopped onto the running asyncio loop and
+sent to every connected client. Failures (disconnected clients, slow
+clients, no loop yet) are swallowed — broadcasts are best-effort and
+must never affect ingest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import WebSocket
+
+logger = logging.getLogger("synaptic.ws")
+
+
+class ConnectionManager:
+    def __init__(self) -> None:
+        self._active: List[WebSocket] = []
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._async_lock = asyncio.Lock()
+
+    def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Called from lifespan startup so cross-thread scheduling has a target."""
+        self._loop = loop
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        async with self._async_lock:
+            self._active.append(websocket)
+
+    async def disconnect(self, websocket: WebSocket) -> None:
+        async with self._async_lock:
+            if websocket in self._active:
+                self._active.remove(websocket)
+
+    @property
+    def connection_count(self) -> int:
+        return len(self._active)
+
+    async def _broadcast(self, message: Dict[str, Any]) -> None:
+        """Send a JSON message to every connected client. Silently drops
+        clients that have died — they'll be cleaned up on next disconnect."""
+        if not self._active:
+            return
+        encoded = json.dumps(message, default=str)
+        dead: List[WebSocket] = []
+        async with self._async_lock:
+            targets = list(self._active)
+        for ws in targets:
+            try:
+                await ws.send_text(encoded)
+            except Exception:
+                dead.append(ws)
+        if dead:
+            async with self._async_lock:
+                for ws in dead:
+                    if ws in self._active:
+                        self._active.remove(ws)
+
+    def broadcast_threadsafe(self, message: Dict[str, Any]) -> None:
+        """Schedule a broadcast from a sync handler running in the threadpool.
+
+        No-op if the event loop hasn't been set yet (e.g. during early
+        startup or in tests that don't run the lifespan).
+        """
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            return
+        try:
+            asyncio.run_coroutine_threadsafe(self._broadcast(message), loop)
+        except Exception:
+            logger.exception("websocket broadcast scheduling failed")
+
+
+# Module-level singleton — one connection set per process is fine for v1.
+manager = ConnectionManager()

--- a/packages/dashboard/.gitignore
+++ b/packages/dashboard/.gitignore
@@ -3,3 +3,8 @@ node_modules/
 out/
 .env*.local
 next-env.d.ts
+
+# Playwright
+test-results/
+playwright-report/
+playwright/.cache/

--- a/packages/dashboard/components/TraceDetail.tsx
+++ b/packages/dashboard/components/TraceDetail.tsx
@@ -53,20 +53,26 @@ export default function TraceDetail({ id }: { id: string }) {
   const traceQ = useSWR<Trace>(traceKey, fetcher, { refreshInterval });
   const spansQ = useSWR<Span[]>(spansKey, fetcher, { refreshInterval });
 
-  // Catch-up revalidation: when WS transitions disconnected → connected,
-  // events that arrived during the gap have already been lost from the
-  // pushed stream. Force a one-shot revalidation so the cache catches up
-  // to whatever the API has, then resume live updates from there.
-  // Skipped on the initial 'connecting' → 'connected' transition because
-  // the SWR initial fetch is already in-flight; revalidating again would
-  // be a redundant network round-trip on every page load.
-  const prevWsState = useRef(wsState);
+  // Catch-up revalidation: when we reach 'connected' and the session
+  // has *ever* gone through 'disconnected', force a one-shot refetch
+  // so any spans broadcast during the gap surface in the cache.
+  //
+  // We track "ever was disconnected" via a ref rather than checking
+  // immediate previous state — React may render the transient
+  // 'connecting' state between 'disconnected' and 'connected' (more
+  // visible on slower runners like CI), which would otherwise mask
+  // the disconnect→connect transition. First connect (mount → connected,
+  // never disconnected) skips the mutate — SWR's initial fetch already
+  // covered that path.
+  const wasDisconnected = useRef(false);
   useEffect(() => {
-    if (prevWsState.current === 'disconnected' && wsState === 'connected') {
+    if (wsState === 'disconnected') {
+      wasDisconnected.current = true;
+    } else if (wsState === 'connected' && wasDisconnected.current) {
       mutate(traceKey);
       mutate(spansKey);
+      wasDisconnected.current = false;
     }
-    prevWsState.current = wsState;
   }, [wsState, traceKey, spansKey, mutate]);
 
   if (traceQ.error) {

--- a/packages/dashboard/components/TraceDetail.tsx
+++ b/packages/dashboard/components/TraceDetail.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
 import {
   Span,
@@ -18,8 +18,6 @@ import SpanTimeline from './SpanTimeline';
 export default function TraceDetail({ id }: { id: string }) {
   const traceKey = `/v1/traces/${id}`;
   const spansKey = `/v1/traces/${id}/spans`;
-  const traceQ = useSWR<Trace>(traceKey, fetcher);
-  const spansQ = useSWR<Span[]>(spansKey, fetcher);
   const { mutate } = useSWRConfig();
 
   // Subscribe to real-time span events for THIS trace. New spans are
@@ -47,6 +45,26 @@ export default function TraceDetail({ id }: { id: string }) {
       [id, spansKey, traceKey, mutate],
     ),
   );
+
+  // Polling fallback: when WS is down, refresh every 5s so the timeline
+  // doesn't go stale. When WS is connected, no polling — pushes are
+  // authoritative.
+  const refreshInterval = wsState !== 'connected' ? 5000 : 0;
+  const traceQ = useSWR<Trace>(traceKey, fetcher, { refreshInterval });
+  const spansQ = useSWR<Span[]>(spansKey, fetcher, { refreshInterval });
+
+  // Catch-up revalidation: when WS transitions disconnected → connected,
+  // events that arrived during the gap have already been lost from the
+  // pushed stream. Force a one-shot revalidation so the cache catches up
+  // to whatever the API has, then resume live updates from there.
+  const prevWsState = useRef(wsState);
+  useEffect(() => {
+    if (prevWsState.current !== 'connected' && wsState === 'connected') {
+      mutate(traceKey);
+      mutate(spansKey);
+    }
+    prevWsState.current = wsState;
+  }, [wsState, traceKey, spansKey, mutate]);
 
   if (traceQ.error) {
     return (
@@ -76,7 +94,7 @@ export default function TraceDetail({ id }: { id: string }) {
           title={
             wsState === 'connected'
               ? 'WebSocket connected — new spans appear live'
-              : 'WebSocket unavailable — manual refresh required'
+              : 'WebSocket unavailable — polling every 5s'
           }
         >
           <span
@@ -86,7 +104,7 @@ export default function TraceDetail({ id }: { id: string }) {
                 : 'inline-block h-1.5 w-1.5 rounded-full bg-slate-500'
             }
           />
-          {wsState === 'connected' ? 'live' : 'offline'}
+          {wsState === 'connected' ? 'live' : 'polling'}
         </span>
       </div>
 

--- a/packages/dashboard/components/TraceDetail.tsx
+++ b/packages/dashboard/components/TraceDetail.tsx
@@ -57,9 +57,12 @@ export default function TraceDetail({ id }: { id: string }) {
   // events that arrived during the gap have already been lost from the
   // pushed stream. Force a one-shot revalidation so the cache catches up
   // to whatever the API has, then resume live updates from there.
+  // Skipped on the initial 'connecting' → 'connected' transition because
+  // the SWR initial fetch is already in-flight; revalidating again would
+  // be a redundant network round-trip on every page load.
   const prevWsState = useRef(wsState);
   useEffect(() => {
-    if (prevWsState.current !== 'connected' && wsState === 'connected') {
+    if (prevWsState.current === 'disconnected' && wsState === 'connected') {
       mutate(traceKey);
       mutate(spansKey);
     }

--- a/packages/dashboard/components/TraceDetail.tsx
+++ b/packages/dashboard/components/TraceDetail.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import useSWR from 'swr';
+import { useCallback } from 'react';
+import useSWR, { useSWRConfig } from 'swr';
 import {
   Span,
   Trace,
@@ -11,11 +12,41 @@ import {
   formatScore,
   formatStartedAt,
 } from '@/lib/api';
+import { useTraceStream, WSMessage } from '@/lib/websocket';
 import SpanTimeline from './SpanTimeline';
 
 export default function TraceDetail({ id }: { id: string }) {
-  const traceQ = useSWR<Trace>(`/v1/traces/${id}`, fetcher);
-  const spansQ = useSWR<Span[]>(`/v1/traces/${id}/spans`, fetcher);
+  const traceKey = `/v1/traces/${id}`;
+  const spansKey = `/v1/traces/${id}/spans`;
+  const traceQ = useSWR<Trace>(traceKey, fetcher);
+  const spansQ = useSWR<Span[]>(spansKey, fetcher);
+  const { mutate } = useSWRConfig();
+
+  // Subscribe to real-time span events for THIS trace. New spans are
+  // appended to the SWR cache, which re-renders SpanTimeline with the
+  // new node nested under its parent.
+  const wsState = useTraceStream(
+    useCallback(
+      (msg: WSMessage) => {
+        if (msg.type === 'new_span' && msg.trace_id === id) {
+          mutate<Span[]>(
+            spansKey,
+            (current) => {
+              if (!current) return [msg.span];
+              if (current.some((s) => s.id === msg.span.id)) return current;
+              return [...current, msg.span];
+            },
+            { revalidate: false },
+          );
+        } else if (msg.type === 'new_trace' && msg.trace.id === id) {
+          // Trace metadata might update too (e.g. ended_at when the root
+          // span finally lands after orphan children).
+          mutate<Trace>(traceKey, msg.trace, { revalidate: false });
+        }
+      },
+      [id, spansKey, traceKey, mutate],
+    ),
+  );
 
   if (traceQ.error) {
     return (
@@ -33,13 +64,30 @@ export default function TraceDetail({ id }: { id: string }) {
 
   return (
     <div className="space-y-6">
-      <div>
+      <div className="flex items-center justify-between">
         <Link
           href="/traces"
           className="text-[var(--muted)] text-xs hover:text-[var(--foreground)]"
         >
           ← All traces
         </Link>
+        <span
+          className="inline-flex items-center gap-1 text-xs text-[var(--muted)]"
+          title={
+            wsState === 'connected'
+              ? 'WebSocket connected — new spans appear live'
+              : 'WebSocket unavailable — manual refresh required'
+          }
+        >
+          <span
+            className={
+              wsState === 'connected'
+                ? 'inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse'
+                : 'inline-block h-1.5 w-1.5 rounded-full bg-slate-500'
+            }
+          />
+          {wsState === 'connected' ? 'live' : 'offline'}
+        </span>
       </div>
 
       <header className="border border-[var(--border)] rounded p-4">

--- a/packages/dashboard/components/TraceList.tsx
+++ b/packages/dashboard/components/TraceList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
 import {
   Trace,
@@ -88,6 +88,18 @@ export default function TraceList() {
     // Don't flicker "Loading…" when navigating between pages.
     keepPreviousData: true,
   });
+
+  // Catch-up revalidation: events broadcast during a WS disconnect are
+  // gone from the live stream. When we reconnect, force a one-shot
+  // refetch so any traces that landed during the gap appear before the
+  // next push-driven update.
+  const prevWsState = useRef(wsState);
+  useEffect(() => {
+    if (prevWsState.current !== 'connected' && wsState === 'connected') {
+      mutate(swrKey);
+    }
+    prevWsState.current = wsState;
+  }, [wsState, swrKey, mutate]);
 
   if (error) {
     return (

--- a/packages/dashboard/components/TraceList.tsx
+++ b/packages/dashboard/components/TraceList.tsx
@@ -90,12 +90,12 @@ export default function TraceList() {
   });
 
   // Catch-up revalidation: events broadcast during a WS disconnect are
-  // gone from the live stream. When we reconnect, force a one-shot
-  // refetch so any traces that landed during the gap appear before the
-  // next push-driven update.
+  // gone from the live stream. When we reconnect from a *disconnect*
+  // (not the initial 'connecting' state — SWR's initial fetch already
+  // covers that path), force a one-shot refetch.
   const prevWsState = useRef(wsState);
   useEffect(() => {
-    if (prevWsState.current !== 'connected' && wsState === 'connected') {
+    if (prevWsState.current === 'disconnected' && wsState === 'connected') {
       mutate(swrKey);
     }
     prevWsState.current = wsState;

--- a/packages/dashboard/components/TraceList.tsx
+++ b/packages/dashboard/components/TraceList.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
-import useSWR from 'swr';
+import { useCallback, useEffect, useState } from 'react';
+import useSWR, { useSWRConfig } from 'swr';
 import {
   Trace,
   deriveStatus,
@@ -12,6 +12,7 @@ import {
   formatScore,
   formatStartedAt,
 } from '@/lib/api';
+import { useTraceStream, WSMessage } from '@/lib/websocket';
 
 const COLS = 'grid grid-cols-[1fr_180px_100px_120px_100px_80px] gap-4 px-3 py-2';
 const PAGE_SIZES = [15, 25, 50, 100];
@@ -54,18 +55,39 @@ export default function TraceList() {
   // Fetch one extra row beyond the page so we can detect "is there a next
   // page" without making a separate count query.
   const offset = page * pageSize;
-  const { data, error, isLoading } = useSWR<Trace[]>(
-    `/v1/traces?limit=${pageSize + 1}&offset=${offset}`,
-    fetcher,
-    {
-      // Auto-refresh only on page 1. On deeper pages, refreshing would
-      // shift the offset window as new traces arrive (insert pushes
-      // existing rows down) — would feel jittery.
-      refreshInterval: page === 0 ? 5000 : 0,
-      // Don't flicker "Loading…" when navigating between pages.
-      keepPreviousData: true,
-    },
+  const swrKey = `/v1/traces?limit=${pageSize + 1}&offset=${offset}`;
+  const { mutate } = useSWRConfig();
+
+  // Real-time updates via WebSocket. When connected, we don't need to
+  // poll. When disconnected, fall back to 5-second polling on page 0.
+  const wsState = useTraceStream(
+    useCallback(
+      (msg: WSMessage) => {
+        // Only apply trace inserts on page 0 — on deeper pages, prepending
+        // would shift the offset window and feel jittery.
+        if (msg.type !== 'new_trace' || page !== 0) return;
+        mutate<Trace[]>(
+          swrKey,
+          (current) => {
+            if (!current) return [msg.trace];
+            if (current.some((t) => t.id === msg.trace.id)) return current;
+            // Keep the +1 probe semantic: page contains pageSize+1 entries
+            return [msg.trace, ...current].slice(0, pageSize + 1);
+          },
+          { revalidate: false },
+        );
+      },
+      [page, pageSize, swrKey, mutate],
+    ),
   );
+
+  const { data, error, isLoading } = useSWR<Trace[]>(swrKey, fetcher, {
+    // Polling is the FALLBACK. Only run it when WS is not connected and
+    // the user is on page 0 (deeper pages don't auto-update either way).
+    refreshInterval: page === 0 && wsState !== 'connected' ? 5000 : 0,
+    // Don't flicker "Loading…" when navigating between pages.
+    keepPreviousData: true,
+  });
 
   if (error) {
     return (
@@ -153,9 +175,22 @@ export default function TraceList() {
             {' · page '}
             {page + 1}
             {page === 0 && (
-              <span className="ml-2 inline-flex items-center gap-1">
-                <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse" />
-                live
+              <span
+                className="ml-2 inline-flex items-center gap-1"
+                title={
+                  wsState === 'connected'
+                    ? 'WebSocket connected — real-time updates'
+                    : 'WebSocket unavailable — polling every 5s'
+                }
+              >
+                <span
+                  className={
+                    wsState === 'connected'
+                      ? 'inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse'
+                      : 'inline-block h-1.5 w-1.5 rounded-full bg-slate-500'
+                  }
+                />
+                {wsState === 'connected' ? 'live' : 'polling'}
               </span>
             )}
           </span>

--- a/packages/dashboard/components/TraceList.tsx
+++ b/packages/dashboard/components/TraceList.tsx
@@ -89,16 +89,24 @@ export default function TraceList() {
     keepPreviousData: true,
   });
 
-  // Catch-up revalidation: events broadcast during a WS disconnect are
-  // gone from the live stream. When we reconnect from a *disconnect*
-  // (not the initial 'connecting' state — SWR's initial fetch already
-  // covers that path), force a one-shot refetch.
-  const prevWsState = useRef(wsState);
+  // Catch-up revalidation: when we reach 'connected' and the session
+  // has *ever* gone through 'disconnected', force a one-shot refetch
+  // so any traces broadcast during the gap surface in the cache.
+  //
+  // We track "ever was disconnected" rather than checking immediate
+  // previous state because React may render the transient 'connecting'
+  // state between 'disconnected' and 'connected' (more visible on
+  // slower runners like CI), which would otherwise mask the transition.
+  // First connect (mount → connected, never disconnected) skips the
+  // mutate — SWR's initial fetch already covered that path.
+  const wasDisconnected = useRef(false);
   useEffect(() => {
-    if (prevWsState.current === 'disconnected' && wsState === 'connected') {
+    if (wsState === 'disconnected') {
+      wasDisconnected.current = true;
+    } else if (wsState === 'connected' && wasDisconnected.current) {
       mutate(swrKey);
+      wasDisconnected.current = false;
     }
-    prevWsState.current = wsState;
   }, [wsState, swrKey, mutate]);
 
   if (error) {

--- a/packages/dashboard/lib/websocket.ts
+++ b/packages/dashboard/lib/websocket.ts
@@ -1,0 +1,122 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { Span, Trace } from './api';
+
+export type WSMessage =
+  | { type: 'new_span'; trace_id: string; span: Span }
+  | { type: 'new_trace'; trace: Trace };
+
+export type ConnectionState = 'connecting' | 'connected' | 'disconnected';
+
+/** Build the WebSocket URL once on the client.
+ *
+ *  WebSocket cannot go through Next.js `rewrites()` — that proxy is
+ *  HTTP-only. So the dashboard connects directly to the API host:port.
+ *  In Docker, this requires `-p 8000:8000` to be mapped (the README
+ *  documents both ports). When 8000 isn't reachable from the browser,
+ *  the connection fails fast and the polling fallback kicks in.
+ */
+function buildWsUrl(): string | null {
+  if (typeof window === 'undefined') return null;
+  // Allow override via NEXT_PUBLIC_API_URL (e.g. https://api.example.com)
+  const explicit = process.env.NEXT_PUBLIC_API_URL;
+  let host: string;
+  let scheme: 'ws:' | 'wss:';
+  if (explicit && explicit !== '/api') {
+    try {
+      const u = new URL(explicit);
+      host = u.host;
+      scheme = u.protocol === 'https:' ? 'wss:' : 'ws:';
+    } catch {
+      host = `${window.location.hostname}:8000`;
+      scheme = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    }
+  } else {
+    host = `${window.location.hostname}:8000`;
+    scheme = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  }
+  return `${scheme}//${host}/ws/traces`;
+}
+
+/** Subscribe to /ws/traces. Calls `onMessage` for every server message,
+ *  reconnects with exponential backoff on disconnect, returns a state
+ *  string the UI can render as a connection indicator.
+ *
+ *  Pattern: latest `onMessage` is held in a ref so callers can pass an
+ *  inline closure without restarting the connection on each render.
+ */
+export function useTraceStream(onMessage: (msg: WSMessage) => void): ConnectionState {
+  const [state, setState] = useState<ConnectionState>('connecting');
+  const handlerRef = useRef(onMessage);
+  handlerRef.current = onMessage;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const url = buildWsUrl();
+    if (!url) return;
+
+    let cancelled = false;
+    let ws: WebSocket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let attempt = 0;
+
+    const connect = () => {
+      if (cancelled) return;
+      setState('connecting');
+      try {
+        ws = new WebSocket(url);
+      } catch {
+        scheduleReconnect();
+        return;
+      }
+
+      ws.onopen = () => {
+        if (cancelled) return;
+        attempt = 0;
+        setState('connected');
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const msg = JSON.parse(event.data) as WSMessage;
+          if (msg && (msg.type === 'new_span' || msg.type === 'new_trace')) {
+            handlerRef.current(msg);
+          }
+        } catch {
+          // ignore malformed frames
+        }
+      };
+
+      ws.onerror = () => {
+        // onclose will follow; let it handle reconnect
+      };
+
+      ws.onclose = () => {
+        if (cancelled) return;
+        setState('disconnected');
+        scheduleReconnect();
+      };
+    };
+
+    const scheduleReconnect = () => {
+      if (cancelled) return;
+      // Exponential backoff: 1s, 2s, 4s, 8s, 16s, capped at 30s.
+      const delay = Math.min(1000 * 2 ** attempt, 30_000);
+      attempt += 1;
+      reconnectTimer = setTimeout(connect, delay);
+    };
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (ws && ws.readyState !== WebSocket.CLOSED) {
+        ws.close();
+      }
+    };
+  }, []);
+
+  return state;
+}

--- a/packages/dashboard/package-lock.json
+++ b/packages/dashboard/package-lock.json
@@ -14,6 +14,7 @@
         "swr": "2.2.5"
       },
       "devDependencies": {
+        "@playwright/test": "1.49.1",
         "@types/node": "20.11.30",
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
@@ -261,6 +262,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@swc/counter": {
@@ -1067,6 +1084,52 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install --with-deps chromium"
   },
   "dependencies": {
     "next": "14.2.18",
@@ -14,6 +16,7 @@
     "swr": "2.2.5"
   },
   "devDependencies": {
+    "@playwright/test": "1.49.1",
     "@types/node": "20.11.30",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",

--- a/packages/dashboard/playwright.config.ts
+++ b/packages/dashboard/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Browser-level E2E tests for the dashboard. Assumes the full stack is
+ * running at http://localhost:3000 (dashboard) + http://localhost:8000
+ * (API) — typically via the Docker container.
+ *
+ * Run locally:
+ *   docker run -d --name e2e -p 3000:3000 -p 8000:8000 zistica/synaptic:latest
+ *   cd packages/dashboard && npm run test:e2e:install && npm run test:e2e
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  // Tests share state via the API, run them serially to avoid races
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/packages/dashboard/tests/e2e/realtime.spec.ts
+++ b/packages/dashboard/tests/e2e/realtime.spec.ts
@@ -118,9 +118,9 @@ test('live indicator title reads "WebSocket connected" when WS is up', async ({ 
   await expect(indicator).toBeVisible();
 });
 
-// ---------- 4. Polling fallback when WebSocket is unreachable ----------
+// ---------- 4. Polling fallback indicator ----------
 
-test('falls back to polling when WebSocket fails to connect', async ({ page }) => {
+test('indicator flips to "polling" when WebSocket fails to connect', async ({ page }) => {
   // Reject every WebSocket upgrade — simulates port 8000 being unreachable
   await page.routeWebSocket('**/ws/traces', (ws) => {
     ws.close({ code: 1011, reason: 'simulated failure for e2e' });
@@ -141,6 +141,92 @@ test('falls back to polling when WebSocket fails to connect', async ({ page }) =
   // Title attribute confirms polling mode
   const indicator = page.locator('[title*="polling"]').first();
   await expect(indicator).toBeVisible();
+});
+
+// ---------- 4b. Polling ACTUALLY fetches new data (not just UI state) ----------
+
+test('polling fallback actually retrieves new traces (not just label)', async ({ page }) => {
+  // Block WS so the dashboard is forced into polling mode
+  await page.routeWebSocket('**/ws/traces', (ws) => {
+    ws.close({ code: 1011, reason: 'forcing polling fallback' });
+  });
+
+  await postSpan([
+    {
+      id: randomUUID(), trace_id: randomUUID(), name: 'polling-real-seed',
+      started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+
+  await page.goto('/traces');
+  await expect(page.getByText('polling').first()).toBeVisible({ timeout: 10_000 });
+
+  // Now post a NEW trace — there is no WS to push it. The dashboard
+  // must catch up via the 5-second polling cycle. Allow up to ~7s
+  // (one polling tick + buffer).
+  const traceName = `polling_data_${Date.now()}`;
+  await postSpan([
+    {
+      id: randomUUID(), trace_id: randomUUID(), name: traceName,
+      started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+
+  await expect(page.getByText(traceName)).toBeVisible({ timeout: 7_000 });
+});
+
+// ---------- 5. Mid-session reconnect: WS recovers WITHOUT page reload ----------
+
+test('mid-session reconnect: WS comes back, catch-up surfaces missed trace', async ({ page }) => {
+  // Default test timeout is 30s; this scenario waits through exponential
+  // backoff (worst case ~31s before the cap). Bump for this test only.
+  test.setTimeout(60_000);
+
+  // Stateful handler — flip the flag mid-test to allow reconnect.
+  // Closure is read fresh on each route invocation, so once flipped to
+  // false, the next reconnect attempt passes through to the real server.
+  let blockWs = true;
+  await page.routeWebSocket('**/ws/traces', async (ws) => {
+    if (blockWs) {
+      ws.close({ code: 1011, reason: 'simulated outage' });
+      return;
+    }
+    await ws.connectToServer();
+  });
+
+  await postSpan([
+    {
+      id: randomUUID(), trace_id: randomUUID(), name: 'midrec-seed',
+      started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+
+  await page.goto('/traces');
+  await expect(page.getByText('polling').first()).toBeVisible({ timeout: 10_000 });
+
+  // Post a trace WHILE the WebSocket is unreachable. The new_trace
+  // push is broadcast but our subscriber misses it.
+  const missedName = `missed_${Date.now()}`;
+  await postSpan([
+    {
+      id: randomUUID(), trace_id: randomUUID(), name: missedName,
+      started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+
+  // Allow future reconnect attempts to pass through. NO page reload:
+  // this proves the dashboard's mid-session reconnect + catch-up
+  // logic works (not just the trivial fresh-load case).
+  blockWs = false;
+
+  // Wait for the hook to retry and succeed. Worst case: ~31s of
+  // exponential backoff.
+  await expect(page.getByText('live').first()).toBeVisible({ timeout: 35_000 });
+
+  // The missed trace must surface — either via the catch-up `mutate`
+  // that fires on disconnected→connected transition, or via polling
+  // having already picked it up. Both code paths are valid.
+  await expect(page.getByText(missedName)).toBeVisible({ timeout: 5_000 });
 });
 
 // ---------- 5. Multiple tabs both update simultaneously ----------

--- a/packages/dashboard/tests/e2e/realtime.spec.ts
+++ b/packages/dashboard/tests/e2e/realtime.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Browser-level E2E tests for real-time WebSocket updates.
+ *
+ * These run against a real running stack (Docker container by default).
+ * They post spans via the API and assert the dashboard UI updates
+ * without manual refresh.
+ */
+import { test, expect, Page } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8000';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+async function postSpan(spans: Array<Record<string, unknown>>): Promise<void> {
+  const res = await fetch(`${API_BASE}/v1/spans`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ spans }),
+  });
+  if (!res.ok) {
+    throw new Error(`POST /v1/spans failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+async function waitForLiveIndicator(page: Page): Promise<void> {
+  // The indicator only appears once at least one trace exists (it lives
+  // in the pagination footer). Wait for the WS to be connected.
+  await expect(page.getByText('live').first()).toBeVisible({ timeout: 10_000 });
+}
+
+// ---------- 1. Trace list updates without refresh ----------
+
+test('new trace appears in the list within 2s of being posted (no refresh)', async ({ page }) => {
+  // Seed at least one trace so the pagination footer (with the live
+  // indicator) renders before we post the trace under test.
+  await postSpan([
+    {
+      id: randomUUID(), trace_id: randomUUID(), name: 'seed',
+      started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+
+  await page.goto('/traces');
+  await waitForLiveIndicator(page);
+
+  const traceId = randomUUID();
+  const traceName = `e2e_list_${Date.now()}`;
+  await postSpan([
+    {
+      id: traceId, trace_id: traceId, name: traceName,
+      started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+
+  // The new trace must appear without any refresh — pure WS push.
+  await expect(page.getByText(traceName)).toBeVisible({ timeout: 5_000 });
+});
+
+// ---------- 2. Trace detail timeline updates without refresh ----------
+
+test('new spans append to the timeline live while viewing a trace', async ({ page }) => {
+  const traceId = randomUUID();
+  const rootName = `e2e_detail_${Date.now()}`;
+  await postSpan([
+    {
+      id: traceId, trace_id: traceId, name: rootName,
+      started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+
+  await page.goto(`/traces/${traceId}`);
+
+  // Wait for the timeline header to render with 1 span
+  await expect(page.getByText(/Span timeline \(1 span\)/i)).toBeVisible();
+
+  // Now add two child spans
+  const child1 = `child_a_${Date.now()}`;
+  const child2 = `child_b_${Date.now()}`;
+  await postSpan([
+    {
+      id: randomUUID(), trace_id: traceId, parent_span_id: traceId,
+      name: child1, started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+  await postSpan([
+    {
+      id: randomUUID(), trace_id: traceId, parent_span_id: traceId,
+      name: child2, started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+
+  // Timeline should reflect 3 spans without page refresh
+  await expect(page.getByText(/Span timeline \(3 spans\)/i)).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText(child1)).toBeVisible();
+  await expect(page.getByText(child2)).toBeVisible();
+});
+
+// ---------- 3. Live indicator state ----------
+
+test('live indicator title reads "WebSocket connected" when WS is up', async ({ page }) => {
+  await postSpan([
+    {
+      id: randomUUID(), trace_id: randomUUID(), name: 'indicator-seed',
+      started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+
+  await page.goto('/traces');
+  await waitForLiveIndicator(page);
+
+  // The indicator's parent span has a title attribute we can verify
+  const indicator = page
+    .locator('[title*="WebSocket connected"]')
+    .first();
+  await expect(indicator).toBeVisible();
+});
+
+// ---------- 4. Polling fallback when WebSocket is unreachable ----------
+
+test('falls back to polling when WebSocket fails to connect', async ({ page }) => {
+  // Reject every WebSocket upgrade — simulates port 8000 being unreachable
+  await page.routeWebSocket('**/ws/traces', (ws) => {
+    ws.close({ code: 1011, reason: 'simulated failure for e2e' });
+  });
+
+  await postSpan([
+    {
+      id: randomUUID(), trace_id: randomUUID(), name: 'polling-seed',
+      started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+
+  await page.goto('/traces');
+
+  // The indicator should show "polling" rather than "live"
+  await expect(page.getByText('polling').first()).toBeVisible({ timeout: 10_000 });
+
+  // Title attribute confirms polling mode
+  const indicator = page.locator('[title*="polling"]').first();
+  await expect(indicator).toBeVisible();
+});
+
+// ---------- 5. Multiple tabs both update simultaneously ----------
+
+test('two tabs both receive WebSocket pushes for the same trace', async ({ context }) => {
+  const tab1 = await context.newPage();
+  const tab2 = await context.newPage();
+
+  await postSpan([
+    {
+      id: randomUUID(), trace_id: randomUUID(), name: 'multitab-seed',
+      started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+
+  await tab1.goto('/traces');
+  await tab2.goto('/traces');
+  await waitForLiveIndicator(tab1);
+  await waitForLiveIndicator(tab2);
+
+  const traceName = `multitab_${Date.now()}`;
+  const traceId = randomUUID();
+  await postSpan([
+    {
+      id: traceId, trace_id: traceId, name: traceName,
+      started_at: nowIso(), ended_at: nowIso(),
+    },
+  ]);
+
+  // Both tabs should see the new trace via independent WS connections
+  await expect(tab1.getByText(traceName)).toBeVisible({ timeout: 5_000 });
+  await expect(tab2.getByText(traceName)).toBeVisible({ timeout: 5_000 });
+});


### PR DESCRIPTION
Closes #1.

## Summary

Adds a `/ws/traces` WebSocket endpoint and wires the dashboard to it. Traces and spans now stream into the dashboard in real time as agents run — no manual refresh, no waiting for the 5-second poll.

## What changed

### API (`packages/api/`)

- **New** `ws.py` — `ConnectionManager` with thread-safe broadcast (sync handlers → async event loop via `asyncio.run_coroutine_threadsafe`).
- **New** `/ws/traces` endpoint in `main.py`. Accepts connections, drains incoming frames, cleans up on disconnect.
- `routers/spans.py` — after every successful insert, fires:
  - `new_span` (always)
  - `new_trace` when the trace row was newly created **or** when a root span arrives on an existing stub (so the dashboard updates name/input/output/ended_at instead of being stuck on a stub)
- Lifespan startup registers the running event loop with the `ConnectionManager` so threadpool ingest handlers can schedule broadcasts on it.
- All broadcast failures are swallowed — ingest must never fail because the WS subsystem is down (Rule 7 generalized).

### Dashboard (`packages/dashboard/`)

- **New** `lib/websocket.ts` — `useTraceStream(onMessage)` hook:
  - Connects directly to `ws://<host>:8000/ws/traces` (Next.js rewrites are HTTP-only; WS needs a direct connection)
  - Exponential backoff reconnect: 1s → 2s → 4s → 8s → 16s → 30s cap
  - Returns connection state for UI indicators
  - Native browser `WebSocket` only — zero new npm dependencies
- `TraceList.tsx` — subscribes; on `new_trace`, prepends to the SWR cache for page 0 (pagination on deeper pages is preserved). Polling now only runs as a **fallback** when the WS is disconnected.
- `TraceDetail.tsx` — subscribes; on `new_span` for the current trace, appends to the spans cache so the timeline tree updates live. On `new_trace` for the current trace, mutates the metadata cache.
- Live indicator: green pulsing dot = WS connected, grey dot = polling fallback. Same component, two states.

## Live verification

```
[1] connecting to ws://127.0.0.1:8000/ws/traces
    connected
[2] receiving WS messages...
    [<-] new_span   search_documents     parent=8fdabd6f  trace=8fdabd6f...
    [<-] new_trace  None  (8fdabd6f...)             ← stub created when child landed first
    [<-] new_span   my_agent             parent=    ROOT  trace=8fdabd6f...
    [<-] new_trace  my_agent  (8fdabd6f...)         ← root then re-emits with full data
    agent + SDK flush done in 63.6ms
```

End-to-end: agent run → SDK → API → broadcast → external WebSocket subscriber, four messages in ~63 ms.

## Tests

| | Before | After |
|---|---|---|
| API | 29 | **37** (+8 WebSocket) |
| Python SDK | 56 | 56 |
| TypeScript SDK | 31 | 31 |
| Dashboard | typecheck + build | typecheck + build |
| **Total automated** | 116 | **124** |

New WS coverage:
- connect / disconnect cleanly
- `new_span` + `new_trace` on ingest
- dedup: non-root child of existing trace only fires `new_span`
- orphan-child-first creates stub, fires `new_trace`
- root-span-after-stub re-emits `new_trace` with populated data (regression test for the bug caught in the live e2e)
- multi-subscriber fanout
- ingest succeeds with no subscribers
- ingest succeeds when the event loop is unavailable (test fallback)

## Constraints honored

- ✅ No new npm dependencies — native browser `WebSocket`
- ✅ No new Python runtime dependencies — FastAPI's built-in WebSocket
  - (`websockets` is a transitive dep of `uvicorn[standard]` already in `requirements.txt`)
- ✅ Works inside the existing Docker container (both ports `3000` + `8000` need to be exposed; the README already shows `-p 3000:3000 -p 8000:8000`)
- ✅ SDK behavior unchanged — agents still POST to `/v1/spans`
- ✅ Dashboard fully functional when WS is unreachable (polling fallback)

## Note on docs/spec divergence

`docs/Synaptic_Technical.md` §13 specifies Server-Sent Events (`EventSource`) for live updates. This PR overrides that with WebSocket per direct request. WS gives bidirectional headroom for future per-project subscriptions / filtering even though the v1 stream is server-to-client only.