### PR TITLE
Multi-turn session tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ That's it. No account, no API key, no data leaves your laptop.
 ## What you get
 
 - **Span timeline** — every LLM call, tool invocation, retrieval, and custom span rendered as an indented tree, click any span to expand its input/output JSON
+- **Multi-turn sessions** — group related traces under a single conversation; the dashboard's `/sessions` view shows turns in chronological order with aggregate cost, duration, and quality
 - **Real-time updates** — WebSocket stream pushes traces and spans into the dashboard the moment they're ingested, no refresh; falls back to 5-second polling if the socket can't connect
 - **Cost & token tracking** — automatic per-call breakdown for OpenAI and Anthropic model families
 - **Quality scoring** — bring-your-own evals via `POST /v1/evals`
@@ -102,10 +103,10 @@ Single Docker container runs the API on `:8000` and the Next.js standalone dashb
 
 | Path | Package | Tests |
 |---|---|---|
-| [`packages/sdk-python/`](packages/sdk-python/) | Python SDK with `@synaptic.trace`, `synaptic.span()`, integrations | 56 |
-| [`packages/sdk-typescript/`](packages/sdk-typescript/) | `@synaptic/sdk` — peer of the Python SDK | 31 |
-| [`packages/api/`](packages/api/) | FastAPI ingest + query API, DuckDB storage, WebSocket fanout | 37 |
-| [`packages/dashboard/`](packages/dashboard/) | Next.js 14 dashboard with paginated timeline | build + 7 Playwright E2E |
+| [`packages/sdk-python/`](packages/sdk-python/) | Python SDK with `@synaptic.trace`, `synaptic.span()`, `synaptic.session()`, integrations | 72 |
+| [`packages/sdk-typescript/`](packages/sdk-typescript/) | `@synaptic/sdk` — peer of the Python SDK | 46 |
+| [`packages/api/`](packages/api/) | FastAPI ingest + query API, DuckDB storage, WebSocket fanout, session aggregations | 46 |
+| [`packages/dashboard/`](packages/dashboard/) | Next.js 14 dashboard with paginated timeline + session view | build + 13 Playwright E2E |
 
 ---
 
