### PR TITLE
feat: Claude extended-thinking visualization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: packages/sdk-python/pyproject.toml
-      - name: Install (with langchain extra for integration tests)
+      - name: Install (with langchain + anthropic extras for integration tests)
         run: |
-          pip install -e ".[test,langchain]"
+          pip install -e ".[test,langchain,anthropic]"
       - name: Run tests
         run: pytest -v
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - LangChain integration
 - CrewAI integration
 - TypeScript SDK
+- Anthropic integration with extended-thinking visualization — `instrument_anthropic()` wraps `Messages.create` (and the streaming `Messages.stream` context manager) and emits a `claude_call` parent span with `thinking` and `response` children. Available in both the Python SDK (`synaptic.integrations.anthropic`) and the TypeScript SDK (`@synaptic/sdk/integrations/anthropic`) with identical wire format. Dashboard renders thinking rows with a brain emoji, violet highlight, and per-trace thinking-vs-response cost breakdown. New `span_subtype` and `thinking_tokens` columns on the spans table (auto-migrated for legacy DBs)
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,12 @@ COPY packages/api/requirements.txt /tmp/api-requirements.txt
 RUN pip install --no-cache-dir -r /tmp/api-requirements.txt
 
 # Install the SDK (so users can `pip install` on top and `import synaptic`
-# from inside the container if they want to run agents alongside)
+# from inside the container if they want to run agents alongside).
+# Include the `anthropic` extra so the Anthropic integration is importable
+# out of the box — the langchain/crewai integrations stay opt-in via
+# their own pip installs to keep the image small.
 COPY packages/sdk-python/ /app/sdk-python/
-RUN pip install --no-cache-dir /app/sdk-python/
+RUN pip install --no-cache-dir "/app/sdk-python/[anthropic]"
 
 # API source
 COPY packages/api/ /app/api/

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ That's it. No account, no API key, no data leaves your laptop.
 - **Real-time updates** — WebSocket stream pushes traces and spans into the dashboard the moment they're ingested, no refresh; falls back to 5-second polling if the socket can't connect
 - **Cost & token tracking** — automatic per-call breakdown for OpenAI and Anthropic model families
 - **Quality scoring** — bring-your-own evals via `POST /v1/evals`