@@ -210,6 +211,43 @@ crew.kickoff()
 # LLM calls inside agents -> grandchildren (via the LangChain integration)
 ```
 
+### Sessions (multi-turn conversations)
+
+Group several agent calls into one logical conversation:
+
+```python
+import synaptic
+
+with synaptic.session(name="booking-conversation"):
+    my_agent("Book me a flight to Tokyo")
+    my_agent("Make it business class")
+    my_agent("Add a hotel for 3 nights")
+```
+
+Every traced call inside the `with` block is tagged with a shared `session_id`. The dashboard groups them under `/sessions` with aggregate cost / duration / quality. Click into a session to see the turns in order, click any turn to expand its full span tree.
+
+TypeScript:
+
+```typescript
+import { withSession, trace } from '@synaptic/sdk';
+
+const myAgent = trace(async (q: string) => '...', { name: 'agent' });
+
+await withSession({ name: 'booking-conversation' }, async () => {
+  await myAgent('Book me a flight');
+  await myAgent('Make it business class');
+});
+```
+
+Or pin a specific session at decoration time:
+
+```python
+@synaptic.trace(session_id="user-123-conv-456")
+def my_agent(q): ...
+```
+
+Resolution priority for a span's `session_id` (most specific wins): explicit `@trace(session_id=…)` > active `synaptic.session()` context > parent span's `session_id` > `None`. Traces without a `session_id` stay in `/traces` as standalone runs and don't appear under any session.
+
 ---
 
 ## Configuration
@@ -266,6 +304,8 @@ POST   /v1/traces             # Manual upsert
 GET    /v1/traces             # Paginated list (?limit=&offset=)
 GET    /v1/traces/{id}        # Single trace
 GET    /v1/traces/{id}/spans  # All spans for a trace
+GET    /v1/sessions           # Sessions, derived via GROUP BY session_id
+GET    /v1/sessions/{id}      # Session detail with all traces in order
 POST   /v1/evals              # Submit a quality score
 WS     /ws/traces             # Real-time fanout — new_trace + new_span events
 GET    /health                # Liveness check

--- a/packages/api/main.py
+++ b/packages/api/main.py
@@ -7,7 +7,7 @@ from typing import AsyncIterator
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 from db import Database, get_db
-from routers import evals, spans, traces
+from routers import evals, sessions, spans, traces
 from ws import manager as ws_manager
 
 logger = logging.getLogger("synaptic.api")
@@ -93,6 +93,7 @@ app = FastAPI(
 
 app.include_router(spans.router)
 app.include_router(traces.router)
+app.include_router(sessions.router)
 app.include_router(evals.router)
 
 

--- a/packages/api/models.py
+++ b/packages/api/models.py
@@ -32,6 +32,8 @@ class SpanInput(BaseModel):
     cost_usd: Optional[float] = None
     tool_name: Optional[str] = None
     metadata: Optional[dict] = None
+    # Session grouping — propagates to the trace row when a root span lands
+    session_id: Optional[str] = None
 
 
 class IngestRequest(BaseModel):
@@ -96,6 +98,25 @@ class Span(BaseModel):
     error_message: Optional[str] = None
     tool_name: Optional[str] = None
     metadata: Optional[Any] = None
+
+
+class Session(BaseModel):
+    session_id: str
+    trace_count: int = 0
+    total_duration_ms: int = 0
+    total_cost_usd: float = 0.0
+    total_tokens: int = 0
+    quality_score: Optional[float] = None
+    first_seen: Optional[datetime] = None
+    last_seen: Optional[datetime] = None
+    # Wall-clock duration of the session — last_seen − first_seen — distinct
+    # from total_duration_ms which sums per-trace durations (and may overlap
+    # if turns ran concurrently).
+    wall_duration_ms: Optional[int] = None
+
+
+class SessionDetail(Session):
+    traces: List[Trace] = []
 
 
 class EvalCreate(BaseModel):

--- a/packages/api/routers/sessions.py
+++ b/packages/api/routers/sessions.py
@@ -1,0 +1,99 @@
+"""Sessions endpoints — derived from the traces table via GROUP BY.
+
+A session is just a value of `traces.session_id` shared across multiple
+trace rows. No separate `sessions` table; aggregations are computed on
+the fly. session_id is optional: traces without one don't appear here.
+"""
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from db import Database, get_db
+from models import Session, SessionDetail
+from routers.traces import _row_to_trace
+
+router = APIRouter()
+
+
+def _row_to_session(row: dict) -> Session:
+    first_seen: Optional[datetime] = row.get("first_seen")
+    last_seen: Optional[datetime] = row.get("last_seen")
+    wall_duration_ms: Optional[int] = None
+    if first_seen is not None and last_seen is not None:
+        wall_duration_ms = int((last_seen - first_seen).total_seconds() * 1000)
+
+    qs = row.get("quality_score")
+    cost = row.get("total_cost_usd")
+    return Session(
+        session_id=row["session_id"],
+        trace_count=int(row.get("trace_count") or 0),
+        total_duration_ms=int(row.get("total_duration_ms") or 0),
+        total_cost_usd=float(cost) if cost is not None else 0.0,
+        total_tokens=int(row.get("total_tokens") or 0),
+        quality_score=float(qs) if qs is not None else None,
+        first_seen=first_seen,
+        last_seen=last_seen,
+        wall_duration_ms=wall_duration_ms,
+    )
+
+
+_BASE_AGG = """
+    session_id,
+    COUNT(*) AS trace_count,
+    SUM(COALESCE(DATEDIFF('millisecond', started_at, ended_at), 0)) AS total_duration_ms,
+    SUM(COALESCE(total_cost_usd, 0)) AS total_cost_usd,
+    SUM(COALESCE(total_tokens, 0)) AS total_tokens,
+    AVG(quality_score) AS quality_score,
+    MIN(started_at) AS first_seen,
+    MAX(COALESCE(ended_at, started_at)) AS last_seen
+"""
+
+
+@router.get("/v1/sessions", response_model=List[Session])
+def list_sessions(
+    limit: int = Query(100, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+    db: Database = Depends(get_db),
+) -> List[Session]:
+    rows = db.fetchall_dict(
+        f"""
+        SELECT {_BASE_AGG}
+        FROM traces
+        WHERE session_id IS NOT NULL AND session_id != ''
+        GROUP BY session_id
+        ORDER BY last_seen DESC NULLS LAST
+        LIMIT ? OFFSET ?
+        """,
+        [limit, offset],
+    )
+    return [_row_to_session(r) for r in rows]
+
+
+@router.get("/v1/sessions/{session_id}", response_model=SessionDetail)
+def get_session(session_id: str, db: Database = Depends(get_db)) -> SessionDetail:
+    summary_row = db.fetchone_dict(
+        f"""
+        SELECT {_BASE_AGG}
+        FROM traces
+        WHERE session_id = ?
+        GROUP BY session_id
+        """,
+        [session_id],
+    )
+    if summary_row is None:
+        raise HTTPException(status_code=404, detail="session not found")
+
+    trace_rows = db.fetchall_dict(
+        """
+        SELECT * FROM traces
+        WHERE session_id = ?
+        ORDER BY started_at ASC
+        """,
+        [session_id],
+    )
+    summary = _row_to_session(summary_row)
+    return SessionDetail(
+        **summary.model_dump(),
+        traces=[_row_to_trace(r) for r in trace_rows],
+    )

--- a/packages/api/routers/spans.py
+++ b/packages/api/routers/spans.py
@@ -131,26 +131,37 @@ def _upsert_trace_from_span(db: Database, span: SpanInput) -> bool:
     if span.parent_span_id is None:
         db.execute(
             """
-            INSERT INTO traces (id, name, input, output, started_at, ended_at, ingest_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO traces (
+                id, name, input, output, started_at, ended_at, session_id, ingest_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (id) DO UPDATE SET
                 name = EXCLUDED.name,
                 input = EXCLUDED.input,
                 output = EXCLUDED.output,
                 started_at = EXCLUDED.started_at,
                 ended_at = EXCLUDED.ended_at,
+                session_id = COALESCE(EXCLUDED.session_id, traces.session_id),
                 ingest_at = EXCLUDED.ingest_at
             """,
-            [trace_id, span.name, span.input, span.output, started_at, ended_at, ingest_at],
+            [
+                trace_id, span.name, span.input, span.output,
+                started_at, ended_at, span.session_id, ingest_at,
+            ],
         )
     else:
+        # Stub upsert from a non-root span. Don't overwrite the trace if it
+        # exists — but DO populate session_id on the stub so the orphan
+        # trace shows up in its session right away (the eventual root span
+        # will COALESCE the same id).
         db.execute(
             """
-            INSERT INTO traces (id, started_at, ingest_at)
-            VALUES (?, ?, ?)
-            ON CONFLICT (id) DO NOTHING
+            INSERT INTO traces (id, started_at, session_id, ingest_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT (id) DO UPDATE SET
+                session_id = COALESCE(traces.session_id, EXCLUDED.session_id)
             """,
-            [trace_id, started_at, ingest_at],
+            [trace_id, started_at, span.session_id, ingest_at],
         )
 
     return is_new_trace

--- a/packages/api/tests/test_sessions.py
+++ b/packages/api/tests/test_sessions.py
@@ -1,0 +1,198 @@
+"""Tests for session aggregation endpoints — derived from traces table."""
+
+from datetime import datetime, timedelta, timezone
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _post_root(client, *, id_, session_id=None, name=None, started_at=None, ended_at=None, cost=None, tokens=0):
+    return client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": id_, "trace_id": id_, "name": name or id_,
+                    "started_at": started_at or _iso(datetime.now(timezone.utc)),
+                    "ended_at": ended_at,
+                    "session_id": session_id,
+                }
+            ]
+        },
+    )
+
+
+def test_list_sessions_groups_traces_by_session_id(client):
+    s1 = "session-A"
+    s2 = "session-B"
+    base = datetime(2026, 5, 1, 10, 0, 0, tzinfo=timezone.utc)
+
+    _post_root(client, id_="a-1", session_id=s1, name="turn 1",
+               started_at=_iso(base), ended_at=_iso(base + timedelta(seconds=2)))
+    _post_root(client, id_="a-2", session_id=s1, name="turn 2",
+               started_at=_iso(base + timedelta(seconds=10)), ended_at=_iso(base + timedelta(seconds=11)))
+    _post_root(client, id_="b-1", session_id=s2, name="other",
+               started_at=_iso(base), ended_at=_iso(base + timedelta(seconds=1)))
+
+    response = client.get("/v1/sessions")
+    assert response.status_code == 200
+    sessions = response.json()
+    by_id = {s["session_id"]: s for s in sessions}
+    assert set(by_id) == {s1, s2}
+    assert by_id[s1]["trace_count"] == 2
+    assert by_id[s2]["trace_count"] == 1
+
+
+def test_session_aggregations(client):
+    sid = "agg-session"
+    base = datetime(2026, 5, 1, 10, 0, 0, tzinfo=timezone.utc)
+    _post_root(client, id_="x1", session_id=sid, name="t1",
+               started_at=_iso(base), ended_at=_iso(base + timedelta(milliseconds=1500)))
+    _post_root(client, id_="x2", session_id=sid, name="t2",
+               started_at=_iso(base + timedelta(seconds=5)),
+               ended_at=_iso(base + timedelta(seconds=5, milliseconds=2500)))
+
+    sessions = client.get("/v1/sessions").json()
+    s = next(x for x in sessions if x["session_id"] == sid)
+    assert s["trace_count"] == 2
+    # 1500 + 2500 ms summed
+    assert s["total_duration_ms"] == 4000
+    # Wall clock: from base to base+7.5s = 7500ms
+    assert s["wall_duration_ms"] == 7500
+    assert s["first_seen"].startswith("2026-05-01T10:00:00")
+    assert s["last_seen"].startswith("2026-05-01T10:00:07")
+
+
+def test_traces_without_session_id_are_excluded(client):
+    base = datetime(2026, 5, 1, 10, 0, 0, tzinfo=timezone.utc)
+    _post_root(client, id_="orphan", session_id=None, name="standalone",
+               started_at=_iso(base))
+    sessions = client.get("/v1/sessions").json()
+    ids = {s["session_id"] for s in sessions}
+    assert "orphan" not in ids
+    # Empty session_id (string) also excluded
+    _post_root(client, id_="empty", session_id="", name="empty",
+               started_at=_iso(base))
+    sessions = client.get("/v1/sessions").json()
+    ids = {s["session_id"] for s in sessions}
+    assert "" not in ids
+
+
+def test_get_session_returns_traces_in_chronological_order(client):
+    sid = "ordered-session"
+    base = datetime(2026, 5, 1, 10, 0, 0, tzinfo=timezone.utc)
+    _post_root(client, id_="t-late", session_id=sid, name="last",
+               started_at=_iso(base + timedelta(seconds=10)))
+    _post_root(client, id_="t-early", session_id=sid, name="first",
+               started_at=_iso(base))
+    _post_root(client, id_="t-mid", session_id=sid, name="middle",
+               started_at=_iso(base + timedelta(seconds=5)))
+
+    detail = client.get(f"/v1/sessions/{sid}").json()
+    names = [t["name"] for t in detail["traces"]]
+    assert names == ["first", "middle", "last"]
+    assert detail["trace_count"] == 3
+    assert detail["session_id"] == sid
+
+
+def test_get_session_404(client):
+    response = client.get("/v1/sessions/does-not-exist")
+    assert response.status_code == 404
+
+
+def test_session_id_propagates_from_root_span(client):
+    """The SDK posts a span with session_id; the trace upsert must store it."""
+    sid = "propagation-test"
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "p-root", "trace_id": "p-root", "name": "agent",
+                    "started_at": "2026-05-01T10:00:00Z",
+                    "ended_at": "2026-05-01T10:00:01Z",
+                    "session_id": sid,
+                }
+            ]
+        },
+    )
+    body = client.get("/v1/traces/p-root").json()
+    assert body["session_id"] == sid
+
+
+def test_session_id_propagates_from_orphan_child_to_stub(client):
+    """A child span arriving before its root creates a stub trace; the
+    session_id should land on the stub so the trace is visible in the
+    session aggregation right away."""
+    sid = "orphan-session"
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "orphan-child", "trace_id": "stub-trace",
+                    "parent_span_id": "missing-root", "name": "child",
+                    "started_at": "2026-05-01T10:00:00Z",
+                    "session_id": sid,
+                }
+            ]
+        },
+    )
+    body = client.get("/v1/traces/stub-trace").json()
+    assert body["session_id"] == sid
+    sessions = client.get("/v1/sessions").json()
+    ids = {s["session_id"] for s in sessions}
+    assert sid in ids
+
+
+def test_root_span_does_not_overwrite_existing_session_id(client):
+    """If a stub already has session_id and a root arrives WITHOUT one,
+    keep the stub's session_id (COALESCE behavior)."""
+    sid = "preserved-session"
+    # Orphan child carries session_id
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "child-y", "trace_id": "preserve-trace",
+                    "parent_span_id": "root-y", "name": "child",
+                    "started_at": "2026-05-01T10:00:00Z",
+                    "session_id": sid,
+                }
+            ]
+        },
+    )
+    # Root arrives without session_id
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "preserve-trace", "trace_id": "preserve-trace",
+                    "name": "root_agent",
+                    "started_at": "2026-05-01T10:00:00Z",
+                    "ended_at": "2026-05-01T10:00:01Z",
+                }
+            ]
+        },
+    )
+    body = client.get("/v1/traces/preserve-trace").json()
+    assert body["session_id"] == sid
+
+
+def test_pagination(client):
+    base = datetime(2026, 5, 1, 10, 0, 0, tzinfo=timezone.utc)
+    for i in range(5):
+        _post_root(
+            client, id_=f"pg-{i}",
+            session_id=f"session-{i:02d}",
+            name=f"t{i}",
+            started_at=_iso(base + timedelta(minutes=i)),
+        )
+    response = client.get("/v1/sessions?limit=2")
+    assert len(response.json()) == 2
+
+    response = client.get("/v1/sessions?limit=2&offset=2")
+    assert len(response.json()) == 2

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -56,6 +56,12 @@ export default function RootLayout({
               >
                 Traces
               </Link>
+              <Link
+                href="/sessions"
+                className="text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+              >
+                Sessions
+              </Link>
               <a
                 href="/api/docs"
                 target="_blank"

--- a/packages/dashboard/app/sessions/[id]/page.tsx
+++ b/packages/dashboard/app/sessions/[id]/page.tsx
@@ -1,0 +1,16 @@
+import SessionDetail from '@/components/SessionDetail';
+
+type Params = { id: string };
+
+export const metadata = {
+  title: 'Session',
+};
+
+export default function SessionDetailPage({ params }: { params: Params }) {
+  // Next.js URL-decodes path params automatically
+  return (
+    <div className="max-w-7xl mx-auto">
+      <SessionDetail id={params.id} />
+    </div>
+  );
+}

--- a/packages/dashboard/app/sessions/page.tsx
+++ b/packages/dashboard/app/sessions/page.tsx
@@ -1,0 +1,14 @@
+import SessionList from '@/components/SessionList';
+
+export const metadata = {
+  title: 'Sessions',
+};
+
+export default function SessionsPage() {
+  return (
+    <div className="max-w-7xl mx-auto">
+      <h1 className="text-lg font-semibold mb-5">Sessions</h1>
+      <SessionList />
+    </div>
+  );
+}

--- a/packages/dashboard/components/ConversationTurn.tsx
+++ b/packages/dashboard/components/ConversationTurn.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import useSWR from 'swr';
+import {
+  Span,
+  Trace,
+  deriveStatus,
+  fetcher,
+  formatCost,
+  formatDuration,
+} from '@/lib/api';
+import SpanTimeline from './SpanTimeline';
+
+const STATUS_STYLES: Record<string, string> = {
+  ok: 'text-emerald-300 border-emerald-700 bg-emerald-900/30',
+  error: 'text-red-300 border-red-700 bg-red-900/30',
+  running: 'text-amber-300 border-amber-700 bg-amber-900/30',
+};
+
+/** A single turn in a conversation — one trace, expandable to its span tree.
+ *  Lazy-fetches its spans only when the user clicks to expand, so a
+ *  long conversation doesn't pay the cost of fetching every trace's
+ *  spans up front. */
+export default function ConversationTurn({
+  trace,
+  turnNumber,
+}: {
+  trace: Trace;
+  turnNumber: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const status = deriveStatus(trace);
+  // Conditional SWR — the key is null until the user expands the row,
+  // so no fetch fires for collapsed turns.
+  const { data: spans } = useSWR<Span[]>(
+    open ? `/v1/traces/${trace.id}/spans` : null,
+    fetcher,
+  );
+
+  return (
+    <div className="border-b border-[var(--border)] last:border-b-0">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full px-3 py-3 hover:bg-[#111418] transition-colors flex items-center gap-3 text-left"
+        aria-expanded={open}
+      >
+        <span className="text-[var(--muted)] text-xs font-mono w-16 shrink-0">
+          Turn {turnNumber}
+        </span>
+        <span className="font-mono text-xs text-[var(--muted)] w-16 shrink-0 tabular-nums">
+          {formatDuration(trace.duration_ms)}
+        </span>
+        <span
+          className={`text-[10px] uppercase tracking-wider px-1.5 py-0.5 border rounded shrink-0 ${
+            STATUS_STYLES[status] ?? STATUS_STYLES.ok
+          }`}
+        >
+          {status}
+        </span>
+        <span className="font-mono truncate flex-1">
+          {trace.name ?? trace.id}
+        </span>
+        {trace.total_cost_usd > 0 && (
+          <span className="text-xs text-[var(--muted)] font-mono shrink-0">
+            {formatCost(trace.total_cost_usd)}
+          </span>
+        )}
+        <Link
+          href={`/traces/${trace.id}`}
+          onClick={(e) => e.stopPropagation()}
+          className="text-xs text-[var(--muted)] hover:text-[var(--foreground)] shrink-0"
+          title="Open trace in its own page"
+        >
+          ↗
+        </Link>
+      </button>
+
+      {open && (
+        <div className="px-3 pb-3 pt-1 bg-[#0d1014] space-y-3">
+          {trace.input && (
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-[var(--muted)] mb-1">
+                User input
+              </div>
+              <pre className="font-mono text-xs whitespace-pre-wrap break-all border border-[var(--border)] rounded p-2">
+                {prettyInput(trace.input)}
+              </pre>
+            </div>
+          )}
+          {trace.output && (
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-[var(--muted)] mb-1">
+                Agent output
+              </div>
+              <pre className="font-mono text-xs whitespace-pre-wrap break-all border border-[var(--border)] rounded p-2">
+                {prettyInput(trace.output)}
+              </pre>
+            </div>
+          )}
+          <div>
+            <div className="text-[10px] uppercase tracking-wider text-[var(--muted)] mb-1">
+              Span timeline
+              {spans ? ` (${spans.length})` : ''}
+            </div>
+            {spans ? (
+              spans.length === 0 ? (
+                <div className="text-xs text-[var(--muted)]">No spans.</div>
+              ) : (
+                <SpanTimeline spans={spans} />
+              )
+            ) : (
+              <div className="text-xs text-[var(--muted)]">Loading spans…</div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function prettyInput(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw);
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return raw;
+  }
+}

--- a/packages/dashboard/components/SessionDetail.tsx
+++ b/packages/dashboard/components/SessionDetail.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useRef } from 'react';
+import useSWR, { useSWRConfig } from 'swr';
+import {
+  SessionDetail as SessionDetailT,
+  fetcher,
+  formatCost,
+  formatDuration,
+  formatScore,
+  formatStartedAt,
+} from '@/lib/api';
+import { useTraceStream, WSMessage } from '@/lib/websocket';
+import ConversationTurn from './ConversationTurn';
+
+export default function SessionDetail({ id }: { id: string }) {
+  const sessionKey = `/v1/sessions/${encodeURIComponent(id)}`;
+  const { mutate } = useSWRConfig();
+
+  // Re-fetch the session when a new trace arrives that belongs to it
+  const wsState = useTraceStream(
+    useCallback(
+      (msg: WSMessage) => {
+        if (
+          (msg.type === 'new_trace' && msg.trace.session_id === id) ||
+          (msg.type === 'new_span' && msg.trace_id /* could be in this session */)
+        ) {
+          mutate(sessionKey);
+        }
+      },
+      [id, sessionKey, mutate],
+    ),
+  );
+
+  const refreshInterval = wsState !== 'connected' ? 5000 : 0;
+  const { data, error } = useSWR<SessionDetailT>(sessionKey, fetcher, {
+    refreshInterval,
+  });
+
+  // Catch-up on reconnect
+  const wasDisconnected = useRef(false);
+  useEffect(() => {
+    if (wsState === 'disconnected') {
+      wasDisconnected.current = true;
+    } else if (wsState === 'connected' && wasDisconnected.current) {
+      mutate(sessionKey);
+      wasDisconnected.current = false;
+    }
+  }, [wsState, sessionKey, mutate]);
+
+  if (error) {
+    if ((error as { status?: number }).status === 404) {
+      return (
+        <div className="text-[var(--muted)]">
+          Session <code className="font-mono">{id}</code> not found.
+        </div>
+      );
+    }
+    return (
+      <div className="text-red-400">
+        Failed to load session:{' '}
+        {String((error as { message?: string }).message ?? error)}
+      </div>
+    );
+  }
+  if (!data) return <div className="text-[var(--muted)]">Loading…</div>;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <Link
+          href="/sessions"
+          className="text-[var(--muted)] text-xs hover:text-[var(--foreground)]"
+        >
+          ← All sessions
+        </Link>
+        <span
+          className="inline-flex items-center gap-1 text-xs text-[var(--muted)]"
+          title={
+            wsState === 'connected'
+              ? 'WebSocket connected — new turns appear live'
+              : 'WebSocket unavailable — polling every 5s'
+          }
+        >
+          <span
+            className={
+              wsState === 'connected'
+                ? 'inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse'
+                : 'inline-block h-1.5 w-1.5 rounded-full bg-slate-500'
+            }
+          />
+          {wsState === 'connected' ? 'live' : 'polling'}
+        </span>
+      </div>
+
+      <header className="border border-[var(--border)] rounded p-4">
+        <h1 className="font-mono text-base mb-1 break-all">
+          {data.session_id}
+        </h1>
+        <div className="text-[var(--muted)] text-xs mb-3">
+          Multi-turn conversation
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-4 text-sm">
+          <Metric label="Turns" value={String(data.trace_count)} />
+          <Metric
+            label="Wall duration"
+            value={formatDuration(data.wall_duration_ms)}
+          />
+          <Metric label="Total cost" value={formatCost(data.total_cost_usd)} />
+          <Metric label="Avg quality" value={formatScore(data.quality_score)} />
+          <Metric label="Started" value={formatStartedAt(data.first_seen)} />
+        </div>
+      </header>
+
+      <section>
+        <h2 className="text-xs uppercase tracking-wider text-[var(--muted)] mb-2">
+          Conversation timeline ({data.traces.length}{' '}
+          {data.traces.length === 1 ? 'turn' : 'turns'})
+        </h2>
+        {data.traces.length === 0 ? (
+          <div className="text-[var(--muted)] text-sm">
+            No turns yet for this session.
+          </div>
+        ) : (
+          <div className="border border-[var(--border)] rounded">
+            {data.traces.map((trace, i) => (
+              <ConversationTurn
+                key={trace.id}
+                trace={trace}
+                turnNumber={i + 1}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider text-[var(--muted)]">
+        {label}
+      </div>
+      <div className="font-mono">{value}</div>
+    </div>
+  );
+}

--- a/packages/dashboard/components/SessionDetail.tsx
+++ b/packages/dashboard/components/SessionDetail.tsx
@@ -18,14 +18,16 @@ export default function SessionDetail({ id }: { id: string }) {
   const sessionKey = `/v1/sessions/${encodeURIComponent(id)}`;
   const { mutate } = useSWRConfig();
 
-  // Re-fetch the session when a new trace arrives that belongs to it
+  // Refetch the session when a new trace arrives that belongs to it.
+  // We deliberately do NOT refetch on every new_span — most spans belong
+  // to traces in OTHER sessions, and we don't have membership info from
+  // the message alone. Inner span counts inside an open turn won't update
+  // live (acceptable for v1 — the user can collapse + re-expand the turn
+  // to refresh, or open the trace in its own page where spans stream live).
   const wsState = useTraceStream(
     useCallback(
       (msg: WSMessage) => {
-        if (
-          (msg.type === 'new_trace' && msg.trace.session_id === id) ||
-          (msg.type === 'new_span' && msg.trace_id /* could be in this session */)
-        ) {
+        if (msg.type === 'new_trace' && msg.trace.session_id === id) {
           mutate(sessionKey);
         }
       },

--- a/packages/dashboard/components/SessionList.tsx
+++ b/packages/dashboard/components/SessionList.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import useSWR, { useSWRConfig } from 'swr';
+import {
+  Session,
+  fetcher,
+  formatCost,
+  formatDuration,
+  formatScore,
+  formatStartedAt,
+} from '@/lib/api';
+import { useTraceStream, WSMessage } from '@/lib/websocket';
+
+const COLS =
+  'grid grid-cols-[1fr_180px_100px_120px_100px_80px] gap-4 px-3 py-2';
+const PAGE_SIZE_DEFAULT = 15;
+const PAGE_SIZES = [15, 25, 50, 100];
+const PAGE_SIZE_STORAGE_KEY = 'synaptic.pageSize';
+
+function readStoredPageSize(): number {
+  if (typeof window === 'undefined') return PAGE_SIZE_DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(PAGE_SIZE_STORAGE_KEY);
+    const n = raw ? Number(raw) : NaN;
+    return PAGE_SIZES.includes(n) ? n : PAGE_SIZE_DEFAULT;
+  } catch {
+    return PAGE_SIZE_DEFAULT;
+  }
+}
+
+export default function SessionList() {
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSizeState] = useState(PAGE_SIZE_DEFAULT);
+  useEffect(() => {
+    const stored = readStoredPageSize();
+    if (stored !== PAGE_SIZE_DEFAULT) setPageSizeState(stored);
+  }, []);
+
+  const setPageSize = (n: number) => {
+    setPageSizeState(n);
+    setPage(0);
+    try {
+      window.localStorage.setItem(PAGE_SIZE_STORAGE_KEY, String(n));
+    } catch {
+      /* swallow */
+    }
+  };
+
+  const offset = page * pageSize;
+  const swrKey = `/v1/sessions?limit=${pageSize + 1}&offset=${offset}`;
+  const { mutate } = useSWRConfig();
+
+  // Listen for new traces — when one arrives with a session_id, the
+  // session aggregations (trace_count, totals, last_seen) might have
+  // changed. Trigger a revalidation to refresh the session list.
+  const wsState = useTraceStream((msg: WSMessage) => {
+    if (msg.type === 'new_trace' && msg.trace.session_id && page === 0) {
+      mutate(swrKey);
+    }
+  });
+
+  const { data, error, isLoading } = useSWR<Session[]>(swrKey, fetcher, {
+    refreshInterval: page === 0 && wsState !== 'connected' ? 5000 : 0,
+    keepPreviousData: true,
+  });
+
+  // Catch-up revalidation on WS reconnect
+  const wasDisconnected = useRef(false);
+  useEffect(() => {
+    if (wsState === 'disconnected') {
+      wasDisconnected.current = true;
+    } else if (wsState === 'connected' && wasDisconnected.current) {
+      mutate(swrKey);
+      wasDisconnected.current = false;
+    }
+  }, [wsState, swrKey, mutate]);
+
+  if (error) {
+    return (
+      <div className="text-red-400">
+        Failed to load sessions: {String(error.message ?? error)}
+      </div>
+    );
+  }
+  if (isLoading || !data) {
+    return <div className="text-[var(--muted)]">Loading…</div>;
+  }
+
+  const hasMore = data.length > pageSize;
+  const visible = data.slice(0, pageSize);
+
+  if (visible.length === 0 && page === 0) {
+    return (
+      <div className="text-[var(--muted)]">
+        No sessions yet. Wrap your agent calls in{' '}
+        <code className="font-mono">synaptic.session(name=&quot;…&quot;)</code> to
+        group multi-turn conversations together.
+      </div>
+    );
+  }
+
+  const startIdx = offset + 1;
+  const endIdx = offset + visible.length;
+
+  return (
+    <div>
+      <div className="border border-[var(--border)] rounded">
+        <div
+          className={`${COLS} text-xs uppercase tracking-wider text-[var(--muted)] border-b border-[var(--border)]`}
+        >
+          <div>Session</div>
+          <div>Last activity</div>
+          <div>Turns</div>
+          <div>Total cost</div>
+          <div>Avg quality</div>
+          <div>Tokens</div>
+        </div>
+        {visible.length === 0 ? (
+          <div className="px-3 py-8 text-center text-[var(--muted)]">
+            No sessions on this page.{' '}
+            <button
+              onClick={() => setPage(0)}
+              className="underline hover:text-[var(--foreground)]"
+            >
+              Back to first page
+            </button>
+          </div>
+        ) : (
+          visible.map((s) => (
+            <Link
+              key={s.session_id}
+              href={`/sessions/${encodeURIComponent(s.session_id)}`}
+              className={`${COLS} border-b border-[var(--border)] last:border-b-0 hover:bg-[#111418] transition-colors`}
+            >
+              <div className="font-mono truncate">{s.session_id}</div>
+              <div className="text-[var(--muted)]">
+                {formatStartedAt(s.last_seen)}
+              </div>
+              <div className="font-mono">{s.trace_count}</div>
+              <div>{formatCost(s.total_cost_usd)}</div>
+              <div>{formatScore(s.quality_score)}</div>
+              <div className="text-[var(--muted)] font-mono text-xs">
+                {s.total_tokens.toLocaleString()}
+              </div>
+            </Link>
+          ))
+        )}
+      </div>
+
+      <div className="mt-4 flex items-center justify-between gap-3 flex-wrap text-xs">
+        <div className="flex items-center gap-3 text-[var(--muted)]">
+          <span>
+            {visible.length === 0 ? 'No results' : `${startIdx}–${endIdx}`}
+            {' · page '}
+            {page + 1}
+            {page === 0 && (
+              <span
+                className="ml-2 inline-flex items-center gap-1"
+                title={
+                  wsState === 'connected'
+                    ? 'WebSocket connected — sessions update live'
+                    : 'WebSocket unavailable — polling every 5s'
+                }
+              >
+                <span
+                  className={
+                    wsState === 'connected'
+                      ? 'inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse'
+                      : 'inline-block h-1.5 w-1.5 rounded-full bg-slate-500'
+                  }
+                />
+                {wsState === 'connected' ? 'live' : 'polling'}
+              </span>
+            )}
+          </span>
+          <span className="opacity-30">|</span>
+          <label className="flex items-center gap-1.5">
+            <span>Per page:</span>
+            <select
+              value={pageSize}
+              onChange={(e) => setPageSize(Number(e.target.value))}
+              className="bg-transparent border border-[var(--border)] rounded px-1.5 py-0.5 text-[var(--foreground)] focus:outline-none focus:border-[var(--accent)]"
+            >
+              {PAGE_SIZES.map((n) => (
+                <option key={n} value={n} className="bg-[var(--background)]">
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {page > 0 && (
+            <button
+              onClick={() => setPage(0)}
+              className="px-2 py-1 text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+              title="Jump to first page"
+            >
+              ⇤ First
+            </button>
+          )}
+          <button
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0}
+            className="px-3 py-1 border border-[var(--border)] rounded hover:bg-[#111418] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            ← Previous
+          </button>
+          <button
+            onClick={() => setPage((p) => p + 1)}
+            disabled={!hasMore}
+            className="px-3 py-1 border border-[var(--border)] rounded hover:bg-[#111418] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            Next →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/lib/api.ts
+++ b/packages/dashboard/lib/api.ts
@@ -21,6 +21,22 @@ export type Trace = {
   ingest_at: string | null;
 };
 
+export type Session = {
+  session_id: string;
+  trace_count: number;
+  total_duration_ms: number;
+  total_cost_usd: number;
+  total_tokens: number;
+  quality_score: number | null;
+  first_seen: string | null;
+  last_seen: string | null;
+  wall_duration_ms: number | null;
+};
+
+export type SessionDetail = Session & {
+  traces: Trace[];
+};
+
 export type Span = {
   id: string;
   trace_id: string;

--- a/packages/dashboard/tests/e2e/sessions.spec.ts
+++ b/packages/dashboard/tests/e2e/sessions.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Browser-level E2E for the Sessions feature.
+ *
+ * Posts traces with shared session_id values directly to the API,
+ * then exercises the /sessions list and /sessions/[id] detail
+ * pages in real Chromium.
+ */
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8000';
+
+function nowIso(offsetMs = 0): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+async function postSpan(spans: Array<Record<string, unknown>>): Promise<void> {
+  const res = await fetch(`${API_BASE}/v1/spans`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ spans }),
+  });
+  if (!res.ok) {
+    throw new Error(`POST /v1/spans failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+async function postTurn(opts: {
+  sessionId: string;
+  name: string;
+  input?: string;
+  startedMsOffset?: number;
+}): Promise<string> {
+  const id = randomUUID();
+  await postSpan([
+    {
+      id, trace_id: id,
+      name: opts.name,
+      input: opts.input ? JSON.stringify({ args: [opts.input] }) : undefined,
+      started_at: nowIso(opts.startedMsOffset ?? 0),
+      ended_at: nowIso((opts.startedMsOffset ?? 0) + 50),
+      session_id: opts.sessionId,
+    },
+  ]);
+  return id;
+}
+
+// ---------- header navigation ----------
+
+test('header has a Sessions link that navigates correctly', async ({ page }) => {
+  await page.goto('/traces');
+  await page.getByRole('link', { name: 'Sessions' }).first().click();
+  await expect(page).toHaveURL(/\/sessions$/);
+  await expect(page.getByRole('heading', { name: 'Sessions' })).toBeVisible();
+});
+
+// ---------- session list ----------
+
+test('session list groups traces by session_id', async ({ page }) => {
+  const sessionId = `e2e-list-${randomUUID()}`;
+  await postTurn({ sessionId, name: 'turn 1', input: 'Book me a flight' });
+  await postTurn({ sessionId, name: 'turn 2', input: 'Business class', startedMsOffset: 100 });
+  await postTurn({ sessionId, name: 'turn 3', input: 'Add hotel', startedMsOffset: 200 });
+
+  await page.goto('/sessions');
+
+  // The session row appears with id and a turn count of 3
+  const row = page.locator(`a:has-text("${sessionId}")`).first();
+  await expect(row).toBeVisible({ timeout: 10_000 });
+  await expect(row).toContainText('3'); // turns column
+});
+
+test('session list excludes traces without session_id', async ({ page }) => {
+  // Post a trace WITHOUT session_id
+  const id = randomUUID();
+  await postSpan([
+    {
+      id, trace_id: id, name: 'standalone',
+      started_at: nowIso(), ended_at: nowIso(50),
+    },
+  ]);
+
+  // Post another trace WITH a session_id (so we can verify the page works at all)
+  const sessionId = `e2e-excl-${randomUUID()}`;
+  await postTurn({ sessionId, name: 'in-session' });
+
+  await page.goto('/sessions');
+  await expect(page.locator(`a:has-text("${sessionId}")`).first()).toBeVisible();
+  // The standalone trace's id should NOT appear as a session
+  await expect(page.locator(`a:has-text("${id}")`)).toHaveCount(0);
+});
+
+// ---------- session detail / conversation timeline ----------
+
+test('session detail renders turns in chronological order with click-to-expand', async ({ page }) => {
+  const sessionId = `e2e-detail-${randomUUID()}`;
+  await postTurn({ sessionId, name: 'turn 1', input: 'Book me a flight to Tokyo' });
+  await postTurn({ sessionId, name: 'turn 2', input: 'Make it business class', startedMsOffset: 100 });
+  await postTurn({ sessionId, name: 'turn 3', input: 'Add hotel for 3 nights', startedMsOffset: 200 });
+
+  await page.goto(`/sessions/${encodeURIComponent(sessionId)}`);
+
+  // Header with the session id
+  await expect(page.getByText(sessionId).first()).toBeVisible();
+
+  // Conversation timeline shows 3 turns
+  await expect(page.getByText(/Conversation timeline \(3 turns\)/i)).toBeVisible();
+
+  // Each turn label appears (use exact match — getByText is case-
+  // insensitive by default, which would also match the lowercase trace
+  // names "turn 1" / "turn 2" / "turn 3" we posted as the trace.name).
+  await expect(page.getByText('Turn 1', { exact: true })).toBeVisible();
+  await expect(page.getByText('Turn 2', { exact: true })).toBeVisible();
+  await expect(page.getByText('Turn 3', { exact: true })).toBeVisible();
+
+  // Order: Turn 1 must come before Turn 3 in the DOM
+  const turn1Box = await page
+    .getByText('Turn 1', { exact: true })
+    .first()
+    .boundingBox();
+  const turn3Box = await page
+    .getByText('Turn 3', { exact: true })
+    .first()
+    .boundingBox();
+  expect(turn1Box).not.toBeNull();
+  expect(turn3Box).not.toBeNull();
+  if (turn1Box && turn3Box) {
+    expect(turn1Box.y).toBeLessThan(turn3Box.y);
+  }
+
+  // Click the first turn — its input should expand into view
+  await page.getByText('Turn 1', { exact: true }).first().click();
+  await expect(page.getByText('Book me a flight to Tokyo')).toBeVisible({
+    timeout: 5_000,
+  });
+
+  // The expanded turn shows its span timeline header
+  await expect(page.getByText(/Span timeline/i).first()).toBeVisible();
+});
+
+test('404 detail for a non-existent session', async ({ page }) => {
+  const bogus = `does-not-exist-${randomUUID()}`;
+  await page.goto(`/sessions/${bogus}`);
+  await expect(page.getByText(/not found/i)).toBeVisible({ timeout: 10_000 });
+});
+
+// ---------- live: WS push refreshes the session list ----------
+
+test('a new turn pushed via WS updates the session list trace_count', async ({ page }) => {
+  const sessionId = `e2e-live-${randomUUID()}`;
+
+  // Seed with one turn so the session exists when we land on the page
+  await postTurn({ sessionId, name: 'first turn' });
+
+  await page.goto('/sessions');
+  const rowSelector = `a:has-text("${sessionId}")`;
+  await expect(page.locator(rowSelector).first()).toBeVisible({ timeout: 10_000 });
+  // Initially 1 turn
+  await expect(page.locator(rowSelector).first()).toContainText('1');
+
+  // Add two more turns — the WS push should refresh the count to 3
+  await postTurn({ sessionId, name: 'second turn', startedMsOffset: 100 });
+  await postTurn({ sessionId, name: 'third turn', startedMsOffset: 200 });
+
+  // Wait up to 6s for the WS push to land the refresh
+  await expect(page.locator(rowSelector).first()).toContainText('3', {
+    timeout: 6_000,
+  });
+});

--- a/packages/sdk-python/synaptic/__init__.py
+++ b/packages/sdk-python/synaptic/__init__.py
@@ -1,5 +1,14 @@
-from .context import get_current_span
+from .context import get_current_session, get_current_span
 from .sdk import configure, span, trace
+from .session import Session, session
 
-__all__ = ["configure", "trace", "span", "get_current_span"]
+__all__ = [
+    "configure",
+    "trace",
+    "span",
+    "session",
+    "Session",
+    "get_current_span",
+    "get_current_session",
+]
 __version__ = "0.1.0"

--- a/packages/sdk-python/synaptic/context.py
+++ b/packages/sdk-python/synaptic/context.py
@@ -1,10 +1,16 @@
 import contextvars
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from .span import Span
 
+if TYPE_CHECKING:
+    from .session import Session
+
 _current_span: contextvars.ContextVar[Optional[Span]] = contextvars.ContextVar(
     "synaptic_current_span", default=None
+)
+_current_session: contextvars.ContextVar[Optional["Session"]] = contextvars.ContextVar(
+    "synaptic_current_session", default=None
 )
 
 
@@ -18,3 +24,7 @@ def set_current_span(span: Optional[Span]) -> contextvars.Token:
 
 def reset_current_span(token: contextvars.Token) -> None:
     _current_span.reset(token)
+
+
+def get_current_session() -> Optional["Session"]:
+    return _current_session.get()

--- a/packages/sdk-python/synaptic/sdk.py
+++ b/packages/sdk-python/synaptic/sdk.py
@@ -6,7 +6,12 @@ import threading
 from typing import Any, Callable, Optional
 
 from .config import Config
-from .context import get_current_span, reset_current_span, set_current_span
+from .context import (
+    get_current_session,
+    get_current_span,
+    reset_current_span,
+    set_current_span,
+)
 from .exporter import HTTPExporter
 from .queue import BoundedQueue
 from .span import Span, SpanContext
@@ -184,7 +189,32 @@ def span(name: str, type: str = "custom") -> SpanContext:
     return SpanContext(_get_sdk(), name, type)
 
 
-def trace(_func: Optional[Callable] = None, *, name: Optional[str] = None, type: str = "custom"):
+def _resolve_session_id(
+    explicit: Optional[str], parent: Optional[Span]
+) -> Optional[str]:
+    """Pick the session_id to attach to a new span.
+
+    Priority: explicit @trace(session_id=...) > active synaptic.session()
+    context > parent span's session_id (so children inherit). None means
+    "no session" and the field is omitted from storage.
+    """
+    if explicit is not None:
+        return explicit
+    current = get_current_session()
+    if current is not None:
+        return current.id
+    if parent is not None and parent.session_id:
+        return parent.session_id
+    return None
+
+
+def trace(
+    _func: Optional[Callable] = None,
+    *,
+    name: Optional[str] = None,
+    type: str = "custom",
+    session_id: Optional[str] = None,
+):
     """Decorator that records a span around a function call.
 
     Works on both sync and async functions (auto-detected).
@@ -194,6 +224,9 @@ def trace(_func: Optional[Callable] = None, *, name: Optional[str] = None, type:
 
         @trace(name="my_step", type="llm")
         async def g(...): ...
+
+        @trace(session_id="user-123-conv-456")
+        def h(...): ...   # always tagged with this session
     """
 
     def decorator(fn: Callable) -> Callable:
@@ -207,6 +240,7 @@ def trace(_func: Optional[Callable] = None, *, name: Optional[str] = None, type:
                 cfg = sdk.config
                 parent = get_current_span()
                 s = Span.create(span_name, type, parent=parent)
+                s.session_id = _resolve_session_id(session_id, parent)
                 if cfg.capture_inputs:
                     s.set_input(
                         {"args": list(args), "kwargs": kwargs}, cfg.max_payload_size
@@ -233,6 +267,7 @@ def trace(_func: Optional[Callable] = None, *, name: Optional[str] = None, type:
             cfg = sdk.config
             parent = get_current_span()
             s = Span.create(span_name, type, parent=parent)
+            s.session_id = _resolve_session_id(session_id, parent)
             if cfg.capture_inputs:
                 s.set_input(
                     {"args": list(args), "kwargs": kwargs}, cfg.max_payload_size

--- a/packages/sdk-python/synaptic/session.py
+++ b/packages/sdk-python/synaptic/session.py
@@ -1,0 +1,73 @@
+"""Session — a logical grouping of related traces.
+
+Use as a context manager to scope a multi-turn conversation or workflow:
+
+    session = synaptic.session(name="booking-conversation")
+
+    with session:
+        my_agent("Book me a flight to Tokyo")
+        my_agent("Make it business class")
+        my_agent("Add a hotel for 3 nights")
+
+Every ``@synaptic.trace`` call inside the ``with`` block automatically
+gets ``session_id`` set on its root span. Sessions are derived server-side
+by grouping ``traces`` rows on ``session_id`` — no separate sessions table.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from contextvars import Token
+from typing import Optional
+
+from .context import _current_session
+
+
+def _slug(name: str) -> str:
+    """Make a name safe to use in a session id: lowercase, dashes only."""
+    s = re.sub(r"[^a-zA-Z0-9_-]+", "-", name).strip("-").lower()
+    return s or "session"
+
+
+class Session:
+    """A logical group of related traces. Both sync and async context-manager
+    compatible. Pass ``id`` to use a known identifier (good for resuming a
+    conversation across processes); pass ``name`` to get a slug-prefixed id;
+    pass nothing for a fresh UUID."""
+
+    def __init__(self, id: Optional[str] = None, name: Optional[str] = None):
+        if id:
+            self.id = id
+        elif name:
+            self.id = f"{_slug(name)}-{uuid.uuid4().hex[:8]}"
+        else:
+            self.id = str(uuid.uuid4())
+        self.name = name
+        self._token: Optional[Token] = None
+
+    def __repr__(self) -> str:
+        if self.name:
+            return f"Session(id={self.id!r}, name={self.name!r})"
+        return f"Session(id={self.id!r})"
+
+    def __enter__(self) -> "Session":
+        self._token = _current_session.set(self)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._token is not None:
+            _current_session.reset(self._token)
+            self._token = None
+
+    async def __aenter__(self) -> "Session":
+        return self.__enter__()
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self.__exit__(exc_type, exc, tb)
+
+
+def session(id: Optional[str] = None, name: Optional[str] = None) -> Session:
+    """Factory matching the ``synaptic.session(...)`` lowercase form shown
+    in the docs. Returns a context manager."""
+    return Session(id=id, name=name)

--- a/packages/sdk-python/synaptic/span.py
+++ b/packages/sdk-python/synaptic/span.py
@@ -36,6 +36,10 @@ class Span:
     started_at: str = field(default_factory=_now_iso)
     ended_at: Optional[str] = None
     error: Optional[str] = None
+    # Optional session grouping — populated from synaptic.session() context
+    # or @synaptic.trace(session_id=...). Default None preserves existing
+    # behavior for callers that don't use sessions.
+    session_id: Optional[str] = None
 
     @classmethod
     def create(
@@ -84,6 +88,7 @@ class Span:
             "started_at": self.started_at,
             "ended_at": self.ended_at,
             "error": self.error,
+            "session_id": self.session_id,
         }
 
 

--- a/packages/sdk-python/tests/test_session.py
+++ b/packages/sdk-python/tests/test_session.py
@@ -1,0 +1,209 @@
+"""Tests for synaptic.session() — multi-turn session grouping."""
+
+import asyncio
+import json
+
+import pytest
+
+import synaptic
+from synaptic import Session
+
+
+# ---------- Session class basics ----------
+
+
+def test_session_with_explicit_id():
+    s = Session(id="user-123-conv-456")
+    assert s.id == "user-123-conv-456"
+    assert s.name is None
+
+
+def test_session_with_name_gets_slug_prefixed_id():
+    s = Session(name="Booking Flow!")
+    assert s.id.startswith("booking-flow-")
+    # slug + 8-char hex suffix
+    assert len(s.id) == len("booking-flow-") + 8
+    assert s.name == "Booking Flow!"
+
+
+def test_session_with_no_args_gets_uuid():
+    s = Session()
+    # Looks like a UUID
+    assert len(s.id) == 36
+    assert s.id.count("-") == 4
+
+
+def test_explicit_id_wins_over_name():
+    s = Session(id="explicit", name="ignored")
+    assert s.id == "explicit"
+
+
+# ---------- Context manager + propagation ----------
+
+
+def test_get_current_session_returns_active(sdk):
+    assert synaptic.get_current_session() is None
+    with Session(id="active") as s:
+        assert synaptic.get_current_session() is s
+    assert synaptic.get_current_session() is None
+
+
+def test_session_id_propagates_to_traced_function(sdk, captured):
+    @synaptic.trace
+    def my_agent(q):
+        return f"answer: {q}"
+
+    with synaptic.session(id="user-1-conv-1"):
+        my_agent("hello")
+        my_agent("again")
+
+    sdk.flush()
+    assert len(captured) == 2
+    for s in captured:
+        assert s.session_id == "user-1-conv-1"
+
+
+def test_session_id_propagates_to_nested_spans(sdk, captured):
+    @synaptic.trace
+    def child():
+        return "x"
+
+    @synaptic.trace
+    def parent():
+        return child()
+
+    with synaptic.session(id="nested-test"):
+        parent()
+    sdk.flush()
+
+    by_name = {s.name: s for s in captured}
+    assert by_name["parent"].session_id == "nested-test"
+    assert by_name["child"].session_id == "nested-test"
+    assert by_name["parent"].trace_id == by_name["child"].trace_id
+
+
+def test_no_session_outside_context(sdk, captured):
+    @synaptic.trace
+    def standalone():
+        return 1
+
+    standalone()
+    sdk.flush()
+    assert captured[0].session_id is None
+
+
+def test_session_only_applies_inside_with(sdk, captured):
+    @synaptic.trace
+    def fn():
+        return 1
+
+    fn()  # before — no session
+
+    with synaptic.session(id="scoped"):
+        fn()  # inside — has session
+
+    fn()  # after — no session
+
+    sdk.flush()
+    sessions = [s.session_id for s in captured]
+    assert sessions == [None, "scoped", None]
+
+
+def test_explicit_session_id_on_decorator_overrides_context(sdk, captured):
+    @synaptic.trace(session_id="from-decorator")
+    def fn():
+        return 1
+
+    with synaptic.session(id="from-context"):
+        fn()
+    sdk.flush()
+
+    assert captured[0].session_id == "from-decorator"
+
+
+def test_explicit_session_id_works_outside_context(sdk, captured):
+    @synaptic.trace(session_id="explicit-only")
+    def fn():
+        return 1
+
+    fn()
+    sdk.flush()
+    assert captured[0].session_id == "explicit-only"
+
+
+# ---------- async ----------
+
+
+async def test_async_session_context_manager(sdk, captured):
+    @synaptic.trace
+    async def async_agent(q):
+        await asyncio.sleep(0)
+        return q
+
+    async with synaptic.session(id="async-session"):
+        await async_agent("first")
+        await async_agent("second")
+    sdk.flush()
+
+    assert all(s.session_id == "async-session" for s in captured)
+
+
+async def test_concurrent_async_tasks_share_session_via_contextvar(sdk, captured):
+    @synaptic.trace
+    async def task(name):
+        await asyncio.sleep(0.005)
+        return name
+
+    async with synaptic.session(id="concurrent-test"):
+        await asyncio.gather(task("a"), task("b"), task("c"))
+    sdk.flush()
+
+    assert all(s.session_id == "concurrent-test" for s in captured)
+
+
+# ---------- nested sessions (inner overrides outer) ----------
+
+
+def test_nested_session_inner_wins_inside(sdk, captured):
+    @synaptic.trace
+    def fn():
+        return 1
+
+    with synaptic.session(id="outer"):
+        fn()  # outer
+        with synaptic.session(id="inner"):
+            fn()  # inner
+        fn()  # outer again
+    sdk.flush()
+
+    sessions = [s.session_id for s in captured]
+    assert sessions == ["outer", "inner", "outer"]
+
+
+# ---------- to_dict shape ----------
+
+
+def test_to_dict_includes_session_id(sdk, captured):
+    @synaptic.trace
+    def fn():
+        return 1
+
+    with synaptic.session(id="dict-shape"):
+        fn()
+    sdk.flush()
+
+    d = captured[0].to_dict()
+    assert "session_id" in d
+    assert d["session_id"] == "dict-shape"
+
+
+def test_to_dict_session_id_is_none_when_no_session(sdk, captured):
+    @synaptic.trace
+    def fn():
+        return 1
+
+    fn()
+    sdk.flush()
+
+    d = captured[0].to_dict()
+    assert d["session_id"] is None

--- a/packages/sdk-typescript/src/context.ts
+++ b/packages/sdk-typescript/src/context.ts
@@ -1,11 +1,20 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { Span } from './span.js';
+import type { Session } from './session.js';
 
 /** Per-async-task current span. Works across await boundaries, Promise
  *  chains, setTimeout, EventEmitter. Does NOT propagate across worker
  *  threads (separate ALS per thread — consistent with Python contextvars). */
 export const spanStorage = new AsyncLocalStorage<Span>();
 
+/** Per-async-task current session. Same propagation semantics as the span
+ *  storage. Populated by Session.run() / withSession(). */
+export const sessionStorage = new AsyncLocalStorage<Session>();
+
 export function getCurrentSpan(): Span | undefined {
   return spanStorage.getStore();
+}
+
+export function getCurrentSession(): Session | undefined {
+  return sessionStorage.getStore();
 }

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -1,7 +1,8 @@
 export { configure, getSDK, setSDK, SynapticSDK } from './sdk.js';
 export { trace, span, withSpan } from './trace.js';
-export { getCurrentSpan } from './context.js';
+export { getCurrentSpan, getCurrentSession } from './context.js';
 export { Span } from './span.js';
+export { Session, session, withSession } from './session.js';
 export { BoundedQueue } from './queue.js';
 export { HTTPExporter } from './exporter.js';
 
@@ -9,3 +10,4 @@ export type { SpanData } from './span.js';
 export type { SynapticConfig, ResolvedConfig } from './config.js';
 export type { Exporter } from './exporter.js';
 export type { TraceOptions, SpanHandle } from './trace.js';
+export type { SessionOptions } from './session.js';

--- a/packages/sdk-typescript/src/session.ts
+++ b/packages/sdk-typescript/src/session.ts
@@ -1,0 +1,58 @@
+import { randomUUID } from 'node:crypto';
+import { sessionStorage } from './context.js';
+
+export interface SessionOptions {
+  id?: string;
+  name?: string;
+}
+
+function slug(name: string): string {
+  const s = name.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '').toLowerCase();
+  return s || 'session';
+}
+
+/** A logical group of related traces — a multi-turn conversation, a
+ *  workflow, etc. JS doesn't have Python-style ``with`` blocks; the
+ *  typical pattern is ``await session.run(async () => { ... })``.
+ *
+ *  Inside the callback, every traced function picks up the session id
+ *  via AsyncLocalStorage and tags its root span. Server-side this groups
+ *  the resulting traces under one session_id.
+ */
+export class Session {
+  readonly id: string;
+  readonly name: string | undefined;
+
+  constructor(opts: SessionOptions = {}) {
+    if (opts.id) {
+      this.id = opts.id;
+    } else if (opts.name) {
+      // Slug + 8 hex chars from a fresh UUID (matches the Python SDK)
+      const short = randomUUID().replace(/-/g, '').slice(0, 8);
+      this.id = `${slug(opts.name)}-${short}`;
+    } else {
+      this.id = randomUUID();
+    }
+    this.name = opts.name;
+  }
+
+  /** Run a callback with this session installed in AsyncLocalStorage.
+   *  All traced functions inside (including transitively) inherit
+   *  ``session_id``. */
+  run<T>(fn: () => Promise<T> | T): Promise<T> {
+    return Promise.resolve(sessionStorage.run(this, fn));
+  }
+}
+
+/** Lowercase factory matching the Python ``synaptic.session(...)`` form. */
+export function session(opts: SessionOptions = {}): Session {
+  return new Session(opts);
+}
+
+/** Convenience: open a session and run a callback in one expression. */
+export async function withSession<T>(
+  opts: SessionOptions,
+  fn: () => Promise<T> | T,
+): Promise<T> {
+  return new Session(opts).run(fn);
+}

--- a/packages/sdk-typescript/src/span.ts
+++ b/packages/sdk-typescript/src/span.ts
@@ -11,6 +11,9 @@ export interface SpanData {
   started_at: string;
   ended_at: string | null;
   error: string | null;
+  /** Optional session grouping. Populated from the current session() context
+   *  or via trace(fn, { sessionId }). Default null preserves prior behavior. */
+  session_id: string | null;
 }
 
 function serialize(value: unknown, maxSize: number): string | null {
@@ -40,6 +43,7 @@ export class Span {
   output: string | null = null;
   ended_at: string | null = null;
   error: string | null = null;
+  session_id: string | null = null;
 
   private constructor(
     id: string,
@@ -98,6 +102,7 @@ export class Span {
       started_at: this.started_at,
       ended_at: this.ended_at,
       error: this.error,
+      session_id: this.session_id,
     };
   }
 }

--- a/packages/sdk-typescript/src/trace.ts
+++ b/packages/sdk-typescript/src/trace.ts
@@ -1,10 +1,24 @@
-import { spanStorage, getCurrentSpan } from './context.js';
+import { spanStorage, getCurrentSpan, getCurrentSession } from './context.js';
 import { Span } from './span.js';
 import { getSDK } from './sdk.js';
 
 export interface TraceOptions {
   name?: string;
   type?: string;
+  /** Pin every invocation to a specific session id. Overrides any active
+   *  session() context. */
+  sessionId?: string;
+}
+
+function resolveSessionId(
+  explicit: string | undefined,
+  parent: Span | null,
+): string | null {
+  if (explicit) return explicit;
+  const current = getCurrentSession();
+  if (current) return current.id;
+  if (parent && parent.session_id) return parent.session_id;
+  return null;
 }
 
 /** Wrap an async function so each invocation records a Synaptic span.
@@ -23,6 +37,7 @@ export function trace<T extends (...args: unknown[]) => Promise<unknown>>(
     const cfg = sdk.config;
     const parent = getCurrentSpan() ?? null;
     const s = Span.create(spanName, spanType, parent);
+    s.session_id = resolveSessionId(options.sessionId, parent);
 
     if (cfg.captureInputs) {
       // Match Python SDK: capture as { args: [...] }
@@ -65,6 +80,7 @@ export function span(name: string, options: { type?: string } = {}): SpanHandle 
   const sdk = getSDK();
   const parent = getCurrentSpan() ?? null;
   const s = Span.create(name, options.type ?? 'custom', parent);
+  s.session_id = resolveSessionId(undefined, parent);
   let ended = false;
 
   return {
@@ -101,6 +117,7 @@ export async function withSpan<T>(
   const sdk = getSDK();
   const parent = getCurrentSpan() ?? null;
   const s = Span.create(name, options.type ?? 'custom', parent);
+  s.session_id = resolveSessionId(undefined, parent);
 
   return spanStorage.run(s, async () => {
     try {

--- a/packages/sdk-typescript/tests/session.test.ts
+++ b/packages/sdk-typescript/tests/session.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { session, Session, withSession } from '../src/session.js';
+import { trace } from '../src/trace.js';
+import { getCurrentSession } from '../src/context.js';
+import { setSDK } from '../src/sdk.js';
+import { CapturingExporter, makeTestSDK } from './helpers.js';
+
+// ---------- Session class basics ----------
+
+describe('Session', () => {
+  it('uses explicit id when provided', () => {
+    const s = new Session({ id: 'user-123-conv-456' });
+    expect(s.id).toBe('user-123-conv-456');
+  });
+
+  it('builds a slug-prefixed id from a name', () => {
+    const s = new Session({ name: 'Booking Flow!' });
+    expect(s.id.startsWith('booking-flow-')).toBe(true);
+    expect(s.id.length).toBe('booking-flow-'.length + 8);
+  });
+
+  it('falls back to a fresh UUID when nothing provided', () => {
+    const s = new Session();
+    // UUID v4: 36 chars, four hyphens
+    expect(s.id).toHaveLength(36);
+    expect(s.id.split('-')).toHaveLength(5);
+  });
+
+  it('explicit id wins over name', () => {
+    const s = new Session({ id: 'explicit', name: 'ignored' });
+    expect(s.id).toBe('explicit');
+  });
+});
+
+// ---------- Propagation through trace() ----------
+
+describe('session propagation', () => {
+  let exporter: CapturingExporter;
+  let sdk: ReturnType<typeof makeTestSDK>['sdk'];
+
+  beforeEach(() => {
+    ({ sdk, exporter } = makeTestSDK());
+  });
+
+  afterEach(async () => {
+    await sdk.shutdown();
+    setSDK(null);
+  });
+
+  it('session.run installs session_id on traced spans inside', async () => {
+    const myAgent = trace(async (q: unknown) => `answer: ${q}`, { name: 'agent' });
+    const s = session({ id: 'user-1-conv-1' });
+
+    await s.run(async () => {
+      await myAgent('hello');
+      await myAgent('again');
+    });
+    await sdk.flush();
+
+    expect(exporter.spans).toHaveLength(2);
+    for (const span of exporter.spans) {
+      expect(span.session_id).toBe('user-1-conv-1');
+    }
+  });
+
+  it('nested traced functions inherit session id from parent', async () => {
+    const child = trace(async () => 'c', { name: 'child' });
+    const parent = trace(async () => child(), { name: 'parent' });
+
+    await session({ id: 'nested-test' }).run(async () => {
+      await parent();
+    });
+    await sdk.flush();
+
+    const byName = Object.fromEntries(exporter.spans.map((s) => [s.name, s]));
+    expect(byName['parent'].session_id).toBe('nested-test');
+    expect(byName['child'].session_id).toBe('nested-test');
+  });
+
+  it('outside session.run, session_id is null', async () => {
+    const fn = trace(async () => 1, { name: 'standalone' });
+    await fn();
+    await sdk.flush();
+    expect(exporter.spans[0].session_id).toBeNull();
+  });
+
+  it('explicit sessionId on trace() overrides session.run context', async () => {
+    const fn = trace(async () => 1, {
+      name: 'pinned',
+      sessionId: 'from-decorator',
+    });
+
+    await session({ id: 'from-context' }).run(async () => {
+      await fn();
+    });
+    await sdk.flush();
+
+    expect(exporter.spans[0].session_id).toBe('from-decorator');
+  });
+
+  it('explicit sessionId works outside any session.run', async () => {
+    const fn = trace(async () => 1, {
+      name: 'pinned',
+      sessionId: 'explicit-only',
+    });
+    await fn();
+    await sdk.flush();
+    expect(exporter.spans[0].session_id).toBe('explicit-only');
+  });
+
+  it('getCurrentSession returns the active session inside run()', async () => {
+    expect(getCurrentSession()).toBeUndefined();
+
+    const s = session({ id: 'check' });
+    let inside: Session | undefined;
+    await s.run(async () => {
+      inside = getCurrentSession();
+    });
+
+    expect(inside).toBe(s);
+    expect(getCurrentSession()).toBeUndefined();
+  });
+
+  it('withSession is a one-line shortcut', async () => {
+    const fn = trace(async () => 1, { name: 'in-with-session' });
+    await withSession({ id: 'short' }, async () => {
+      await fn();
+    });
+    await sdk.flush();
+    expect(exporter.spans[0].session_id).toBe('short');
+  });
+
+  it('nested sessions: inner wins inside, outer restored after', async () => {
+    const fn = trace(async () => 1, { name: 'nest' });
+
+    await session({ id: 'outer' }).run(async () => {
+      await fn(); // outer
+      await session({ id: 'inner' }).run(async () => {
+        await fn(); // inner
+      });
+      await fn(); // outer again
+    });
+    await sdk.flush();
+
+    const sessions = exporter.spans.map((s) => s.session_id);
+    expect(sessions).toEqual(['outer', 'inner', 'outer']);
+  });
+
+  it('toJSON includes session_id', async () => {
+    const fn = trace(async () => 1, { name: 'shape-check' });
+    await withSession({ id: 'in-json' }, async () => {
+      await fn();
+    });
+    await sdk.flush();
+    const dict = exporter.spans[0].toJSON();
+    expect(dict).toHaveProperty('session_id', 'in-json');
+  });
+
+  it('toJSON has session_id null when no session', async () => {
+    const fn = trace(async () => 1, { name: 'no-session' });
+    await fn();
+    await sdk.flush();
+    expect(exporter.spans[0].toJSON()).toHaveProperty('session_id', null);
+  });
+
+  it('concurrent tasks under one session all share the id', async () => {
+    const fn = trace(async (n: unknown) => n, { name: 'task' });
+    await withSession({ id: 'concurrent' }, async () => {
+      await Promise.all([fn('a'), fn('b'), fn('c')]);
+    });
+    await sdk.flush();
+    expect(exporter.spans).toHaveLength(3);
+    for (const s of exporter.spans) {
+      expect(s.session_id).toBe('concurrent');
+    }
+  });
+});


### PR DESCRIPTION
Closes #3.

## Summary

Group related traces into sessions so multi-turn conversations show up as a coherent unit in the dashboard, with aggregate metrics, instead of unrelated rows in the trace list.

```python
import synaptic

with synaptic.session(name="booking-conversation"):
    my_agent("Book me a flight to Tokyo")
    my_agent("Make it business class")
    my_agent("Add hotel for 3 nights")

# /sessions/booking-conversation-{8hex}  →  3 turns, total cost, avg quality, click-to-expand turn
```

## Live verification

```
=== running 3 turns under one session ===
session.id = 'booking-conversation-615f5a8d'
answer to Book me a flight to Tokyo
answer to Make it business class
answer to Add hotel for 3 nights

=== GET /v1/sessions ===
  1 session(s):
    booking-conversation-615f5a8d   turns=3 wall=165ms cost=$0.0

=== GET /v1/sessions/{id} ===
  3 traces in chronological order:
    Turn 1: my_agent — 55ms — 'Book me a flight to Tokyo'
    Turn 2: my_agent — 55ms — 'Make it business class'
    Turn 3: my_agent — 55ms — 'Add hotel for 3 nights'
```

Plus a TypeScript-SDK live test posting `withSession({ name: 'TS conversation' }, ...)` to the same container — landed as `ts-conversation-{8hex}` with 3 turns, proving cross-language session propagation.

## What changed

### Backend (`packages/api/`)
- `SpanInput` accepts optional `session_id`
- Trace upsert propagates `session_id` (root path, and onto orphan stubs with `COALESCE` to avoid blanking an existing value)
- `routers/sessions.py`: `GET /v1/sessions` (list + aggregations) and `GET /v1/sessions/{id}` (summary + traces)
- **No new database tables.** Aggregations come from `GROUP BY session_id` on the existing `traces` table — `session_id` was already in the v1 schema

### Python SDK
- `synaptic.session(id=None, name=None)` — context manager (sync + async)
- `session_id` resolution chain (most specific wins): `@synaptic.trace(session_id=…)` > `synaptic.session()` context > parent span's `session_id` > `None`
- `synaptic.get_current_session()`
- `Span` gets an optional `session_id` field — default `None`, **fully backward compatible**

### TypeScript SDK
- Peer API: `new Session({ id, name })`, `session()`, `withSession()`, `getCurrentSession()`
- AsyncLocalStorage propagation matching Python's `contextvars`
- `trace(fn, { sessionId })` explicit override matches the Python decorator
- Same wire format — `session_id` on `toJSON`

### Dashboard
- `/sessions` list page (paginated, WS-aware live indicator + polling fallback — mirrors `/traces` UX)
- `/sessions/[id]` conversation timeline: turns numbered 1..N, click any turn to lazily fetch and expand its span tree
- Sessions link in header nav
- WS subscription on the session list refetches on `new_trace` events that carry a `session_id`

## Tests

| Layer | Before | After |
|---|---|---|
| FastAPI | 37 | **46** (+9 sessions) |
| Python SDK | 56 | **72** (+16 sessions) |
| TypeScript SDK | 31 | **46** (+15 sessions) |
| Playwright E2E | 7 | **13** (+6 sessions) |
| **Total automated** | **131** | **177 + 13 E2E = 190** |

Plus two cross-language live e2e scripts run against the live Docker container.

## Constraints honored

- ✅ No new database tables — derived from `traces.session_id`
- ✅ `session_id` is optional — traces without one stay listed in `/traces`, don't appear under any session
- ✅ No breaking SDK changes — `Span` field is additive with `None` default
- ✅ Single Docker container as before — no new services