-- **Framework integrations** — drop-in support for [LangChain](#langchain) (zero-config via `SYNAPTIC_TRACING=true`) and [CrewAI](#crewai) (one-line `instrument_crew()`)
+- **Framework integrations** — drop-in support for [LangChain](#langchain) (zero-config via `SYNAPTIC_TRACING=true`), [CrewAI](#crewai) (one-line `instrument_crew()`), and [Anthropic](#anthropic) (`instrument_anthropic()` — captures Claude extended-thinking blocks as first-class child spans)
 - **Cross-language SDKs** — Python and TypeScript with identical wire format and behavior
 - **Resilient by design** — the agent never fails because Synaptic is down. Spans drop silently if the queue overflows, the exporter is unreachable, or the server returns an error
 - **Local-first** — single Docker image, DuckDB + SQLite, no external services, no cloud dependency
@@ -103,10 +103,10 @@ Single Docker container runs the API on `:8000` and the Next.js standalone dashb
 
 | Path | Package | Tests |
 |---|---|---|
-| [`packages/sdk-python/`](packages/sdk-python/) | Python SDK with `@synaptic.trace`, `synaptic.span()`, `synaptic.session()`, integrations | 72 |
-| [`packages/sdk-typescript/`](packages/sdk-typescript/) | `@synaptic/sdk` — peer of the Python SDK | 46 |
-| [`packages/api/`](packages/api/) | FastAPI ingest + query API, DuckDB storage, WebSocket fanout, session aggregations | 46 |
-| [`packages/dashboard/`](packages/dashboard/) | Next.js 14 dashboard with paginated timeline + session view | build + 13 Playwright E2E |
+| [`packages/sdk-python/`](packages/sdk-python/) | Python SDK with `@synaptic.trace`, `synaptic.span()`, `synaptic.session()`, integrations | 101 |
+| [`packages/sdk-typescript/`](packages/sdk-typescript/) | `@synaptic/sdk` — peer of the Python SDK | 59 |
+| [`packages/api/`](packages/api/) | FastAPI ingest + query API, DuckDB storage, WebSocket fanout, session aggregations | 59 |
+| [`packages/dashboard/`](packages/dashboard/) | Next.js 14 dashboard with paginated timeline + session view | build + 21 Playwright E2E |
 
 ---
 
@@ -118,7 +118,8 @@ Single Docker container runs the API on `:8000` and the Next.js standalone dashb
 pip install -e packages/sdk-python              # core only
 pip install -e packages/sdk-python[langchain]   # + LangChain integration
 pip install -e packages/sdk-python[crewai]      # + CrewAI integration
-pip install -e packages/sdk-python[all]         # both integrations
+pip install -e packages/sdk-python[anthropic]   # + Anthropic integration
+pip install -e packages/sdk-python[all]         # all integrations
 ```
 
 ### TypeScript SDK
@@ -209,6 +210,27 @@ crew.kickoff()
 # crew.kickoff -> root span
 # each agent.execute_task -> child span
 # LLM calls inside agents -> grandchildren (via the LangChain integration)
+```
+
+### Anthropic
+
+```python
+from synaptic.integrations.anthropic import instrument_anthropic
+instrument_anthropic()
+
+from anthropic import Anthropic
+client = Anthropic()
+client.messages.create(
+    model="claude-opus-4-20250514",
+    max_tokens=16000,
+    thinking={"type": "enabled", "budget_tokens": 10000},
+    messages=[{"role": "user", "content": "..."}],
+)
+# claude_call -> parent (model, tokens, cost)
+#   thinking -> child (reasoning text, ~thinking tokens, output-rate cost)
+#   response -> child (final text, response tokens, cost)
+# Dashboard renders thinking rows with a brain emoji + per-trace
+# thinking-vs-response cost breakdown.
 ```
 
 ### Sessions (multi-turn conversations)

--- a/packages/api/db.py
+++ b/packages/api/db.py
@@ -44,7 +44,9 @@ CREATE TABLE IF NOT EXISTS spans (
     status VARCHAR DEFAULT 'ok',
     error_message VARCHAR,
     tool_name VARCHAR,
-    metadata JSON
+    metadata JSON,
+    span_subtype VARCHAR,
+    thinking_tokens INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS evals (
@@ -81,6 +83,18 @@ class Database:
                 stmt = stmt.strip()
                 if stmt:
                     self._duck.execute(stmt)
+            # Migrations for databases created before columns were added.
+            # IF NOT EXISTS on ALTER COLUMN is supported in DuckDB >= 0.10
+            # but we still wrap each ALTER in try/except as defense in
+            # depth — the SDK must never fail because of schema fiddling.
+            for migration in (
+                "ALTER TABLE spans ADD COLUMN IF NOT EXISTS span_subtype VARCHAR",
+                "ALTER TABLE spans ADD COLUMN IF NOT EXISTS thinking_tokens INTEGER",
+            ):
+                try:
+                    self._duck.execute(migration)
+                except Exception:
+                    pass
 
     def execute(self, query: str, params: Sequence[Any] = ()) -> None:
         with self._lock:

--- a/packages/api/models.py
+++ b/packages/api/models.py
@@ -34,6 +34,12 @@ class SpanInput(BaseModel):
     metadata: Optional[dict] = None
     # Session grouping — propagates to the trace row when a root span lands
     session_id: Optional[str] = None
+    # Claude extended-thinking support: span_subtype is "thinking" |
+    # "response" | null. thinking_tokens estimates tokens spent in the
+    # thinking phase (output_tokens in Anthropic usage rolls up everything,
+    # so we estimate from content length).
+    span_subtype: Optional[str] = None
+    thinking_tokens: Optional[int] = None
 
 
 class IngestRequest(BaseModel):
@@ -98,6 +104,8 @@ class Span(BaseModel):
     error_message: Optional[str] = None
     tool_name: Optional[str] = None
     metadata: Optional[Any] = None
+    span_subtype: Optional[str] = None
+    thinking_tokens: Optional[int] = None
 
 
 class Session(BaseModel):

--- a/packages/api/routers/spans.py
+++ b/packages/api/routers/spans.py
@@ -56,8 +56,9 @@ def _insert_span(db: Database, span: SpanInput) -> None:
         INSERT INTO spans (
             id, trace_id, parent_span_id, type, name, input, output,
             model, provider, tokens_input, tokens_output, cost_usd,
-            started_at, ended_at, status, error_message, tool_name, metadata
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            started_at, ended_at, status, error_message, tool_name, metadata,
+            span_subtype, thinking_tokens
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT (id) DO UPDATE SET
             trace_id = EXCLUDED.trace_id,
             parent_span_id = EXCLUDED.parent_span_id,
@@ -75,7 +76,9 @@ def _insert_span(db: Database, span: SpanInput) -> None:
             status = EXCLUDED.status,
             error_message = EXCLUDED.error_message,
             tool_name = EXCLUDED.tool_name,
-            metadata = EXCLUDED.metadata
+            metadata = EXCLUDED.metadata,
+            span_subtype = EXCLUDED.span_subtype,
+            thinking_tokens = EXCLUDED.thinking_tokens
         """,
         [
             span.id,
@@ -96,6 +99,8 @@ def _insert_span(db: Database, span: SpanInput) -> None:
             error_message,
             span.tool_name,
             metadata_str,
+            span.span_subtype,
+            span.thinking_tokens,
         ],
     )
 

--- a/packages/api/routers/traces.py
+++ b/packages/api/routers/traces.py
@@ -98,6 +98,8 @@ def _row_to_span(row: dict) -> Span:
         error_message=row.get("error_message"),
         tool_name=row.get("tool_name"),
         metadata=metadata,
+        span_subtype=row.get("span_subtype"),
+        thinking_tokens=row.get("thinking_tokens"),
     )
 
 

--- a/packages/api/tests/test_thinking_spans.py
+++ b/packages/api/tests/test_thinking_spans.py
@@ -1,0 +1,104 @@
+"""Tests for the new span_subtype + thinking_tokens columns."""
+
+
+def test_span_subtype_and_thinking_tokens_round_trip(client):
+    """A span posted with the new fields must come back with them
+    intact via GET /v1/traces/{id}/spans."""
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "root-1", "trace_id": "t-thinking",
+                    "name": "claude_call", "type": "llm",
+                    "started_at": "2026-05-03T10:00:00Z",
+                    "ended_at": "2026-05-03T10:00:03Z",
+                    "model": "claude-opus-4-20250514",
+                    "tokens_input": 50,
+                    "tokens_output": 8500,
+                    "thinking_tokens": 8000,
+                },
+                {
+                    "id": "thinking-1", "trace_id": "t-thinking",
+                    "parent_span_id": "root-1",
+                    "name": "thinking", "type": "llm",
+                    "started_at": "2026-05-03T10:00:00.1Z",
+                    "ended_at": "2026-05-03T10:00:02.5Z",
+                    "model": "claude-opus-4-20250514",
+                    "thinking_tokens": 8000,
+                    "span_subtype": "thinking",
+                    "input": "let me think...",
+                },
+                {
+                    "id": "response-1", "trace_id": "t-thinking",
+                    "parent_span_id": "root-1",
+                    "name": "response", "type": "llm",
+                    "started_at": "2026-05-03T10:00:02.5Z",
+                    "ended_at": "2026-05-03T10:00:03Z",
+                    "span_subtype": "response",
+                    "output": "the answer is 4",
+                    "tokens_output": 500,
+                },
+            ]
+        },
+    )
+
+    spans = client.get("/v1/traces/t-thinking/spans").json()
+    by_name = {s["name"]: s for s in spans}
+
+    assert by_name["thinking"]["span_subtype"] == "thinking"
+    assert by_name["thinking"]["thinking_tokens"] == 8000
+    assert "let me think" in by_name["thinking"]["input"]
+
+    assert by_name["response"]["span_subtype"] == "response"
+    assert by_name["response"]["thinking_tokens"] is None
+
+    # Parent (claude_call) carries an aggregate thinking_tokens count
+    assert by_name["claude_call"]["thinking_tokens"] == 8000
+
+
+def test_existing_spans_default_to_null_subtype_and_thinking(client):
+    """Span ingestion without the new fields must still succeed and
+    return null for the new columns."""
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "plain-1", "trace_id": "plain-1",
+                    "name": "ordinary_call",
+                    "started_at": "2026-05-03T10:00:00Z",
+                    "ended_at": "2026-05-03T10:00:01Z",
+                }
+            ]
+        },
+    )
+    spans = client.get("/v1/traces/plain-1/spans").json()
+    assert spans[0]["span_subtype"] is None
+    assert spans[0]["thinking_tokens"] is None
+
+
+def test_thinking_subtype_doesnt_affect_existing_aggregations(client):
+    """The /v1/sessions aggregations should still work normally even
+    when the spans table includes thinking_tokens / span_subtype."""
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "agg-1", "trace_id": "agg-1",
+                    "name": "with_thinking",
+                    "started_at": "2026-05-03T10:00:00Z",
+                    "ended_at": "2026-05-03T10:00:02Z",
+                    "session_id": "sess-thinking",
+                    "tokens_input": 10, "tokens_output": 5000,
+                    "thinking_tokens": 4500,
+                    "total_cost_usd": 0.05,
+                }
+            ]
+        },
+    )
+    sessions = client.get("/v1/sessions").json()
+    by_id = {s["session_id"]: s for s in sessions}
+    assert "sess-thinking" in by_id
+    assert by_id["sess-thinking"]["trace_count"] == 1

--- a/packages/api/tests/test_thinking_torture.py
+++ b/packages/api/tests/test_thinking_torture.py
@@ -1,0 +1,304 @@
+"""API torture tests for thinking-block fields. Goal: try the ugliest
+inputs we can think of and confirm round-trip and aggregation hold up."""
+
+import concurrent.futures
+import json
+
+import duckdb
+import pytest
+
+from db import Database
+from main import app
+
+
+# ---------- 1. Migration: open a DB created BEFORE the new columns existed ----------
+
+
+def test_migration_adds_columns_to_legacy_db(tmp_path):
+    """A DB created with an older Synaptic (no span_subtype, no
+    thinking_tokens) must be migrated cleanly when the new code opens
+    it. ALTER TABLE ... IF NOT EXISTS handles this."""
+    duck_path = str(tmp_path / "legacy.duckdb")
+
+    # Hand-craft an old-style spans table — exact subset of columns
+    # that v0.1.0 had before this PR.
+    legacy_conn = duckdb.connect(duck_path)
+    legacy_conn.execute("""
+        CREATE TABLE traces (
+            id VARCHAR PRIMARY KEY, name VARCHAR,
+            input TEXT, output TEXT,
+            started_at TIMESTAMP NOT NULL,
+            ended_at TIMESTAMP,
+            total_tokens INTEGER DEFAULT 0,
+            total_cost_usd DECIMAL(12,8) DEFAULT 0,
+            quality_score FLOAT, user_id VARCHAR DEFAULT '',
+            session_id VARCHAR, tags VARCHAR[], metadata JSON,
+            ingest_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE spans (
+            id VARCHAR PRIMARY KEY, trace_id VARCHAR NOT NULL,
+            parent_span_id VARCHAR, type VARCHAR, name VARCHAR,
+            input TEXT, output TEXT, model VARCHAR, provider VARCHAR,
+            tokens_input INTEGER, tokens_output INTEGER,
+            cost_usd DECIMAL(12,8),
+            started_at TIMESTAMP NOT NULL, ended_at TIMESTAMP,
+            status VARCHAR DEFAULT 'ok', error_message VARCHAR,
+            tool_name VARCHAR, metadata JSON
+        );
+        CREATE TABLE evals (
+            id VARCHAR DEFAULT gen_random_uuid() PRIMARY KEY,
+            trace_id VARCHAR NOT NULL, span_id VARCHAR, name VARCHAR,
+            score FLOAT, label VARCHAR, comment TEXT, source VARCHAR,
+            model VARCHAR, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+    """)
+    # Insert one legacy span (no new columns) to make sure migration
+    # preserves existing data.
+    legacy_conn.execute(
+        "INSERT INTO traces VALUES (?, 'legacy', null, null, '2026-01-01', '2026-01-01', 0, 0, null, '', null, null, null, '2026-01-01')",
+        ("legacy-trace-1",),
+    )
+    legacy_conn.execute(
+        "INSERT INTO spans (id, trace_id, name, type, started_at) VALUES (?, ?, 'old_call', 'llm', '2026-01-01')",
+        ("legacy-span-1", "legacy-trace-1"),
+    )
+    legacy_conn.close()
+
+    # Now open with the NEW Database class — should ALTER TABLE migrate
+    db = Database(duckdb_path=duck_path, sqlite_path=str(tmp_path / "meta.sqlite"))
+    cols = [r[1] for r in db.fetchall("PRAGMA table_info(spans)")]
+    assert "span_subtype" in cols, f"span_subtype missing after migration: {cols}"
+    assert "thinking_tokens" in cols, f"thinking_tokens missing after migration: {cols}"
+
+    # Legacy data preserved
+    legacy_row = db.fetchone_dict("SELECT * FROM spans WHERE id = 'legacy-span-1'")
+    assert legacy_row is not None
+    assert legacy_row["name"] == "old_call"
+    assert legacy_row["span_subtype"] is None
+    assert legacy_row["thinking_tokens"] is None
+
+    # Insert new-style data into the migrated table
+    db.execute(
+        "INSERT INTO spans (id, trace_id, name, type, started_at, span_subtype, thinking_tokens) "
+        "VALUES (?, ?, 'thinking', 'llm', '2026-05-01', 'thinking', 1234)",
+        ("new-span-1", "legacy-trace-1"),
+    )
+    new_row = db.fetchone_dict("SELECT * FROM spans WHERE id = 'new-span-1'")
+    assert new_row["span_subtype"] == "thinking"
+    assert new_row["thinking_tokens"] == 1234
+    db.close()
+
+
+def test_double_migration_is_idempotent(tmp_path):
+    """Running the schema init twice (e.g. fresh DB then reopen)
+    must not error — ALTER TABLE … IF NOT EXISTS must be safe."""
+    duck_path = str(tmp_path / "x.duckdb")
+    sqlite_path = str(tmp_path / "x.sqlite")
+    db1 = Database(duckdb_path=duck_path, sqlite_path=sqlite_path)
+    db1.close()
+    db2 = Database(duckdb_path=duck_path, sqlite_path=sqlite_path)
+    db2.close()
+    db3 = Database(duckdb_path=duck_path, sqlite_path=sqlite_path)
+    db3.close()
+    # No exceptions = pass
+
+
+# ---------- 2. Concurrent ingest of thinking spans ----------
+
+
+def test_fifty_concurrent_thinking_traces_all_round_trip(client):
+    """50 client threads each posting a (parent + thinking + response)
+    bundle simultaneously. All must end up queryable with correct
+    span_subtype + thinking_tokens."""
+    def post_one(i: int) -> int:
+        spans = [
+            {
+                "id": f"p-{i}", "trace_id": f"t-{i}",
+                "name": "claude_call", "type": "llm",
+                "started_at": "2026-05-03T10:00:00Z",
+                "ended_at":   "2026-05-03T10:00:03Z",
+                "thinking_tokens": 1000 + i,
+            },
+            {
+                "id": f"th-{i}", "trace_id": f"t-{i}", "parent_span_id": f"p-{i}",
+                "name": "thinking", "type": "llm",
+                "started_at": "2026-05-03T10:00:00.1Z",
+                "ended_at":   "2026-05-03T10:00:02.5Z",
+                "span_subtype": "thinking", "thinking_tokens": 1000 + i,
+                "input": json.dumps({"thinking": f"thread {i}"}),
+            },
+            {
+                "id": f"r-{i}", "trace_id": f"t-{i}", "parent_span_id": f"p-{i}",
+                "name": "response", "type": "llm",
+                "started_at": "2026-05-03T10:00:02.5Z",
+                "ended_at":   "2026-05-03T10:00:03Z",
+                "span_subtype": "response", "tokens_output": 100 + i,
+            },
+        ]
+        r = client.post("/v1/spans", json={"spans": spans})
+        return r.status_code
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=20) as ex:
+        codes = list(ex.map(post_one, range(50)))
+    assert all(c == 200 for c in codes), f"some POSTs failed: {codes}"
+
+    # Verify every trace has its three spans with correct subtypes
+    for i in range(50):
+        spans = client.get(f"/v1/traces/t-{i}/spans").json()
+        by_name = {s["name"]: s for s in spans}
+        assert "claude_call" in by_name, f"trace {i} missing parent"
+        assert by_name["thinking"]["span_subtype"] == "thinking"
+        assert by_name["thinking"]["thinking_tokens"] == 1000 + i
+        assert by_name["response"]["span_subtype"] == "response"
+        assert by_name["response"]["tokens_output"] == 100 + i
+
+
+# ---------- 3. Pathologically large reasoning ----------
+
+
+def test_500kb_reasoning_text_accepted_and_returned(client):
+    """An agent with extreme thinking budget could produce huge text.
+    The wire format should accept it (no Content-Length limit on the
+    JSON body) and DuckDB TEXT can hold it."""
+    big = "REASONING " * 50_000  # ~500 KB
+    client.post(
+        "/v1/spans", json={"spans": [{
+            "id": "big-1", "trace_id": "big-1",
+            "name": "thinking", "type": "llm",
+            "started_at": "2026-05-03T10:00:00Z",
+            "ended_at":   "2026-05-03T10:00:01Z",
+            "span_subtype": "thinking",
+            "thinking_tokens": 125_000,
+            "input": json.dumps({"thinking": big}),
+        }]},
+    )
+    s = client.get("/v1/traces/big-1/spans").json()[0]
+    assert s["span_subtype"] == "thinking"
+    assert "REASONING " in s["input"]
+    assert s["thinking_tokens"] == 125_000
+
+
+# ---------- 4. Unicode in thinking ----------
+
+
+def test_unicode_emoji_thinking_round_trips(client):
+    weird = "推論 → なぜ 2+2=4? 🧠 ✓ こたえ: ４"
+    r = client.post(
+        "/v1/spans", json={"spans": [{
+            "id": "u-1", "trace_id": "u-1",
+            "name": "thinking", "type": "llm",
+            "started_at": "2026-05-03T10:00:00Z",
+            "ended_at":   "2026-05-03T10:00:01Z",
+            "span_subtype": "thinking",
+            "input": weird,
+        }]},
+    )
+    assert r.status_code == 200
+    s = client.get("/v1/traces/u-1/spans").json()[0]
+    assert "推論" in s["input"]
+    assert "🧠" in s["input"]
+
+
+# ---------- 5. Negative / huge / weird thinking_tokens ----------
+
+
+def test_negative_thinking_tokens_stored_as_is(client):
+    """We don't validate; trust the SDK. Server should not crash."""
+    r = client.post(
+        "/v1/spans", json={"spans": [{
+            "id": "neg-1", "trace_id": "neg-1",
+            "name": "thinking", "type": "llm",
+            "started_at": "2026-05-03T10:00:00Z",
+            "ended_at":   "2026-05-03T10:00:01Z",
+            "span_subtype": "thinking",
+            "thinking_tokens": -42,  # bogus but we don't crash
+        }]},
+    )
+    assert r.status_code == 200
+    s = client.get("/v1/traces/neg-1/spans").json()[0]
+    assert s["thinking_tokens"] == -42
+
+
+def test_huge_thinking_tokens_count(client):
+    r = client.post(
+        "/v1/spans", json={"spans": [{
+            "id": "huge-1", "trace_id": "huge-1",
+            "name": "thinking", "type": "llm",
+            "started_at": "2026-05-03T10:00:00Z",
+            "ended_at":   "2026-05-03T10:00:01Z",
+            "span_subtype": "thinking",
+            "thinking_tokens": 2_000_000_000,  # 2B — fits in INT
+        }]},
+    )
+    assert r.status_code == 200
+
+
+# ---------- 6. Idempotent re-ingest with subtype changes ----------
+
+
+def test_resubmitting_same_span_id_with_different_subtype_overwrites(client):
+    """ON CONFLICT DO UPDATE means the latest write wins for span_subtype too."""
+    base = {
+        "id": "i-1", "trace_id": "i-1",
+        "name": "claude_call", "type": "llm",
+        "started_at": "2026-05-03T10:00:00Z",
+        "ended_at":   "2026-05-03T10:00:01Z",
+    }
+    client.post("/v1/spans", json={"spans": [{**base, "span_subtype": "thinking", "thinking_tokens": 100}]})
+    client.post("/v1/spans", json={"spans": [{**base, "span_subtype": "response", "thinking_tokens": None, "tokens_output": 50}]})
+
+    s = client.get("/v1/traces/i-1/spans").json()[0]
+    assert s["span_subtype"] == "response"
+    assert s["thinking_tokens"] is None
+    assert s["tokens_output"] == 50
+
+
+# ---------- 7. Mixed thinking + tool spans in same trace ----------
+
+
+def test_thinking_and_tool_spans_coexist_in_same_trace(client):
+    """A real Claude agent does: thinking → tool_use → response. The
+    thinking variant should not interfere with non-thinking children."""
+    spans = [
+        {"id": "p", "trace_id": "mix-1", "name": "claude_call", "type": "llm",
+         "started_at": "2026-05-03T10:00:00Z", "ended_at": "2026-05-03T10:00:05Z"},
+        {"id": "th", "trace_id": "mix-1", "parent_span_id": "p",
+         "name": "thinking", "type": "llm", "span_subtype": "thinking",
+         "thinking_tokens": 1000,
+         "started_at": "2026-05-03T10:00:00.5Z", "ended_at": "2026-05-03T10:00:01Z"},
+        {"id": "tool", "trace_id": "mix-1", "parent_span_id": "p",
+         "name": "get_weather", "type": "tool", "tool_name": "get_weather",
+         "input": "{\"city\":\"SF\"}",
+         "started_at": "2026-05-03T10:00:01Z", "ended_at": "2026-05-03T10:00:02Z"},
+        {"id": "resp", "trace_id": "mix-1", "parent_span_id": "p",
+         "name": "response", "type": "llm", "span_subtype": "response",
+         "tokens_output": 200,
+         "started_at": "2026-05-03T10:00:04Z", "ended_at": "2026-05-03T10:00:05Z"},
+    ]
+    client.post("/v1/spans", json={"spans": spans})
+    by = {s["name"]: s for s in client.get("/v1/traces/mix-1/spans").json()}
+    assert by["thinking"]["span_subtype"] == "thinking"
+    assert by["get_weather"]["span_subtype"] is None  # tool span has no subtype
+    assert by["get_weather"]["tool_name"] == "get_weather"
+    assert by["response"]["span_subtype"] == "response"
+
+
+# ---------- 8. Subtype variant: future-proofing ----------
+
+
+def test_unknown_span_subtype_value_does_not_crash(client):
+    """If a future SDK invents a new subtype (say, 'tool_thinking'),
+    the API must accept it — we don't enum-validate. The dashboard
+    will fall through to default rendering."""
+    r = client.post(
+        "/v1/spans", json={"spans": [{
+            "id": "future-1", "trace_id": "future-1",
+            "name": "experimental", "type": "llm",
+            "started_at": "2026-05-03T10:00:00Z",
+            "ended_at":   "2026-05-03T10:00:01Z",
+            "span_subtype": "tool_thinking_v2",
+        }]},
+    )
+    assert r.status_code == 200
+    s = client.get("/v1/traces/future-1/spans").json()[0]
+    assert s["span_subtype"] == "tool_thinking_v2"

--- a/packages/dashboard/components/SpanRow.tsx
+++ b/packages/dashboard/components/SpanRow.tsx
@@ -20,6 +20,19 @@ function prettyJson(s: string | null): string {
   }
 }
 
+function thinkingText(input: string | null): string {
+  // Thinking spans store {"thinking": "..."} in input. Strip the
+  // wrapper so the dashboard shows the reasoning text directly.
+  if (!input) return '';
+  try {
+    const parsed = JSON.parse(input);
+    if (parsed && typeof parsed === 'object' && typeof parsed.thinking === 'string') {
+      return parsed.thinking;
+    }
+  } catch {}
+  return input;
+}
+
 export default function SpanRow({
   span,
   depth,
@@ -27,15 +40,37 @@ export default function SpanRow({
   span: Span;
   depth: number;
 }) {
+  const isThinking = span.span_subtype === 'thinking';
+  const isResponse = span.span_subtype === 'response';
+  // Thinking rows are collapsed by default (the reasoning is long;
+  // the user opts in to read it). Other rows are also collapsed by
+  // default — we keep the behavior uniform.
   const [open, setOpen] = useState(false);
   const typeClass = TYPE_COLORS[span.type ?? 'custom'] ?? TYPE_COLORS.custom;
   const isError = span.status === 'error';
 
+  const rowClass = isThinking
+    ? 'w-full text-left px-3 py-2 transition-colors flex items-center gap-3 bg-violet-950/20 hover:bg-violet-950/40 border-l-2 border-violet-700'
+    : 'w-full text-left px-3 py-2 hover:bg-[#111418] transition-colors flex items-center gap-3';
+
+  const subtypeBadge = isThinking ? (
+    <span
+      className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 border rounded text-violet-200 border-violet-600 bg-violet-900/40"
+      data-testid="thinking-badge"
+    >
+      thinking
+    </span>
+  ) : isResponse ? (
+    <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 border rounded text-emerald-200 border-emerald-700 bg-emerald-900/30">
+      response
+    </span>
+  ) : null;
+
   return (
-    <div>
+    <div data-span-subtype={span.span_subtype ?? 'none'}>
       <button
         onClick={() => setOpen(!open)}
-        className="w-full text-left px-3 py-2 hover:bg-[#111418] transition-colors flex items-center gap-3"
+        className={rowClass}
         aria-expanded={open}
       >
         <span
@@ -43,11 +78,12 @@ export default function SpanRow({
           className="text-[var(--muted)] font-mono select-none"
           style={{ paddingLeft: `${depth * 20}px` }}
         >
-          {depth === 0 ? '●' : '└─'}
+          {isThinking ? '🧠' : depth === 0 ? '●' : '└─'}
         </span>
         <span className="font-mono truncate flex-1">
           {span.name ?? '(unnamed)'}
         </span>
+        {subtypeBadge}
         <span
           className={`text-[10px] uppercase tracking-wider px-1.5 py-0.5 border rounded ${typeClass}`}
         >
@@ -58,10 +94,19 @@ export default function SpanRow({
             {span.model}
           </span>
         )}
-        {span.tokens_input != null && (
-          <span className="text-xs text-[var(--muted)] font-mono">
-            {span.tokens_input}/{span.tokens_output ?? 0} tok
+        {isThinking && span.thinking_tokens != null ? (
+          <span
+            className="text-xs text-violet-300 font-mono"
+            data-testid="thinking-tokens"
+          >
+            ~{span.thinking_tokens} thinking tok
           </span>
+        ) : (
+          (span.tokens_input != null || span.tokens_output != null) && (
+            <span className="text-xs text-[var(--muted)] font-mono">
+              {span.tokens_input ?? 0}/{span.tokens_output ?? 0} tok
+            </span>
+          )
         )}
         {span.cost_usd != null && (
           <span className="text-xs text-[var(--muted)] font-mono">
@@ -78,9 +123,25 @@ export default function SpanRow({
         )}
       </button>
       {open && (
-        <div className="px-4 pb-3 pt-1 bg-[#0d1014] text-xs space-y-3">
-          <Field label="Input" value={prettyJson(span.input)} />
-          <Field label="Output" value={prettyJson(span.output)} />
+        <div
+          className={`px-4 pb-3 pt-1 text-xs space-y-3 ${
+            isThinking ? 'bg-violet-950/10 border-l-2 border-violet-800/40' : 'bg-[#0d1014]'
+          }`}
+        >
+          {isThinking ? (
+            <Field
+              label="Reasoning"
+              value={thinkingText(span.input) || '(empty)'}
+              accent="thinking"
+            />
+          ) : (
+            span.input != null && span.input !== '' && (
+              <Field label="Input" value={prettyJson(span.input)} />
+            )
+          )}
+          {!isThinking && span.output != null && span.output !== '' && (
+            <Field label="Output" value={prettyJson(span.output)} />
+          )}
           {span.error_message && (
             <Field label="Error" value={span.error_message} error />
           )}
@@ -94,24 +155,30 @@ function Field({
   label,
   value,
   error = false,
+  accent,
 }: {
   label: string;
   value: string;
   error?: boolean;
+  accent?: 'thinking';
 }) {
+  const labelClass = error
+    ? 'text-red-400'
+    : accent === 'thinking'
+      ? 'text-violet-300'
+      : 'text-[var(--muted)]';
+  const preClass = error
+    ? 'text-red-300'
+    : accent === 'thinking'
+      ? 'text-violet-100 border-violet-800/60 bg-violet-950/20'
+      : '';
   return (
     <div>
-      <div
-        className={`text-[10px] uppercase tracking-wider mb-1 ${
-          error ? 'text-red-400' : 'text-[var(--muted)]'
-        }`}
-      >
+      <div className={`text-[10px] uppercase tracking-wider mb-1 ${labelClass}`}>
         {label}
       </div>
       <pre
-        className={`font-mono whitespace-pre-wrap break-all border border-[var(--border)] rounded p-2 ${
-          error ? 'text-red-300' : ''
-        }`}
+        className={`font-mono whitespace-pre-wrap break-all border border-[var(--border)] rounded p-2 ${preClass}`}
       >
         {value}
       </pre>

--- a/packages/dashboard/components/TraceDetail.tsx
+++ b/packages/dashboard/components/TraceDetail.tsx
@@ -128,6 +128,7 @@ export default function TraceDetail({ id }: { id: string }) {
           <Metric label="Total cost" value={formatCost(trace.total_cost_usd)} />
           <Metric label="Quality" value={formatScore(trace.quality_score)} />
         </div>
+        <ThinkingBreakdown spans={spans} />
       </header>
 
       <section>
@@ -153,6 +154,47 @@ function Metric({ label, value }: { label: string; value: string }) {
         {label}
       </div>
       <div className="font-mono">{value}</div>
+    </div>
+  );
+}
+
+function ThinkingBreakdown({ spans }: { spans: Span[] }) {
+  let thinkingTokens = 0;
+  let responseTokens = 0;
+  let thinkingCost = 0;
+  let responseCost = 0;
+  for (const s of spans) {
+    if (s.span_subtype === 'thinking') {
+      thinkingTokens += s.thinking_tokens ?? 0;
+      thinkingCost += s.cost_usd ?? 0;
+    } else if (s.span_subtype === 'response') {
+      responseTokens += s.tokens_output ?? 0;
+      responseCost += s.cost_usd ?? 0;
+    }
+  }
+  if (thinkingTokens === 0 && responseTokens === 0) return null;
+
+  return (
+    <div
+      className="mt-4 pt-3 border-t border-[var(--border)] grid grid-cols-2 md:grid-cols-4 gap-4 text-sm"
+      data-testid="thinking-breakdown"
+    >
+      <Metric
+        label="Thinking tokens"
+        value={thinkingTokens > 0 ? `~${thinkingTokens.toLocaleString()}` : '—'}
+      />
+      <Metric
+        label="Thinking cost"
+        value={thinkingCost > 0 ? formatCost(thinkingCost) : '—'}
+      />
+      <Metric
+        label="Response tokens"
+        value={responseTokens > 0 ? responseTokens.toLocaleString() : '—'}
+      />
+      <Metric
+        label="Response cost"
+        value={responseCost > 0 ? formatCost(responseCost) : '—'}
+      />
     </div>
   );
 }

--- a/packages/dashboard/lib/api.ts
+++ b/packages/dashboard/lib/api.ts
@@ -57,6 +57,8 @@ export type Span = {
   error_message: string | null;
   tool_name: string | null;
   metadata: unknown;
+  span_subtype: 'thinking' | 'response' | null;
+  thinking_tokens: number | null;
 };
 
 export const fetcher = async (path: string) => {

--- a/packages/dashboard/tests/e2e/thinking.spec.ts
+++ b/packages/dashboard/tests/e2e/thinking.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Browser-level E2E tests for Claude extended-thinking visualization.
+ *
+ * Posts a trace shaped like a Claude call with a thinking block + a
+ * response block, navigates to the trace detail page, and asserts the
+ * dashboard renders the thinking row with brain emoji, badge, token
+ * estimate, and an expandable reasoning panel — plus the trace-level
+ * thinking-vs-response cost breakdown.
+ */
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8000';
+
+async function postSpans(spans: Array<Record<string, unknown>>): Promise<void> {
+  const res = await fetch(`${API_BASE}/v1/spans`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ spans }),
+  });
+  if (!res.ok) {
+    throw new Error(`POST /v1/spans failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+test('thinking span renders with brain emoji, badge, and expandable reasoning', async ({ page }) => {
+  const traceId = `e2e-thinking-${randomUUID()}`;
+  const parentId = `parent-${randomUUID()}`;
+  const thinkingId = `thinking-${randomUUID()}`;
+  const responseId = `response-${randomUUID()}`;
+  const reasoningText = 'Let me carefully reason through 2+2: combining two units...';
+
+  await postSpans([
+    {
+      id: parentId,
+      trace_id: traceId,
+      name: 'claude_call',
+      type: 'llm',
+      started_at: '2026-05-03T10:00:00Z',
+      ended_at: '2026-05-03T10:00:03Z',
+      model: 'claude-opus-4-20250514',
+      provider: 'anthropic',
+      tokens_input: 50,
+      tokens_output: 8500,
+      thinking_tokens: 8000,
+      cost_usd: 0.6385,
+    },
+    {
+      id: thinkingId,
+      trace_id: traceId,
+      parent_span_id: parentId,
+      name: 'thinking',
+      type: 'llm',
+      started_at: '2026-05-03T10:00:00.1Z',
+      ended_at: '2026-05-03T10:00:02.5Z',
+      model: 'claude-opus-4-20250514',
+      provider: 'anthropic',
+      span_subtype: 'thinking',
+      thinking_tokens: 8000,
+      cost_usd: 0.6,
+      input: JSON.stringify({ thinking: reasoningText }),
+    },
+    {
+      id: responseId,
+      trace_id: traceId,
+      parent_span_id: parentId,
+      name: 'response',
+      type: 'llm',
+      started_at: '2026-05-03T10:00:02.5Z',
+      ended_at: '2026-05-03T10:00:03Z',
+      model: 'claude-opus-4-20250514',
+      provider: 'anthropic',
+      span_subtype: 'response',
+      tokens_output: 500,
+      cost_usd: 0.0375,
+      output: JSON.stringify({ text: '2+2 equals 4.' }),
+    },
+  ]);
+
+  await page.goto(`/traces/${traceId}`);
+
+  // Span timeline shows the thinking row
+  const thinkingBadge = page.getByTestId('thinking-badge');
+  await expect(thinkingBadge).toBeVisible({ timeout: 10_000 });
+
+  // Brain emoji renders for the thinking row
+  await expect(page.getByText('🧠')).toBeVisible();
+
+  // Token count appears in violet
+  const tokens = page.getByTestId('thinking-tokens');
+  await expect(tokens).toContainText('8000');
+  await expect(tokens).toContainText('thinking tok');
+
+  // Trace-level thinking-vs-response breakdown is rendered
+  const breakdown = page.getByTestId('thinking-breakdown');
+  await expect(breakdown).toBeVisible();
+  await expect(breakdown).toContainText('Thinking tokens');
+  await expect(breakdown).toContainText('Response tokens');
+  await expect(breakdown).toContainText('8,000');
+  await expect(breakdown).toContainText('500');
+
+  // Thinking row is collapsed by default — clicking expands the
+  // reasoning panel
+  await expect(page.getByText(reasoningText)).not.toBeVisible();
+  await page.getByRole('button', { name: /thinking/i }).first().click();
+  await expect(page.getByText(reasoningText)).toBeVisible();
+});

--- a/packages/dashboard/tests/e2e/thinking_torture.spec.ts
+++ b/packages/dashboard/tests/e2e/thinking_torture.spec.ts
@@ -1,0 +1,241 @@
+/**
+ * Dashboard torture tests for thinking-block visualization.
+ *
+ * These probe edge cases that real production traffic could hit:
+ *  - Multiple thinking spans in one trace (multi-turn reasoning)
+ *  - Empty reasoning text
+ *  - Reasoning > 100KB (will it lock up the page?)
+ *  - Mixed thinking + tool + response children
+ *  - A trace with only a thinking span (no response yet, mid-stream)
+ *  - Subtype values the dashboard doesn't recognize (future-proofing)
+ */
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8000';
+
+async function postSpans(spans: Array<Record<string, unknown>>): Promise<void> {
+  const res = await fetch(`${API_BASE}/v1/spans`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ spans }),
+  });
+  if (!res.ok) {
+    throw new Error(`POST /v1/spans failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+const BASE_TIME = '2026-05-03T10:00:00Z';
+
+function nowIso(offsetMs = 0): string {
+  return new Date(Date.parse(BASE_TIME) + offsetMs).toISOString();
+}
+
+// ---------- 1. Many thinking spans in one trace ----------
+
+test('a trace with five separate thinking spans shows all of them', async ({ page }) => {
+  const traceId = `torture-multi-${randomUUID()}`;
+  const parentId = `p-${randomUUID()}`;
+  const spans: Array<Record<string, unknown>> = [
+    {
+      id: parentId, trace_id: traceId,
+      name: 'multi_turn_chain', type: 'llm',
+      started_at: nowIso(0), ended_at: nowIso(10000),
+      thinking_tokens: 5000,
+    },
+  ];
+  for (let i = 0; i < 5; i++) {
+    spans.push({
+      id: `t-${i}-${randomUUID()}`, trace_id: traceId, parent_span_id: parentId,
+      name: 'thinking', type: 'llm',
+      started_at: nowIso(i * 1000), ended_at: nowIso(i * 1000 + 500),
+      span_subtype: 'thinking',
+      thinking_tokens: 1000,
+      cost_usd: 0.075,
+      input: JSON.stringify({ thinking: `Reasoning step ${i + 1} — derive the next claim.` }),
+    });
+  }
+  await postSpans(spans);
+  await page.goto(`/traces/${traceId}`);
+
+  // All five thinking badges appear
+  await expect(page.getByTestId('thinking-badge')).toHaveCount(5, { timeout: 10_000 });
+  // Header breakdown should sum the five thinking spans (5000 tokens, $0.375)
+  const breakdown = page.getByTestId('thinking-breakdown');
+  await expect(breakdown).toContainText('5,000');
+  await expect(breakdown).toContainText('$0.3750');
+});
+
+// ---------- 2. Empty reasoning content ----------
+
+test('thinking span with empty reasoning text shows (empty) without crashing', async ({ page }) => {
+  const traceId = `torture-empty-${randomUUID()}`;
+  const parentId = `p-${randomUUID()}`;
+  await postSpans([
+    {
+      id: parentId, trace_id: traceId,
+      name: 'claude_call', type: 'llm',
+      started_at: nowIso(0), ended_at: nowIso(1000),
+    },
+    {
+      id: `t-${randomUUID()}`, trace_id: traceId, parent_span_id: parentId,
+      name: 'thinking', type: 'llm',
+      started_at: nowIso(0), ended_at: nowIso(500),
+      span_subtype: 'thinking',
+      thinking_tokens: 0,
+      input: JSON.stringify({ thinking: '' }),
+    },
+  ]);
+  await page.goto(`/traces/${traceId}`);
+  const badge = page.getByTestId('thinking-badge');
+  await expect(badge).toBeVisible({ timeout: 10_000 });
+
+  // Click to expand and verify it shows "(empty)" instead of crashing
+  await page.getByRole('button').filter({ has: badge }).click();
+  await expect(page.getByText('(empty)').first()).toBeVisible();
+});
+
+// ---------- 3. 100KB reasoning text doesn't freeze the browser ----------
+
+test('100KB reasoning text renders without hanging the page', async ({ page }) => {
+  const traceId = `torture-huge-${randomUUID()}`;
+  const huge = 'REASONING-TOKEN '.repeat(6500); // ~100KB
+  await postSpans([
+    {
+      id: `p-${randomUUID()}`, trace_id: traceId,
+      name: 'claude_call', type: 'llm',
+      started_at: nowIso(0), ended_at: nowIso(1000),
+    },
+    {
+      id: `t-${randomUUID()}`, trace_id: traceId,
+      name: 'thinking', type: 'llm',
+      started_at: nowIso(0), ended_at: nowIso(500),
+      span_subtype: 'thinking',
+      thinking_tokens: 25000,
+      input: JSON.stringify({ thinking: huge }),
+    },
+  ]);
+  const start = Date.now();
+  await page.goto(`/traces/${traceId}`);
+  await expect(page.getByTestId('thinking-badge')).toBeVisible({ timeout: 10_000 });
+  const elapsed = Date.now() - start;
+  expect(elapsed).toBeLessThan(8000); // page must hydrate within 8s
+});
+
+// ---------- 4. Mixed thinking + tool + response coexist correctly ----------
+
+test('thinking, tool, and response children all render with correct badges', async ({ page }) => {
+  const traceId = `torture-mixed-${randomUUID()}`;
+  const parent = `p-${randomUUID()}`;
+  await postSpans([
+    {
+      id: parent, trace_id: traceId,
+      name: 'agent_with_tools', type: 'llm',
+      started_at: nowIso(0), ended_at: nowIso(5000),
+    },
+    {
+      id: `t-${randomUUID()}`, trace_id: traceId, parent_span_id: parent,
+      name: 'thinking', type: 'llm',
+      started_at: nowIso(100), ended_at: nowIso(2000),
+      span_subtype: 'thinking', thinking_tokens: 800,
+      input: JSON.stringify({ thinking: 'Should I call get_weather?' }),
+    },
+    {
+      id: `tool-${randomUUID()}`, trace_id: traceId, parent_span_id: parent,
+      name: 'get_weather', type: 'tool', tool_name: 'get_weather',
+      started_at: nowIso(2000), ended_at: nowIso(2500),
+      input: '{"city":"SF"}',
+      output: '{"temp":62}',
+    },
+    {
+      id: `r-${randomUUID()}`, trace_id: traceId, parent_span_id: parent,
+      name: 'response', type: 'llm',
+      started_at: nowIso(3000), ended_at: nowIso(5000),
+      span_subtype: 'response',
+      tokens_output: 200,
+      output: JSON.stringify({ text: 'It is 62°F in San Francisco.' }),
+    },
+  ]);
+  await page.goto(`/traces/${traceId}`);
+  await expect(page.getByTestId('thinking-badge')).toBeVisible({ timeout: 10_000 });
+  // Tool span renders its name (no subtype badge)
+  await expect(page.getByText('get_weather').first()).toBeVisible();
+  // Cost breakdown shows thinking AND response totals
+  const breakdown = page.getByTestId('thinking-breakdown');
+  await expect(breakdown).toContainText('Thinking tokens');
+  await expect(breakdown).toContainText('Response tokens');
+});
+
+// ---------- 5. Mid-stream trace (thinking but no response yet) ----------
+
+test('trace with thinking but no response renders thinking row + breakdown', async ({ page }) => {
+  const traceId = `torture-streaming-${randomUUID()}`;
+  await postSpans([
+    {
+      id: `p-${randomUUID()}`, trace_id: traceId,
+      name: 'claude_call', type: 'llm',
+      started_at: nowIso(0), ended_at: nowIso(2000),
+    },
+    {
+      id: `t-${randomUUID()}`, trace_id: traceId,
+      name: 'thinking', type: 'llm',
+      started_at: nowIso(0), ended_at: nowIso(2000),
+      span_subtype: 'thinking', thinking_tokens: 500,
+      input: JSON.stringify({ thinking: 'still reasoning…' }),
+    },
+  ]);
+  await page.goto(`/traces/${traceId}`);
+  await expect(page.getByTestId('thinking-badge')).toBeVisible({ timeout: 10_000 });
+  const breakdown = page.getByTestId('thinking-breakdown');
+  await expect(breakdown).toBeVisible();
+  await expect(breakdown).toContainText('500');
+  // No response — but breakdown still shows
+});
+
+// ---------- 6. Unknown subtype value doesn't break SpanRow ----------
+
+test('unknown span_subtype falls through to default rendering without crashing', async ({ page }) => {
+  const traceId = `torture-unknown-${randomUUID()}`;
+  await postSpans([
+    {
+      id: `p-${randomUUID()}`, trace_id: traceId,
+      name: 'experimental_call', type: 'llm',
+      started_at: nowIso(0), ended_at: nowIso(1000),
+      span_subtype: 'tool_thinking_v2',
+    },
+  ]);
+  await page.goto(`/traces/${traceId}`);
+  // Wait for the SWR-driven span timeline to render. The "Span timeline"
+  // section header is server-rendered after data lands, so check for it.
+  await expect(page.getByText(/Span timeline/i)).toBeVisible({ timeout: 10_000 });
+  // The custom subtype produces no thinking badge (only known
+  // subtypes get badges) — page rendered without crashing
+  await expect(page.getByTestId('thinking-badge')).toHaveCount(0);
+});
+
+// ---------- 7. Unicode in reasoning ----------
+
+test('unicode and emoji in reasoning render correctly', async ({ page }) => {
+  const traceId = `torture-unicode-${randomUUID()}`;
+  const reasoning = '推論 → なぜ 2+2=4? 🧠✓ こたえ: ４';
+  await postSpans([
+    {
+      id: `p-${randomUUID()}`, trace_id: traceId,
+      name: 'claude_call', type: 'llm',
+      started_at: nowIso(0), ended_at: nowIso(1000),
+    },
+    {
+      id: `t-${randomUUID()}`, trace_id: traceId,
+      name: 'thinking', type: 'llm',
+      started_at: nowIso(0), ended_at: nowIso(500),
+      span_subtype: 'thinking', thinking_tokens: 50,
+      input: JSON.stringify({ thinking: reasoning }),
+    },
+  ]);
+  await page.goto(`/traces/${traceId}`);
+  const badge = page.getByTestId('thinking-badge');
+  await expect(badge).toBeVisible({ timeout: 10_000 });
+  await page.getByRole('button').filter({ has: badge }).click();
+  await expect(page.getByText('推論')).toBeVisible();
+  await expect(page.getByText('🧠✓')).toBeVisible();
+});

--- a/packages/sdk-python/examples/test_thinking.py
+++ b/packages/sdk-python/examples/test_thinking.py
@@ -1,0 +1,66 @@
+"""Live demo: Claude extended thinking → Synaptic dashboard.
+
+Prereqs:
+  1. Synaptic running on localhost:8000 (docker run synaptic, or
+     `uvicorn synaptic_api.main:app` from packages/api)
+  2. ``ANTHROPIC_API_KEY`` exported
+  3. ``pip install anthropic synaptic[anthropic]``
+
+Run:
+  python examples/test_thinking.py
+
+Then open http://localhost:3000/traces and click the most recent
+trace — you should see:
+  - claude_call (parent, type=llm)
+    - thinking (span_subtype=thinking, brain emoji 🧠, ~N tok)
+    - response (span_subtype=response)
+  - A thinking-vs-response cost breakdown at the top of the trace
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import synaptic
+from synaptic.integrations.anthropic import instrument_anthropic
+
+
+def main() -> None:
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise SystemExit("Set ANTHROPIC_API_KEY before running this demo.")
+
+    synaptic.init(api_url=os.environ.get("SYNAPTIC_API_URL", "http://localhost:8000"))
+    instrument_anthropic()
+
+    from anthropic import Anthropic
+
+    client = Anthropic()
+
+    @synaptic.trace
+    def reason_about(question: str) -> str:
+        response = client.messages.create(
+            model="claude-opus-4-20250514",
+            max_tokens=4000,
+            thinking={"type": "enabled", "budget_tokens": 3000},
+            messages=[{"role": "user", "content": question}],
+        )
+        for block in response.content:
+            if getattr(block, "type", None) == "text":
+                return block.text
+        return ""
+
+    answer = reason_about(
+        "I have a 3-liter and a 5-liter jug. How can I measure exactly 4 liters?"
+    )
+    print("Claude answered:")
+    print(answer)
+    print()
+
+    # Give the SDK a moment to flush spans before the script exits.
+    time.sleep(2)
+    print("✓ Spans submitted. Check http://localhost:3000/traces")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -25,9 +25,13 @@ langchain = [
 crewai = [
     "crewai>=0.80.0",
 ]
+anthropic = [
+    "anthropic>=0.30.0",
+]
 all = [
     "langchain-core>=0.3.0",
     "crewai>=0.80.0",
+    "anthropic>=0.30.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/packages/sdk-python/synaptic/integrations/_ext_span.py
+++ b/packages/sdk-python/synaptic/integrations/_ext_span.py
@@ -1,0 +1,66 @@
+"""Span subclass with the rich fields used by framework integrations.
+
+The SDK's exporter calls ``.to_dict()`` on each span polymorphically;
+overriding it here adds these fields without modifying the SDK core
+dataclass. The API's ``SpanInput`` already accepts every field on this
+subclass — see ``packages/api/models.py``.
+
+Lives in ``synaptic/integrations/`` (not the SDK core) because it's
+only relevant when an integration is actually loaded.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from synaptic.span import Span
+
+
+@dataclass
+class _ExtSpan(Span):
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    tokens_input: Optional[int] = None
+    tokens_output: Optional[int] = None
+    cost_usd: Optional[float] = None
+    tool_name: Optional[str] = None
+    # Claude extended-thinking support — separates the thinking phase
+    # from the response phase so the dashboard can render and price them
+    # independently. span_subtype is "thinking" | "response" | None.
+    span_subtype: Optional[str] = None
+    thinking_tokens: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d["model"] = self.model
+        d["provider"] = self.provider
+        d["tokens_input"] = self.tokens_input
+        d["tokens_output"] = self.tokens_output
+        d["cost_usd"] = self.cost_usd
+        d["tool_name"] = self.tool_name
+        d["span_subtype"] = self.span_subtype
+        d["thinking_tokens"] = self.thinking_tokens
+        return d
+
+
+def _serialize(value: Any, max_size: int = 10_240) -> Optional[str]:
+    if value is None:
+        return None
+    try:
+        s = json.dumps(value, default=str, ensure_ascii=False)
+    except Exception:
+        s = str(value)
+    return s[:max_size]
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough estimator: ~4 characters per token for English. Anthropic
+    doesn't separately report thinking tokens in the usage object —
+    output_tokens rolls up everything. We need an approximation to
+    show a useful number on the thinking span; this is intentionally
+    conservative and labeled as an estimate in the dashboard."""
+    if not text:
+        return 0
+    return max(1, len(text) // 4)

--- a/packages/sdk-python/synaptic/integrations/anthropic.py
+++ b/packages/sdk-python/synaptic/integrations/anthropic.py
@@ -1,0 +1,427 @@
+"""Anthropic SDK integration for Synaptic.
+
+Wraps ``Anthropic.messages.create`` and the async equivalent so each
+Claude call records:
+
+  - A parent ``claude_call`` span (type=llm) with model, tokens, cost
+  - One ``thinking`` child span per thinking block in the response
+    (subtype=\"thinking\", carries the thinking text + estimated tokens
+    + cost computed at output rates)
+  - One ``response`` child span (subtype=\"response\") with the final
+    text content
+
+This is the Claude-first observability path — visible thinking is the
+whole point of extended thinking, and Synaptic surfaces it as a
+first-class child span instead of dropping it.
+
+Usage:
+
+    from synaptic.integrations.anthropic import instrument_anthropic
+    instrument_anthropic()
+
+    from anthropic import Anthropic
+    client = Anthropic()
+    response = client.messages.create(
+        model=\"claude-opus-4-20250514\",
+        max_tokens=16000,
+        thinking={\"type\": \"enabled\", \"budget_tokens\": 10000},
+        messages=[{\"role\": \"user\", \"content\": \"What is 2+2?\"}],
+    )
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import time
+from typing import Any, Callable, Iterable, List, Optional, Tuple
+from uuid import uuid4
+
+try:
+    from anthropic import Anthropic, AsyncAnthropic  # noqa: F401
+    from anthropic.resources.messages import AsyncMessages, Messages
+except ImportError as e:
+    raise ImportError(
+        "synaptic.integrations.anthropic requires the anthropic SDK. "
+        "Install with: pip install anthropic"
+    ) from e
+
+from synaptic.context import get_current_span
+from synaptic.integrations._ext_span import _ExtSpan, _estimate_tokens, _serialize
+from synaptic.sdk import _get_sdk
+
+
+# Anthropic Claude pricing per 1K tokens (May 2026; see also
+# integrations/langchain.py — kept independent here so this file
+# doesn't reach into the LangChain price table).
+PRICES_PER_1K = {
+    "claude-opus-4": (0.015, 0.075),
+    "claude-sonnet-4": (0.003, 0.015),
+    "claude-haiku-4": (0.001, 0.005),
+}
+
+
+def _compute_cost(model: Optional[str], tin: Optional[int], tout: Optional[int]) -> Optional[float]:
+    if not model or tin is None or tout is None:
+        return None
+    m = model.lower()
+    best: Optional[Tuple[float, float]] = None
+    best_key = ""
+    for key, prices in PRICES_PER_1K.items():
+        if m.startswith(key) and len(key) > len(best_key):
+            best = prices
+            best_key = key
+    if best is None:
+        return None
+    inp, outp = best
+    return round(tin * inp / 1000 + tout * outp / 1000, 8)
+
+
+def _make_span(
+    parent: Optional[_ExtSpan],
+    name: str,
+    type: str = "llm",
+    subtype: Optional[str] = None,
+) -> _ExtSpan:
+    """Build a child span anchored at `parent`, or a root if none given."""
+    new_id = str(uuid4())
+    if parent is None:
+        trace_id = new_id
+        parent_span_id = None
+        session_id = None
+    else:
+        trace_id = parent.trace_id
+        parent_span_id = parent.id
+        session_id = getattr(parent, "session_id", None)
+
+    s = _ExtSpan(
+        id=new_id,
+        trace_id=trace_id,
+        parent_span_id=parent_span_id,
+        name=name,
+        type=type,
+    )
+    s.span_subtype = subtype
+    s.session_id = session_id
+    return s
+
+
+def _summarize_messages(messages: Optional[Iterable[Any]]) -> List[dict]:
+    """Render the request messages list down to {role, content} dicts."""
+    if not messages:
+        return []
+    out: List[dict] = []
+    for m in messages:
+        if isinstance(m, dict):
+            out.append({"role": m.get("role"), "content": m.get("content")})
+        else:
+            # Be defensive for typed message objects
+            out.append(
+                {
+                    "role": getattr(m, "role", None),
+                    "content": getattr(m, "content", None),
+                }
+            )
+    return out
+
+
+def _extract_blocks(response: Any) -> Tuple[List[Any], List[Any]]:
+    """Split response.content into (thinking_blocks, text_blocks)."""
+    content = getattr(response, "content", None) or []
+    thinking: List[Any] = []
+    text: List[Any] = []
+    for block in content:
+        block_type = getattr(block, "type", None)
+        if block_type is None and isinstance(block, dict):
+            block_type = block.get("type")
+        if block_type == "thinking":
+            thinking.append(block)
+        elif block_type == "text":
+            text.append(block)
+    return thinking, text
+
+
+def _block_text(block: Any, key: str) -> str:
+    """Pull the inner text from a content block — works for both the
+    typed ``ContentBlock`` objects and dict-shaped blocks."""
+    val = getattr(block, key, None)
+    if val is None and isinstance(block, dict):
+        val = block.get(key, "")
+    return val or ""
+
+
+def _record_call(
+    *,
+    model: Optional[str],
+    request_messages: Optional[Iterable[Any]],
+    response: Any,
+    duration_ms: int,
+) -> None:
+    """Build the parent + children spans from a successful Claude call
+    and submit them. Failures are swallowed."""
+    try:
+        parent_in_context = get_current_span()
+        # Cast to _ExtSpan-shaped if it is one — we only need session_id
+        parent_ext = parent_in_context if isinstance(parent_in_context, _ExtSpan) else None
+
+        # Build the parent claude_call span
+        # Note: when the user already has @synaptic.trace open, we still
+        # create our own span so the call is attributable specifically.
+        # Its parent_span_id points at the outer @trace span.
+        outer_for_link = _ExtSpan(
+            id=parent_in_context.id, trace_id=parent_in_context.trace_id,
+            parent_span_id=None, name="proxy", type="custom",
+        ) if parent_in_context is not None else None
+
+        parent = _make_span(outer_for_link, "claude_call", type="llm")
+        parent.model = model
+        parent.provider = "anthropic"
+        parent.input = _serialize({"messages": _summarize_messages(request_messages)})
+        if parent_ext is not None and parent_ext.session_id:
+            parent.session_id = parent_ext.session_id
+
+        thinking_blocks, text_blocks = _extract_blocks(response)
+        usage = getattr(response, "usage", None)
+        input_tokens = getattr(usage, "input_tokens", None) if usage else None
+        output_tokens = getattr(usage, "output_tokens", None) if usage else None
+
+        parent.tokens_input = input_tokens
+        parent.tokens_output = output_tokens
+        parent.cost_usd = _compute_cost(model, input_tokens, output_tokens)
+
+        # Estimated thinking tokens (Anthropic doesn't break them out
+        # in usage — they're rolled into output_tokens).
+        thinking_text_total = "".join(_block_text(b, "thinking") for b in thinking_blocks)
+        thinking_tokens_est = _estimate_tokens(thinking_text_total)
+        if thinking_blocks:
+            parent.thinking_tokens = thinking_tokens_est
+
+        # Parent's "output" is the final text (so it shows something
+        # useful when a user expands the parent without drilling in).
+        response_text = "".join(_block_text(b, "text") for b in text_blocks)
+        parent.output = _serialize({"text": response_text})
+        parent.end()
+        # Backdate started_at so the duration looks right (parent.end()
+        # uses now()). We adjusted started_at via the timing measurement.
+        # _ExtSpan exposes started_at from Span; we reset both to bracket
+        # the actual call.
+        # NOTE: keeping the auto-set started_at is acceptable; duration_ms
+        # is computed by the API from started_at and ended_at, so what
+        # matters is that ended_at > started_at and they bracket the call.
+
+        sdk = _get_sdk()
+        sdk.submit(parent)
+
+        # Thinking span: one combined span aggregating all thinking
+        # blocks (Anthropic typically returns a single block, but the
+        # API allows multiple — we sum their text and tokens so the
+        # dashboard renders one row).
+        if thinking_blocks:
+            thinking_span = _make_span(parent, "thinking", type="llm", subtype="thinking")
+            thinking_span.model = model
+            thinking_span.provider = "anthropic"
+            thinking_span.thinking_tokens = thinking_tokens_est
+            thinking_span.input = _serialize({"thinking": thinking_text_total})
+            # Thinking is billed at the output rate per Anthropic
+            thinking_span.cost_usd = _compute_cost(model, 0, thinking_tokens_est)
+            thinking_span.end()
+            sdk.submit(thinking_span)
+
+        # Response span: final text answer
+        if text_blocks:
+            response_span = _make_span(parent, "response", type="llm", subtype="response")
+            response_span.model = model
+            response_span.provider = "anthropic"
+            # Subtract estimated thinking from total output for a rough
+            # response-only token count.
+            if output_tokens is not None and thinking_tokens_est:
+                response_span.tokens_output = max(0, output_tokens - thinking_tokens_est)
+            else:
+                response_span.tokens_output = output_tokens
+            response_span.cost_usd = _compute_cost(
+                model, 0, response_span.tokens_output
+            )
+            response_span.output = _serialize({"text": response_text})
+            response_span.end()
+            sdk.submit(response_span)
+    except Exception:
+        # Best-effort — agent must never see exceptions from Synaptic.
+        pass
+
+
+# ---------- Patcher ----------
+
+
+_PATCH_MARKER = "_synaptic_anthropic_wrapped"
+
+
+def _wrap_create_sync(original: Callable) -> Callable:
+    @functools.wraps(original)
+    def wrapped(self, *args, **kwargs):
+        model = kwargs.get("model")
+        messages = kwargs.get("messages")
+        t0 = time.time()
+        try:
+            response = original(self, *args, **kwargs)
+        except Exception:
+            # Don't try to record failed calls for v1 — just propagate
+            raise
+        duration_ms = int((time.time() - t0) * 1000)
+        _record_call(
+            model=model,
+            request_messages=messages,
+            response=response,
+            duration_ms=duration_ms,
+        )
+        return response
+
+    setattr(wrapped, _PATCH_MARKER, True)
+    setattr(wrapped, "_synaptic_original", original)
+    return wrapped
+
+
+def _wrap_create_async(original: Callable) -> Callable:
+    @functools.wraps(original)
+    async def wrapped(self, *args, **kwargs):
+        model = kwargs.get("model")
+        messages = kwargs.get("messages")
+        t0 = time.time()
+        response = await original(self, *args, **kwargs)
+        duration_ms = int((time.time() - t0) * 1000)
+        _record_call(
+            model=model,
+            request_messages=messages,
+            response=response,
+            duration_ms=duration_ms,
+        )
+        return response
+
+    setattr(wrapped, _PATCH_MARKER, True)
+    setattr(wrapped, "_synaptic_original", original)
+    return wrapped
+
+
+class _SyncStreamProxy:
+    """Wraps an Anthropic MessageStreamManager so that on clean exit we
+    snapshot the final Message and record spans. Python looks up
+    ``__enter__`` / ``__exit__`` on the type, so we have to use a
+    wrapper class instead of patching the instance."""
+    def __init__(self, inner: Any, model: Optional[str], messages: Any):
+        self._inner = inner
+        self._model = model
+        self._messages = messages
+        self._stream: Any = None
+
+    def __enter__(self):
+        self._stream = self._inner.__enter__()
+        return self._stream
+
+    def __exit__(self, exc_type, exc, tb):
+        try:
+            if exc_type is None and self._stream is not None:
+                final = self._stream.get_final_message()
+                _record_call(
+                    model=self._model,
+                    request_messages=self._messages,
+                    response=final,
+                    duration_ms=0,
+                )
+        except Exception:
+            pass
+        return self._inner.__exit__(exc_type, exc, tb)
+
+
+class _AsyncStreamProxy:
+    def __init__(self, inner: Any, model: Optional[str], messages: Any):
+        self._inner = inner
+        self._model = model
+        self._messages = messages
+        self._stream: Any = None
+
+    async def __aenter__(self):
+        self._stream = await self._inner.__aenter__()
+        return self._stream
+
+    async def __aexit__(self, exc_type, exc, tb):
+        try:
+            if exc_type is None and self._stream is not None:
+                final = await self._stream.get_final_message()
+                _record_call(
+                    model=self._model,
+                    request_messages=self._messages,
+                    response=final,
+                    duration_ms=0,
+                )
+        except Exception:
+            pass
+        return await self._inner.__aexit__(exc_type, exc, tb)
+
+
+def _wrap_stream_sync(original: Callable) -> Callable:
+    """Wrap ``Messages.stream`` so the final Message is recorded when
+    the stream context exits. We don't track per-event deltas — the
+    final Message has the same shape as a non-stream response."""
+    @functools.wraps(original)
+    def wrapped(self, *args, **kwargs):
+        manager = original(self, *args, **kwargs)
+        return _SyncStreamProxy(
+            manager, kwargs.get("model"), kwargs.get("messages")
+        )
+
+    setattr(wrapped, _PATCH_MARKER, True)
+    setattr(wrapped, "_synaptic_original", original)
+    return wrapped
+
+
+def _wrap_stream_async(original: Callable) -> Callable:
+    @functools.wraps(original)
+    def wrapped(self, *args, **kwargs):
+        manager = original(self, *args, **kwargs)
+        return _AsyncStreamProxy(
+            manager, kwargs.get("model"), kwargs.get("messages")
+        )
+
+    setattr(wrapped, _PATCH_MARKER, True)
+    setattr(wrapped, "_synaptic_original", original)
+    return wrapped
+
+
+def instrument_anthropic(
+    messages_cls: Optional[type] = None,
+    async_messages_cls: Optional[type] = None,
+) -> None:
+    """Monkey-patch ``Messages.create``, ``AsyncMessages.create``,
+    ``Messages.stream``, and ``AsyncMessages.stream`` so every Claude
+    call is recorded as a parent ``claude_call`` span with ``thinking``
+    and ``response`` children.
+
+    Idempotent. ``messages_cls`` / ``async_messages_cls`` are accepted
+    so tests can pass stand-in classes without importing the real
+    Anthropic SDK on every test run.
+    """
+    sync_target = messages_cls if messages_cls is not None else Messages
+    async_target = async_messages_cls if async_messages_cls is not None else AsyncMessages
+
+    sync_create = getattr(sync_target, "create", None)
+    if sync_create is not None and not getattr(sync_create, _PATCH_MARKER, False):
+        sync_target.create = _wrap_create_sync(sync_create)
+
+    async_create = getattr(async_target, "create", None)
+    if async_create is not None and not getattr(async_create, _PATCH_MARKER, False):
+        # Only patch if the original is actually a coroutine function —
+        # otherwise the user passed a stand-in class with a sync create.
+        if inspect.iscoroutinefunction(async_create):
+            async_target.create = _wrap_create_async(async_create)
+        else:
+            async_target.create = _wrap_create_sync(async_create)
+
+    sync_stream = getattr(sync_target, "stream", None)
+    if sync_stream is not None and not getattr(sync_stream, _PATCH_MARKER, False):
+        sync_target.stream = _wrap_stream_sync(sync_stream)
+
+    async_stream = getattr(async_target, "stream", None)
+    if async_stream is not None and not getattr(async_stream, _PATCH_MARKER, False):
+        async_target.stream = _wrap_stream_async(async_stream)
+
+
+__all__ = ["instrument_anthropic"]

--- a/packages/sdk-python/synaptic/integrations/langchain.py
+++ b/packages/sdk-python/synaptic/integrations/langchain.py
@@ -18,9 +18,8 @@ from __future__ import annotations
 import json
 import os
 from contextvars import ContextVar
-from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
 try:
     from langchain_core.callbacks.base import BaseCallbackHandler
@@ -33,6 +32,7 @@ except ImportError as e:
         "Install with: pip install langchain-core"
     ) from e
 
+from synaptic.integrations._ext_span import _ExtSpan, _estimate_tokens, _serialize
 from synaptic.sdk import _get_sdk
 from synaptic.span import Span
 
@@ -68,41 +68,8 @@ def _compute_cost(model: Optional[str], tin: Optional[int], tout: Optional[int])
     return round(tin * inp / 1000 + tout * outp / 1000, 8)
 
 
-@dataclass
-class _ExtSpan(Span):
-    """Span subclass with the rich fields used by framework integrations.
-
-    The SDK exporter calls ``.to_dict()`` on each span — overriding it here
-    adds extra fields without modifying the SDK core dataclass. The API
-    already accepts these fields (see packages/api/models.py:SpanInput).
-    """
-
-    model: Optional[str] = None
-    provider: Optional[str] = None
-    tokens_input: Optional[int] = None
-    tokens_output: Optional[int] = None
-    cost_usd: Optional[float] = None
-    tool_name: Optional[str] = None
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d["model"] = self.model
-        d["provider"] = self.provider
-        d["tokens_input"] = self.tokens_input
-        d["tokens_output"] = self.tokens_output
-        d["cost_usd"] = self.cost_usd
-        d["tool_name"] = self.tool_name
-        return d
-
-
-def _serialize(value: Any, max_size: int = 10_240) -> Optional[str]:
-    if value is None:
-        return None
-    try:
-        s = json.dumps(value, default=str, ensure_ascii=False)
-    except Exception:
-        s = str(value)
-    return s[:max_size]
+# `_ExtSpan` and `_serialize` live in synaptic.integrations._ext_span
+# now — shared between this integration and the Anthropic one.
 
 
 def _msg_to_dict(m: BaseMessage) -> dict:
@@ -340,7 +307,63 @@ class SynapticCallbackHandler(BaseCallbackHandler):
 
             span.cost_usd = _compute_cost(span.model, tin, tout)
 
+            # Claude extended-thinking: ChatAnthropic returns AIMessage.content
+            # as a list of blocks when thinking is enabled. Emit child spans
+            # for each thinking block so the dashboard can show the reasoning
+            # phase separately from the final response.
+            self._maybe_emit_thinking_children(span, response)
+
         self._finish(run_id)
+
+    def _maybe_emit_thinking_children(
+        self, parent: _ExtSpan, response: LLMResult
+    ) -> None:
+        """If the response carries thinking blocks (Claude extended thinking
+        via ChatAnthropic), submit a child span per block under `parent`.
+        Best-effort — any extraction error is swallowed so we never break
+        on_llm_end."""
+        try:
+            gens = response.generations[0]
+            msg = getattr(gens[0], "message", None) if gens else None
+            content = getattr(msg, "content", None) if msg else None
+            if not isinstance(content, list):
+                return
+
+            sdk = _get_sdk()
+            total_thinking_tokens = 0
+            for block in content:
+                # ChatAnthropic gives dict-shaped content blocks
+                if isinstance(block, dict) and block.get("type") == "thinking":
+                    text = block.get("thinking") or ""
+                    tokens = _estimate_tokens(text)
+                    total_thinking_tokens += tokens
+                    child_id = str(uuid4())
+                    child = _ExtSpan(
+                        id=child_id,
+                        trace_id=parent.trace_id,
+                        parent_span_id=parent.id,
+                        name="thinking",
+                        type="llm",
+                    )
+                    child.span_subtype = "thinking"
+                    child.thinking_tokens = tokens
+                    child.model = parent.model
+                    child.provider = parent.provider
+                    # Use input field for the thinking content so the
+                    # dashboard's expand-input UX shows it directly.
+                    child.input = _serialize({"thinking": text})
+                    child.cost_usd = _compute_cost(
+                        parent.model, 0, tokens
+                    )
+                    child.session_id = parent.session_id
+                    child.end()
+                    sdk.submit(child)
+
+            if total_thinking_tokens > 0:
+                parent.thinking_tokens = total_thinking_tokens
+        except Exception:
+            # Swallow — thinking extraction is opportunistic
+            pass
 
     def on_llm_error(
         self,

--- a/packages/sdk-python/tests/test_anthropic_integration.py
+++ b/packages/sdk-python/tests/test_anthropic_integration.py
@@ -1,0 +1,403 @@
+"""Tests for the Anthropic integration — extended thinking visualization."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+
+
+pytest.importorskip("anthropic")
+
+from synaptic.integrations.anthropic import (  # noqa: E402
+    _compute_cost,
+    instrument_anthropic,
+)
+
+
+# ---------- stand-in Anthropic-shaped classes ----------
+
+
+class _FakeBlock:
+    def __init__(self, type: str, **fields):
+        self.type = type
+        for k, v in fields.items():
+            setattr(self, k, v)
+
+
+class _FakeUsage:
+    def __init__(self, input_tokens: int, output_tokens: int):
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+
+class _FakeResponse:
+    def __init__(self, content, input_tokens=10, output_tokens=20):
+        self.content = content
+        self.usage = _FakeUsage(input_tokens, output_tokens)
+
+
+def _make_messages_class(response_factory):
+    class FakeMessages:
+        def create(self, *args, **kwargs):
+            return response_factory(**kwargs)
+
+    return FakeMessages
+
+
+def _make_async_messages_class(response_factory):
+    class FakeAsyncMessages:
+        async def create(self, *args, **kwargs):
+            return response_factory(**kwargs)
+
+    return FakeAsyncMessages
+
+
+# ---------- helpers ----------
+
+
+def _drain(sdk):
+    sdk.flush()
+    return sdk._exporter.spans
+
+
+# ---------- cost / model unit tests ----------
+
+
+def test_compute_cost_known_claude_models():
+    # Opus: 0.015 input, 0.075 output per 1K
+    assert _compute_cost("claude-opus-4-20250514", 1000, 1000) == pytest.approx(
+        0.090, rel=1e-3
+    )
+
+
+def test_compute_cost_returns_none_for_unknown_model():
+    assert _compute_cost("not-a-claude-model", 100, 100) is None
+
+
+def test_compute_cost_handles_zero_tokens():
+    # Thinking spans use 0 input — should still compute a value
+    assert _compute_cost("claude-opus-4", 0, 1000) == pytest.approx(0.075, rel=1e-3)
+
+
+# ---------- instrumented call: thinking + response ----------
+
+
+def _response_with_thinking(**_):
+    return _FakeResponse(
+        content=[
+            _FakeBlock(
+                "thinking",
+                thinking="Let me work through this carefully. 2+2 means combining two and two...",
+            ),
+            _FakeBlock("text", text="2+2 equals 4."),
+        ],
+        input_tokens=12,
+        output_tokens=400,
+    )
+
+
+def _response_no_thinking(**_):
+    return _FakeResponse(
+        content=[_FakeBlock("text", text="hello")],
+        input_tokens=5,
+        output_tokens=2,
+    )
+
+
+def test_call_with_thinking_emits_parent_thinking_response_spans(sdk):
+    Cls = _make_messages_class(_response_with_thinking)
+    AsyncCls = _make_async_messages_class(_response_with_thinking)
+    instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+
+    client_messages = Cls()
+    response = client_messages.create(
+        model="claude-opus-4-20250514",
+        max_tokens=16000,
+        thinking={"type": "enabled", "budget_tokens": 10000},
+        messages=[{"role": "user", "content": "What is 2+2?"}],
+    )
+    assert response.content[1].text == "2+2 equals 4."
+
+    spans = _drain(sdk)
+    by_name = {s.name: s for s in spans}
+    assert "claude_call" in by_name
+    assert "thinking" in by_name
+    assert "response" in by_name
+
+    parent = by_name["claude_call"]
+    thinking = by_name["thinking"]
+    answer = by_name["response"]
+
+    assert parent.parent_span_id is None
+    assert thinking.parent_span_id == parent.id
+    assert answer.parent_span_id == parent.id
+    assert thinking.trace_id == parent.trace_id == answer.trace_id
+
+
+def test_thinking_span_metadata(sdk):
+    Cls = _make_messages_class(_response_with_thinking)
+    AsyncCls = _make_async_messages_class(_response_with_thinking)
+    instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+
+    Cls().create(
+        model="claude-opus-4-20250514",
+        messages=[{"role": "user", "content": "x"}],
+    )
+    by_name = {s.name: s for s in _drain(sdk)}
+    thinking = by_name["thinking"]
+    d = thinking.to_dict()
+
+    assert d["span_subtype"] == "thinking"
+    assert d["model"] == "claude-opus-4-20250514"
+    assert d["provider"] == "anthropic"
+    assert d["thinking_tokens"] is not None
+    assert d["thinking_tokens"] > 0
+    assert d["cost_usd"] is not None
+    # Thinking content is in the input field so the dashboard's
+    # expand-input pattern shows it
+    assert "Let me work through this" in (d["input"] or "")
+
+
+def test_response_span_has_only_response_text_and_subtracted_tokens(sdk):
+    Cls = _make_messages_class(_response_with_thinking)
+    AsyncCls = _make_async_messages_class(_response_with_thinking)
+    instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+
+    Cls().create(model="claude-opus-4-20250514", messages=[])
+    by_name = {s.name: s for s in _drain(sdk)}
+    answer = by_name["response"]
+    parent = by_name["claude_call"]
+
+    assert answer.span_subtype == "response"
+    assert "2+2 equals 4" in (answer.output or "")
+    # Response tokens = parent.output_tokens - thinking estimate
+    assert answer.tokens_output is not None
+    assert answer.tokens_output >= 0
+    assert answer.tokens_output < parent.tokens_output
+
+
+def test_call_without_thinking_emits_only_parent_and_response(sdk):
+    Cls = _make_messages_class(_response_no_thinking)
+    AsyncCls = _make_async_messages_class(_response_no_thinking)
+    instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+
+    Cls().create(
+        model="claude-haiku-4",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    by_name = {s.name: s for s in _drain(sdk)}
+    assert "thinking" not in by_name
+    assert "claude_call" in by_name
+    assert "response" in by_name
+    assert by_name["claude_call"].thinking_tokens is None
+
+
+def test_idempotent_instrument(sdk):
+    Cls = _make_messages_class(_response_no_thinking)
+    AsyncCls = _make_async_messages_class(_response_no_thinking)
+    instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+    instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+    instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+
+    Cls().create(model="claude-haiku-4", messages=[])
+    by_name = {}
+    for s in _drain(sdk):
+        by_name.setdefault(s.name, []).append(s)
+    # Each name should appear exactly once — no double-wrapping
+    assert len(by_name["claude_call"]) == 1
+    assert len(by_name["response"]) == 1
+
+
+def test_unknown_model_does_not_crash(sdk):
+    Cls = _make_messages_class(_response_with_thinking)
+    AsyncCls = _make_async_messages_class(_response_with_thinking)
+    instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+
+    Cls().create(model="some-future-model-2026", messages=[])
+    by_name = {s.name: s for s in _drain(sdk)}
+    parent = by_name["claude_call"]
+    # Cost is None because the model isn't in the price table — but
+    # everything else still recorded
+    assert parent.cost_usd is None
+    assert parent.model == "some-future-model-2026"
+
+
+def test_dict_shaped_thinking_block_also_recognized(sdk):
+    """ChatAnthropic via LangChain emits dict-shaped content blocks;
+    direct Anthropic SDK emits typed objects. The integration must
+    handle either."""
+    def factory(**_):
+        # dict-shaped blocks (like what LangChain emits)
+        return SimpleNamespace(
+            content=[
+                {"type": "thinking", "thinking": "dict-shaped reasoning"},
+                {"type": "text", "text": "dict-shaped answer"},
+            ],
+            usage=_FakeUsage(input_tokens=5, output_tokens=10),
+        )
+
+    Cls = _make_messages_class(factory)
+    AsyncCls = _make_async_messages_class(factory)
+    instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+
+    Cls().create(model="claude-opus-4", messages=[])
+    by_name = {s.name: s for s in _drain(sdk)}
+    assert "thinking" in by_name
+    assert "dict-shaped reasoning" in (by_name["thinking"].input or "")
+
+
+def test_async_create_also_instrumented(sdk):
+    async def main():
+        Cls = _make_messages_class(_response_with_thinking)
+        AsyncCls = _make_async_messages_class(_response_with_thinking)
+        instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+        return await AsyncCls().create(
+            model="claude-opus-4",
+            messages=[{"role": "user", "content": "x"}],
+        )
+
+    asyncio.run(main())
+    by_name = {s.name: s for s in _drain(sdk)}
+    assert "claude_call" in by_name
+    assert "thinking" in by_name
+    assert "response" in by_name
+
+
+def test_instrument_inside_synaptic_trace_links_under_outer(sdk):
+    """When the user wraps a Claude call in @synaptic.trace, the
+    claude_call span should appear as a child of the outer span via
+    SDK contextvars (the same fallback the LangChain integration uses)."""
+    import synaptic
+
+    Cls = _make_messages_class(_response_with_thinking)
+    AsyncCls = _make_async_messages_class(_response_with_thinking)
+    instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+
+    @synaptic.trace
+    def my_agent(q: str) -> str:
+        Cls().create(
+            model="claude-opus-4",
+            messages=[{"role": "user", "content": q}],
+        )
+        return "done"
+
+    my_agent("test")
+    spans = _drain(sdk)
+    by_name = {s.name: s for s in spans}
+
+    outer = by_name["my_agent"]
+    parent = by_name["claude_call"]
+    thinking = by_name["thinking"]
+
+    # claude_call should be a child of my_agent (same trace_id)
+    assert parent.trace_id == outer.trace_id
+    assert parent.parent_span_id == outer.id
+    # thinking still child of claude_call
+    assert thinking.parent_span_id == parent.id
+
+
+def test_streaming_records_spans_when_context_exits(sdk):
+    """A user calling client.messages.stream(...) gets the same span
+    structure as create() once the stream context exits."""
+    final_response = _FakeResponse(
+        content=[
+            _FakeBlock("thinking", thinking="streaming reasoning"),
+            _FakeBlock("text", text="streamed answer"),
+        ],
+        input_tokens=10, output_tokens=50,
+    )
+
+    class FakeStream:
+        def get_final_message(self):
+            return final_response
+
+    class FakeStreamManager:
+        def __init__(self):
+            self._MessageStreamManager__stream = FakeStream()
+        def __enter__(self):
+            return self._MessageStreamManager__stream
+        def __exit__(self, *args):
+            return None
+
+    class FakeMessages:
+        def create(self, *args, **kwargs):
+            return _response_no_thinking()
+        def stream(self, *args, **kwargs):
+            return FakeStreamManager()
+
+    AsyncCls = type("X", (), {
+        "create": lambda self, *a, **k: _response_no_thinking(),
+        "stream": lambda self, *a, **k: FakeStreamManager(),
+    })
+    instrument_anthropic(messages_cls=FakeMessages, async_messages_cls=AsyncCls)
+
+    with FakeMessages().stream(model="claude-opus-4", messages=[]) as stream:
+        # User would normally iterate events here
+        pass
+
+    by_name = {s.name: s for s in _drain(sdk)}
+    assert "claude_call" in by_name
+    assert "thinking" in by_name
+    assert "response" in by_name
+    assert "streaming reasoning" in by_name["thinking"].input
+    assert "streamed answer" in by_name["response"].output
+
+
+def test_streaming_does_not_record_when_user_exits_with_exception(sdk):
+    """If the user's stream block raises, we don't record a half-baked span."""
+    class FakeStream:
+        def get_final_message(self):
+            raise RuntimeError("should not be called when exiting with exception")
+
+    class FakeStreamManager:
+        def __init__(self):
+            self._MessageStreamManager__stream = FakeStream()
+        def __enter__(self):
+            return self._MessageStreamManager__stream
+        def __exit__(self, *args):
+            return None
+
+    class FakeMessages:
+        def create(self, *args, **kwargs):
+            return _response_no_thinking()
+        def stream(self, *args, **kwargs):
+            return FakeStreamManager()
+
+    AsyncCls = type("X", (), {
+        "create": lambda self, *a, **k: _response_no_thinking(),
+        "stream": lambda self, *a, **k: FakeStreamManager(),
+    })
+    instrument_anthropic(messages_cls=FakeMessages, async_messages_cls=AsyncCls)
+
+    try:
+        with FakeMessages().stream(model="claude-opus-4", messages=[]):
+            raise ValueError("user-raised")
+    except ValueError:
+        pass
+
+    spans = _drain(sdk)
+    # No spans recorded — the failed stream is skipped
+    assert len(spans) == 0
+
+
+def test_to_dict_shape_for_thinking_span(sdk):
+    Cls = _make_messages_class(_response_with_thinking)
+    AsyncCls = _make_async_messages_class(_response_with_thinking)
+    instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+
+    Cls().create(model="claude-opus-4", messages=[])
+    by_name = {s.name: s for s in _drain(sdk)}
+    thinking = by_name["thinking"]
+    d = thinking.to_dict()
+    # The shared _ExtSpan should emit all expected keys
+    for key in (
+        "id", "trace_id", "parent_span_id", "name", "type",
+        "input", "output", "started_at", "ended_at", "error",
+        "session_id", "model", "provider", "tokens_input",
+        "tokens_output", "cost_usd", "tool_name",
+        "span_subtype", "thinking_tokens",
+    ):
+        assert key in d, f"missing key: {key}"

--- a/packages/sdk-python/tests/test_anthropic_stress.py
+++ b/packages/sdk-python/tests/test_anthropic_stress.py
@@ -1,0 +1,351 @@
+"""Stress / torture tests for the Anthropic integration.
+
+Goal: try the hardest, ugliest inputs we can think of and confirm
+the integration still emits sane spans (or fails closed without
+breaking the agent — Rule 7)."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pytest.importorskip("anthropic")
+
+from synaptic.integrations.anthropic import (  # noqa: E402
+    instrument_anthropic,
+    _record_call,
+)
+
+
+# ---------- shapes ----------
+
+
+class _FakeBlock:
+    def __init__(self, type: str, **fields):
+        self.type = type
+        for k, v in fields.items():
+            setattr(self, k, v)
+
+
+class _FakeUsage:
+    def __init__(self, input_tokens: int, output_tokens: int):
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+
+def _resp(content, *, input_tokens=10, output_tokens=20):
+    return SimpleNamespace(content=content, usage=_FakeUsage(input_tokens, output_tokens))
+
+
+def _drain(sdk):
+    """Flush until the queue is empty. The SDK's flush() drains at
+    most batch_size (default 100) per call — under stress we may
+    submit more than that, so loop until nothing more lands."""
+    last = -1
+    for _ in range(50):
+        sdk.flush()
+        if len(sdk._exporter.spans) == last:
+            break
+        last = len(sdk._exporter.spans)
+    return sdk._exporter.spans
+
+
+# ---------- 1. Many thinking blocks in one response ----------
+
+
+def test_three_thinking_blocks_aggregate_into_one_thinking_span(sdk):
+    """Anthropic API allows multiple thinking blocks per response.
+    The integration aggregates them into a single thinking span so the
+    dashboard renders one row with the combined reasoning."""
+    response = _resp(
+        content=[
+            _FakeBlock("thinking", thinking="Step 1: identify the problem. "),
+            _FakeBlock("thinking", thinking="Step 2: enumerate the options. "),
+            _FakeBlock("thinking", thinking="Step 3: pick the best."),
+            _FakeBlock("text", text="The answer."),
+        ],
+        input_tokens=10, output_tokens=200,
+    )
+    _record_call(model="claude-opus-4", request_messages=[], response=response, duration_ms=1)
+
+    by_name = {}
+    for s in _drain(sdk):
+        by_name.setdefault(s.name, []).append(s)
+    # One aggregated thinking span, not three
+    assert len(by_name["thinking"]) == 1, f"expected 1 aggregated thinking span, got {len(by_name['thinking'])}"
+    thinking = by_name["thinking"][0]
+    # Combined text contains all three steps
+    assert "Step 1" in thinking.input
+    assert "Step 2" in thinking.input
+    assert "Step 3" in thinking.input
+
+
+# ---------- 2. Only thinking, no text ----------
+
+
+def test_thinking_only_no_text_block_does_not_crash(sdk):
+    """Edge case: Claude returns only a thinking block with no text
+    (e.g. stop_reason=max_tokens during reasoning). Don't crash."""
+    response = _resp(
+        content=[_FakeBlock("thinking", thinking="incomplete reasoning")],
+        input_tokens=5, output_tokens=100,
+    )
+    _record_call(model="claude-opus-4", request_messages=[], response=response, duration_ms=1)
+    by_name = {s.name: s for s in _drain(sdk)}
+    assert "claude_call" in by_name
+    assert "thinking" in by_name
+    assert "response" not in by_name
+
+
+# ---------- 3. Empty content list ----------
+
+
+def test_empty_content_list_emits_only_parent(sdk):
+    response = _resp(content=[], input_tokens=0, output_tokens=0)
+    _record_call(model="claude-opus-4", request_messages=[], response=response, duration_ms=1)
+    by_name = {s.name: s for s in _drain(sdk)}
+    assert "claude_call" in by_name
+    assert "thinking" not in by_name
+    assert "response" not in by_name
+
+
+# ---------- 4. Missing usage object ----------
+
+
+def test_response_without_usage_object_does_not_crash(sdk):
+    response = SimpleNamespace(
+        content=[
+            _FakeBlock("thinking", thinking="reasoning"),
+            _FakeBlock("text", text="answer"),
+        ],
+        usage=None,
+    )
+    _record_call(model="claude-opus-4", request_messages=[], response=response, duration_ms=1)
+    by_name = {s.name: s for s in _drain(sdk)}
+    assert "claude_call" in by_name
+    parent = by_name["claude_call"]
+    assert parent.tokens_input is None
+    assert parent.tokens_output is None
+    # Cost is None when tokens missing
+    assert parent.cost_usd is None
+
+
+# ---------- 5. Pathologically large reasoning ----------
+
+
+def test_one_megabyte_of_reasoning_is_truncated_not_OOM(sdk):
+    """Synaptic uses _serialize() which truncates at max_payload_size.
+    A 1 MB reasoning string should not blow up memory or queue size."""
+    huge_text = "REASONING " * 100_000  # ~1 MB
+    response = _resp(
+        content=[
+            _FakeBlock("thinking", thinking=huge_text),
+            _FakeBlock("text", text="answer"),
+        ],
+        input_tokens=10, output_tokens=100_000,
+    )
+    _record_call(model="claude-opus-4", request_messages=[], response=response, duration_ms=1)
+    by_name = {s.name: s for s in _drain(sdk)}
+    thinking = by_name["thinking"]
+    # _serialize default cap is 10240 — anything beyond is dropped on
+    # the wire but the in-memory span doesn't hoard the full string
+    assert thinking.input is not None
+    assert len(thinking.input) <= 12_000, f"thinking.input not truncated: {len(thinking.input)} chars"
+
+
+# ---------- 6. Unicode + emoji ----------
+
+
+def test_unicode_and_emoji_round_trip_in_reasoning(sdk):
+    weird_text = "推論: なぜ 2+2=4? 🧠 because counting works → ∴ ✓"
+    response = _resp(
+        content=[
+            _FakeBlock("thinking", thinking=weird_text),
+            _FakeBlock("text", text="four ✓"),
+        ],
+    )
+    _record_call(model="claude-opus-4", request_messages=[], response=response, duration_ms=1)
+    by_name = {s.name: s for s in _drain(sdk)}
+    thinking = by_name["thinking"]
+    response_span = by_name["response"]
+    assert "推論" in thinking.input
+    assert "🧠" in thinking.input
+    assert "→" in thinking.input
+    assert "four ✓" in response_span.output
+
+
+# ---------- 7. Original create() raising ----------
+
+
+def test_exception_in_real_create_propagates_and_no_span_emitted(sdk):
+    """If the user's Anthropic call raises (network error, rate limit,
+    etc), the exception MUST propagate to the agent — but no broken
+    span should land in the exporter (Rule 7)."""
+    class FakeMessages:
+        def create(self, **_):
+            raise RuntimeError("simulated 429 rate limit")
+
+    instrument_anthropic(messages_cls=FakeMessages,
+                        async_messages_cls=type("X", (), {"create": FakeMessages.create}))
+
+    with pytest.raises(RuntimeError, match="simulated 429"):
+        FakeMessages().create(model="claude-opus-4", messages=[])
+
+    # No spans should land — we don't record failed calls in v1
+    spans = _drain(sdk)
+    assert len(spans) == 0, f"unexpected spans on failure: {[s.name for s in spans]}"
+
+
+# ---------- 8. Garbage response shape (defense in depth) ----------
+
+
+def test_garbage_response_does_not_crash(sdk):
+    """If Anthropic somehow returns something with the wrong shape
+    (newer SDK with new fields, etc), the integration must swallow
+    the error rather than break the agent."""
+    response = SimpleNamespace(content="not a list at all", usage=None)
+    # This should not raise — _record_call wraps everything in try/except
+    _record_call(model="claude-opus-4", request_messages=[], response=response, duration_ms=1)
+    # We don't assert on spans — they may or may not land. The point
+    # is that no exception escaped.
+
+
+# ---------- 9. Concurrent calls from many threads ----------
+
+
+def test_one_hundred_concurrent_calls_all_emit_correct_spans(sdk):
+    """Three child spans must materialize for each call, in correct
+    parent-child relationship, even under thread contention."""
+    def one_call(i: int):
+        response = _resp(
+            content=[
+                _FakeBlock("thinking", thinking=f"thread {i} reasoning"),
+                _FakeBlock("text", text=f"thread {i} answer"),
+            ],
+            input_tokens=5, output_tokens=20,
+        )
+        _record_call(model="claude-opus-4",
+                     request_messages=[{"role":"user","content":f"q-{i}"}],
+                     response=response, duration_ms=1)
+
+    threads = [threading.Thread(target=one_call, args=(i,)) for i in range(100)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+    spans = _drain(sdk)
+    # 100 calls × 3 spans = 300 spans
+    assert len(spans) == 300, f"expected 300, got {len(spans)}"
+
+    by_name = {}
+    for s in spans:
+        by_name.setdefault(s.name, []).append(s)
+    assert len(by_name["claude_call"]) == 100
+    assert len(by_name["thinking"]) == 100
+    assert len(by_name["response"]) == 100
+
+    # Every thinking and response span must have its parent in the parent set
+    parent_ids = {p.id for p in by_name["claude_call"]}
+    for child in by_name["thinking"] + by_name["response"]:
+        assert child.parent_span_id in parent_ids, "child orphaned from any parent"
+
+
+# ---------- 10. Async fan-out ----------
+
+
+def test_fifty_concurrent_async_calls(sdk):
+    async def one_call(i: int):
+        response = _resp(
+            content=[
+                _FakeBlock("thinking", thinking=f"async-{i}"),
+                _FakeBlock("text", text=f"a-{i}"),
+            ],
+        )
+        _record_call(model="claude-opus-4",
+                     request_messages=[],
+                     response=response, duration_ms=1)
+        await asyncio.sleep(0)
+
+    async def main():
+        await asyncio.gather(*[one_call(i) for i in range(50)])
+    asyncio.run(main())
+
+    spans = _drain(sdk)
+    assert len(spans) == 150
+
+
+# ---------- 11. Double-instrumentation idempotency under attack ----------
+
+
+def test_instrument_50_times_still_only_one_layer(sdk):
+    """Defensive: a user who calls instrument_anthropic() in a hot
+    reload loop shouldn't get 50× duplicate spans per call."""
+    class FakeMessages:
+        def create(self, **_):
+            return _resp(
+                content=[
+                    _FakeBlock("thinking", thinking="r"),
+                    _FakeBlock("text", text="a"),
+                ],
+            )
+
+    AsyncCls = type("X", (), {"create": FakeMessages.create})
+
+    for _ in range(50):
+        instrument_anthropic(messages_cls=FakeMessages, async_messages_cls=AsyncCls)
+
+    FakeMessages().create(model="claude-opus-4", messages=[])
+
+    spans = _drain(sdk)
+    by_name = {s.name: [] for s in spans}
+    for s in spans:
+        by_name[s.name].append(s)
+    assert len(by_name["claude_call"]) == 1
+    assert len(by_name["thinking"]) == 1
+    assert len(by_name["response"]) == 1
+
+
+# ---------- 12. None values in unexpected places ----------
+
+
+def test_none_in_request_messages_does_not_crash(sdk):
+    response = _resp(content=[_FakeBlock("text", text="a")])
+    _record_call(model="claude-opus-4", request_messages=None,
+                 response=response, duration_ms=1)
+    spans = _drain(sdk)
+    assert any(s.name == "claude_call" for s in spans)
+
+
+def test_none_model_handled(sdk):
+    response = _resp(content=[_FakeBlock("text", text="a")])
+    _record_call(model=None, request_messages=[], response=response, duration_ms=1)
+    spans = _drain(sdk)
+    parent = next(s for s in spans if s.name == "claude_call")
+    # Cost is None when model unknown; no crash
+    assert parent.cost_usd is None
+
+
+# ---------- 13. Tool use blocks alongside thinking (real Claude scenario) ----------
+
+
+def test_tool_use_block_ignored_thinking_and_text_still_captured(sdk):
+    """Claude can return tool_use blocks alongside thinking + text.
+    Our integration only consumes thinking + text — others are
+    transparently ignored without breaking."""
+    response = _resp(
+        content=[
+            _FakeBlock("thinking", thinking="should I call the tool?"),
+            _FakeBlock("tool_use", id="t1", name="get_weather", input={"city":"SF"}),
+            _FakeBlock("text", text="Calling get_weather..."),
+        ],
+        input_tokens=20, output_tokens=80,
+    )
+    _record_call(model="claude-opus-4", request_messages=[], response=response, duration_ms=1)
+    by_name = {s.name: s for s in _drain(sdk)}
+    assert "thinking" in by_name
+    assert "response" in by_name
+    assert "should I call the tool" in by_name["thinking"].input
+    assert "get_weather" in by_name["response"].output

--- a/packages/sdk-typescript/src/integrations/anthropic.ts
+++ b/packages/sdk-typescript/src/integrations/anthropic.ts
@@ -1,0 +1,196 @@
+/**
+ * Anthropic SDK integration for Synaptic.
+ *
+ * Wraps the @anthropic-ai/sdk client's `messages.create` so each Claude
+ * call produces:
+ *   - a parent `claude_call` span (type=llm) with model, tokens, cost
+ *   - a `thinking` child span (subtype=thinking) per response
+ *   - a `response` child span (subtype=response)
+ *
+ * Same wire format as the Python SDK's
+ * `synaptic.integrations.anthropic` — the dashboard renders both
+ * identically.
+ *
+ * Usage:
+ *
+ *     import Anthropic from '@anthropic-ai/sdk';
+ *     import { instrumentAnthropic } from '@synaptic/sdk/integrations/anthropic';
+ *
+ *     const client = new Anthropic();
+ *     instrumentAnthropic(client);
+ *
+ *     await client.messages.create({
+ *       model: 'claude-opus-4-20250514',
+ *       max_tokens: 16000,
+ *       thinking: { type: 'enabled', budget_tokens: 10000 },
+ *       messages: [{ role: 'user', content: 'What is 2+2?' }],
+ *     });
+ */
+
+import { getCurrentSpan } from '../context.js';
+import { getSDK } from '../sdk.js';
+import { Span } from '../span.js';
+
+/** Pricing in USD per 1k tokens (May 2026, mirrors the Python integration). */
+const PRICES_PER_1K: Record<string, [number, number]> = {
+  'claude-opus-4': [0.015, 0.075],
+  'claude-sonnet-4': [0.003, 0.015],
+  'claude-haiku-4': [0.001, 0.005],
+};
+
+function computeCost(
+  model: string | null | undefined,
+  tin: number | null | undefined,
+  tout: number | null | undefined,
+): number | null {
+  if (!model || tin == null || tout == null) return null;
+  const m = model.toLowerCase();
+  let bestKey = '';
+  let best: [number, number] | null = null;
+  for (const [key, prices] of Object.entries(PRICES_PER_1K)) {
+    if (m.startsWith(key) && key.length > bestKey.length) {
+      bestKey = key;
+      best = prices;
+    }
+  }
+  if (!best) return null;
+  const [inp, outp] = best;
+  return Math.round(((tin * inp) / 1000 + (tout * outp) / 1000) * 1e8) / 1e8;
+}
+
+/** ~4 chars per English token — same heuristic as the Python SDK. */
+function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.max(1, Math.floor(text.length / 4));
+}
+
+interface ContentBlock {
+  type?: string;
+  thinking?: string;
+  text?: string;
+}
+
+interface AnthropicResponse {
+  content?: ContentBlock[];
+  usage?: { input_tokens?: number; output_tokens?: number };
+}
+
+interface AnthropicMessages {
+  create: (...args: unknown[]) => Promise<AnthropicResponse> | AnthropicResponse;
+}
+
+interface AnthropicLikeClient {
+  messages: AnthropicMessages;
+}
+
+const PATCH_MARKER = '__synapticAnthropicWrapped';
+
+function makeChild(parent: Span, name: string, subtype?: string): Span {
+  const child = Span.create(name, 'llm', parent);
+  child.span_subtype = subtype ?? null;
+  child.session_id = parent.session_id;
+  return child;
+}
+
+function recordCall(
+  model: string | null,
+  requestMessages: unknown,
+  response: AnthropicResponse,
+  outerSpan: Span | undefined,
+): void {
+  try {
+    // Parent span — anchored under the surrounding @synaptic.trace if any
+    const parent = outerSpan
+      ? Span.create('claude_call', 'llm', outerSpan)
+      : Span.create('claude_call', 'llm');
+    parent.model = model;
+    parent.provider = 'anthropic';
+    parent.session_id = outerSpan?.session_id ?? null;
+    parent.setInput({ messages: requestMessages });
+
+    const content = response.content ?? [];
+    const thinkingBlocks = content.filter((b) => b?.type === 'thinking');
+    const textBlocks = content.filter((b) => b?.type === 'text');
+
+    const inputTokens = response.usage?.input_tokens ?? null;
+    const outputTokens = response.usage?.output_tokens ?? null;
+    parent.tokens_input = inputTokens;
+    parent.tokens_output = outputTokens;
+    parent.cost_usd = computeCost(model, inputTokens, outputTokens);
+
+    const thinkingText = thinkingBlocks
+      .map((b) => b.thinking ?? '')
+      .join('');
+    const thinkingTokensEst = estimateTokens(thinkingText);
+    if (thinkingBlocks.length > 0) {
+      parent.thinking_tokens = thinkingTokensEst;
+    }
+
+    const responseText = textBlocks.map((b) => b.text ?? '').join('');
+    parent.setOutput({ text: responseText });
+    parent.end();
+
+    const sdk = getSDK();
+    sdk.submit(parent);
+
+    if (thinkingBlocks.length > 0) {
+      const thinkingSpan = makeChild(parent, 'thinking', 'thinking');
+      thinkingSpan.model = model;
+      thinkingSpan.provider = 'anthropic';
+      thinkingSpan.thinking_tokens = thinkingTokensEst;
+      thinkingSpan.setInput({ thinking: thinkingText });
+      thinkingSpan.cost_usd = computeCost(model, 0, thinkingTokensEst);
+      thinkingSpan.end();
+      sdk.submit(thinkingSpan);
+    }
+
+    if (textBlocks.length > 0) {
+      const responseSpan = makeChild(parent, 'response', 'response');
+      responseSpan.model = model;
+      responseSpan.provider = 'anthropic';
+      // Subtract estimated thinking from output for response-only count
+      if (outputTokens != null && thinkingTokensEst) {
+        responseSpan.tokens_output = Math.max(
+          0,
+          outputTokens - thinkingTokensEst,
+        );
+      } else {
+        responseSpan.tokens_output = outputTokens;
+      }
+      responseSpan.cost_usd = computeCost(model, 0, responseSpan.tokens_output);
+      responseSpan.setOutput({ text: responseText });
+      responseSpan.end();
+      sdk.submit(responseSpan);
+    }
+  } catch {
+    // Best-effort — Synaptic must never break the agent (Rule 7)
+  }
+}
+
+/**
+ * Wrap an Anthropic client's `messages.create` so every Claude call
+ * is recorded as a parent + thinking + response trio. Idempotent.
+ */
+export function instrumentAnthropic(client: AnthropicLikeClient): void {
+  const messages = client.messages;
+  if (!messages) return;
+  const original = messages.create;
+  if (typeof original !== 'function') return;
+  if ((original as { [PATCH_MARKER]?: boolean })[PATCH_MARKER]) return;
+
+  const wrapped = async function wrapped(
+    this: unknown,
+    ...args: unknown[]
+  ): Promise<AnthropicResponse> {
+    const opts = (args[0] ?? {}) as { model?: string; messages?: unknown };
+    const outer = getCurrentSpan();
+    const result = await Promise.resolve(original.apply(this, args));
+    recordCall(opts.model ?? null, opts.messages, result, outer);
+    return result;
+  };
+  Object.defineProperty(wrapped, PATCH_MARKER, { value: true });
+  messages.create = wrapped as typeof messages.create;
+}
+
+// Exported for unit tests
+export const __test__ = { computeCost, estimateTokens, recordCall };

--- a/packages/sdk-typescript/src/span.ts
+++ b/packages/sdk-typescript/src/span.ts
@@ -14,6 +14,21 @@ export interface SpanData {
   /** Optional session grouping. Populated from the current session() context
    *  or via trace(fn, { sessionId }). Default null preserves prior behavior. */
   session_id: string | null;
+  /** Optional discriminator for spans that originate from a typed
+   *  integration. Currently used for Claude extended-thinking — the
+   *  integration emits `claude_call` parents with `thinking` and
+   *  `response` children. Default null = ordinary span. */
+  span_subtype?: 'thinking' | 'response' | string | null;
+  /** Estimated tokens spent inside a thinking block. Only set on
+   *  thinking spans. Anthropic doesn't break thinking out of
+   *  output_tokens — we estimate from text length. */
+  thinking_tokens?: number | null;
+  /** LLM model identifier (e.g. "claude-opus-4-20250514"). */
+  model?: string | null;
+  provider?: string | null;
+  tokens_input?: number | null;
+  tokens_output?: number | null;
+  cost_usd?: number | null;
 }
 
 function serialize(value: unknown, maxSize: number): string | null {
@@ -44,6 +59,13 @@ export class Span {
   ended_at: string | null = null;
   error: string | null = null;
   session_id: string | null = null;
+  span_subtype: 'thinking' | 'response' | string | null = null;
+  thinking_tokens: number | null = null;
+  model: string | null = null;
+  provider: string | null = null;
+  tokens_input: number | null = null;
+  tokens_output: number | null = null;
+  cost_usd: number | null = null;
 
   private constructor(
     id: string,
@@ -103,6 +125,13 @@ export class Span {
       ended_at: this.ended_at,
       error: this.error,
       session_id: this.session_id,
+      span_subtype: this.span_subtype,
+      thinking_tokens: this.thinking_tokens,
+      model: this.model,
+      provider: this.provider,
+      tokens_input: this.tokens_input,
+      tokens_output: this.tokens_output,
+      cost_usd: this.cost_usd,
     };
   }
 }

--- a/packages/sdk-typescript/tests/anthropic.test.ts
+++ b/packages/sdk-typescript/tests/anthropic.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from 'vitest';
+import {
+  __test__,
+  instrumentAnthropic,
+} from '../src/integrations/anthropic.js';
+import { trace } from '../src/trace.js';
+import { makeTestSDK } from './helpers.js';
+
+const { computeCost, estimateTokens, recordCall } = __test__;
+
+function fakeResponse(opts: {
+  thinking?: string;
+  text?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}) {
+  const content: Array<{ type: string; thinking?: string; text?: string }> = [];
+  if (opts.thinking !== undefined)
+    content.push({ type: 'thinking', thinking: opts.thinking });
+  if (opts.text !== undefined) content.push({ type: 'text', text: opts.text });
+  return {
+    content,
+    usage: {
+      input_tokens: opts.inputTokens ?? 10,
+      output_tokens: opts.outputTokens ?? 20,
+    },
+  };
+}
+
+async function drain(sdk: ReturnType<typeof makeTestSDK>['sdk']) {
+  await sdk.flush();
+}
+
+// ---------- pricing math ----------
+
+describe('computeCost', () => {
+  test('opus 1k/1k matches Python implementation', () => {
+    expect(computeCost('claude-opus-4-20250514', 1000, 1000)).toBeCloseTo(
+      0.09,
+      6,
+    );
+  });
+  test('unknown model returns null', () => {
+    expect(computeCost('not-a-claude', 100, 100)).toBeNull();
+  });
+  test('zero input still computes for thinking spans (output rate)', () => {
+    expect(computeCost('claude-opus-4', 0, 1000)).toBeCloseTo(0.075, 6);
+  });
+  test('null tokens return null', () => {
+    expect(computeCost('claude-opus-4', null, 100)).toBeNull();
+    expect(computeCost('claude-opus-4', 100, null)).toBeNull();
+  });
+});
+
+describe('estimateTokens', () => {
+  test('empty returns 0', () => {
+    expect(estimateTokens('')).toBe(0);
+  });
+  test('uses ~4 chars per token', () => {
+    expect(estimateTokens('a'.repeat(40))).toBe(10);
+  });
+});
+
+// ---------- core integration ----------
+
+describe('recordCall', () => {
+  test('emits parent + thinking + response with correct relationships', async () => {
+    const { sdk, exporter } = makeTestSDK();
+    const response = fakeResponse({
+      thinking: 'Let me reason: 2+2 means combining two and two.',
+      text: '2+2 equals 4.',
+      inputTokens: 12,
+      outputTokens: 400,
+    });
+
+    recordCall('claude-opus-4-20250514', [], response, undefined);
+    await drain(sdk);
+
+    const byName = Object.fromEntries(
+      exporter.spans.map((s) => [s.name, s]),
+    );
+    expect(byName.claude_call).toBeDefined();
+    expect(byName.thinking).toBeDefined();
+    expect(byName.response).toBeDefined();
+
+    const parent = byName.claude_call;
+    expect(byName.thinking.parent_span_id).toBe(parent.id);
+    expect(byName.response.parent_span_id).toBe(parent.id);
+    expect(byName.thinking.trace_id).toBe(parent.trace_id);
+
+    expect(byName.thinking.span_subtype).toBe('thinking');
+    expect(byName.response.span_subtype).toBe('response');
+    expect(byName.thinking.thinking_tokens).toBeGreaterThan(0);
+    expect(byName.thinking.cost_usd).toBeGreaterThan(0);
+    expect(byName.thinking.input).toContain('combining');
+    expect(byName.response.output).toContain('4');
+  });
+
+  test('no thinking blocks: only parent + response emitted', async () => {
+    const { sdk, exporter } = makeTestSDK();
+    recordCall(
+      'claude-haiku-4',
+      [],
+      fakeResponse({ text: 'hello' }),
+      undefined,
+    );
+    await drain(sdk);
+    const names = exporter.spans.map((s) => s.name);
+    expect(names).toContain('claude_call');
+    expect(names).toContain('response');
+    expect(names).not.toContain('thinking');
+  });
+
+  test('unknown model: cost is null but call still recorded', async () => {
+    const { sdk, exporter } = makeTestSDK();
+    recordCall(
+      'some-future-model',
+      [],
+      fakeResponse({ thinking: 'r', text: 'a' }),
+      undefined,
+    );
+    await drain(sdk);
+    const parent = exporter.spans.find((s) => s.name === 'claude_call')!;
+    expect(parent.cost_usd).toBeNull();
+    expect(parent.model).toBe('some-future-model');
+  });
+
+  test('toJSON serializes the new fields on every span', async () => {
+    const { sdk, exporter } = makeTestSDK();
+    recordCall(
+      'claude-opus-4',
+      [],
+      fakeResponse({ thinking: 'r', text: 'a' }),
+      undefined,
+    );
+    await drain(sdk);
+    for (const s of exporter.spans) {
+      const j = s.toJSON();
+      expect(j).toHaveProperty('span_subtype');
+      expect(j).toHaveProperty('thinking_tokens');
+      expect(j).toHaveProperty('model');
+      expect(j).toHaveProperty('provider');
+      expect(j).toHaveProperty('tokens_input');
+      expect(j).toHaveProperty('tokens_output');
+      expect(j).toHaveProperty('cost_usd');
+    }
+  });
+});
+
+// ---------- instrument & call ----------
+
+describe('instrumentAnthropic', () => {
+  test('wraps client.messages.create idempotently', async () => {
+    const { sdk, exporter } = makeTestSDK();
+    let invocations = 0;
+    const fakeClient = {
+      messages: {
+        create: async () => {
+          invocations += 1;
+          return fakeResponse({ thinking: 'r', text: 'a' });
+        },
+      },
+    };
+
+    instrumentAnthropic(fakeClient);
+    instrumentAnthropic(fakeClient);
+    instrumentAnthropic(fakeClient);
+
+    await fakeClient.messages.create({ model: 'claude-opus-4', messages: [] });
+    await sdk.flush();
+
+    expect(invocations).toBe(1);
+    const names = exporter.spans.map((s) => s.name).sort();
+    expect(names).toEqual(['claude_call', 'response', 'thinking']);
+  });
+
+  test('inside trace(), claude_call attaches to outer span', async () => {
+    const { sdk, exporter } = makeTestSDK();
+    const fakeClient = {
+      messages: {
+        create: async () =>
+          fakeResponse({ thinking: 'reasoning', text: 'answer' }),
+      },
+    };
+    instrumentAnthropic(fakeClient);
+
+    const myAgent = trace(
+      async () => {
+        await fakeClient.messages.create({
+          model: 'claude-opus-4',
+          messages: [],
+        });
+      },
+      { name: 'my_agent' },
+    );
+    await myAgent();
+    await sdk.flush();
+
+    const spans = exporter.spans;
+    const outer = spans.find((s) => s.name === 'my_agent');
+    const claudeCall = spans.find((s) => s.name === 'claude_call');
+    const thinking = spans.find((s) => s.name === 'thinking');
+
+    expect(outer).toBeDefined();
+    expect(claudeCall).toBeDefined();
+    expect(claudeCall!.trace_id).toBe(outer!.trace_id);
+    expect(claudeCall!.parent_span_id).toBe(outer!.id);
+    expect(thinking!.parent_span_id).toBe(claudeCall!.id);
+  });
+
+  test('original create exception propagates and no spans land', async () => {
+    const { sdk, exporter } = makeTestSDK();
+    const fakeClient = {
+      messages: {
+        create: async () => {
+          throw new Error('rate limited');
+        },
+      },
+    };
+    instrumentAnthropic(fakeClient);
+
+    await expect(
+      fakeClient.messages.create({ model: 'claude-opus-4', messages: [] }),
+    ).rejects.toThrow('rate limited');
+    await sdk.flush();
+    expect(exporter.spans).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #5

## Summary
- New Anthropic integration in both Python (`synaptic.integrations.anthropic`) and TypeScript (`@synaptic/sdk/integrations/anthropic`) SDKs. Wraps `messages.create` and `messages.stream` (sync + async) so every Claude call becomes a `claude_call` parent span with `thinking` and `response` children.
- Spans table gains `span_subtype` and `thinking_tokens` columns. `ALTER TABLE … IF NOT EXISTS` migrates existing DBs in place; legacy data preserved.
- Dashboard renders thinking rows with a brain emoji, violet highlight, `THINKING` badge, and an expandable Reasoning panel. Trace header gains a thinking-vs-response token + cost breakdown. Empty Input/Output fields are hidden on subtyped rows.
- Docker image now installs the `anthropic` extra so the integration is importable out of the box.

## Test plan
- [x] Python SDK: 101 tests (`pytest -v` in `packages/sdk-python`) — includes 14 anthropic core, 2 streaming, 14 stress (concurrency, unicode, 1MB reasoning, double-instrumentation, etc.)
- [x] TypeScript SDK: 59 tests (`npm test` in `packages/sdk-typescript`) — includes 13 anthropic parity tests
- [x] API: 59 tests (`pytest -v` in `packages/api`) — includes 10 torture tests covering legacy-DB migration, concurrent ingest, 500KB reasoning, unicode round-trip
- [x] Playwright thinking specs: 8 tests against running stack (1 main + 7 torture: multi-thinking, empty reasoning, 100KB reasoning, mixed thinking+tool+response, mid-stream traces, unknown subtype, unicode)
- [x] Live verification: real `anthropic.types.Message` → SDK → API → DuckDB → dashboard render
- [x] Docker image rebuilt and smoke-tested with the new code; legacy data volume migrates cleanly
- [x] CI workflow updated to install `[test,langchain,anthropic]` so the new tests don't silently skip