### PR TITLE
fix(mastra): capture tool input/output from string-valued OTel attributes

### DIFF
--- a/packages/integrations/mastra/src/exporter.ts
+++ b/packages/integrations/mastra/src/exporter.ts
@@ -67,17 +67,47 @@ const DEFAULT_TIMEOUT_MS = 5_000;
 const DEFAULT_PROJECT = 'mastra';
 const DEFAULT_MAX_PAYLOAD = 10_240;
 
-/** Convert a value of any shape to a JSON string with size cap. */
+/**
+ * Convert an OTel attribute value to a string suitable for the
+ * Synaptic `input` / `output` field. OTel only delivers primitives
+ * or arrays of primitives, so the cases are:
+ *   - string: pass through (already JSON in most Mastra/Vercel
+ *     conventions — re-stringifying would double-encode)
+ *   - array of strings: join with newlines (each Vercel-style
+ *     prompt message is its own array element)
+ *   - other primitives: String(value)
+ *   - object (rare; only if the SDK ever surfaces them): JSON.stringify
+ *
+ * Always capped at maxSize.
+ */
 function serialize(value: unknown, maxSize: number): string | null {
   if (value === null || value === undefined) return null;
   let s: string;
-  try {
-    s = JSON.stringify(value);
-    if (s === undefined) s = String(value);
-  } catch {
+  if (typeof value === 'string') {
+    s = value;
+  } else if (Array.isArray(value)) {
+    s = value
+      .map((v) => (typeof v === 'string' ? v : safeStringify(v)))
+      .join('\n');
+  } else if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint'
+  ) {
     s = String(value);
+  } else {
+    s = safeStringify(value);
   }
   return s.length > maxSize ? s.slice(0, maxSize) : s;
+}
+
+function safeStringify(v: unknown): string {
+  try {
+    const result = JSON.stringify(v);
+    return result === undefined ? String(v) : result;
+  } catch {
+    return String(v);
+  }
 }
 
 /** OTel `[seconds, nanos]` HrTime → ISO-8601 string in UTC. */
@@ -151,16 +181,29 @@ export function otelSpanToSynaptic(
   const tokensOut = attrNumber(attrs, 'gen_ai.usage.output_tokens');
   const toolName = attrString(attrs, 'gen_ai.tool.name');
 
-  // OTel surfaces the prompt and completion via either
-  // `gen_ai.prompt`/`gen_ai.completion` (older convention) or
-  // `gen_ai.input.messages`/`gen_ai.output.messages` (newer). We
-  // accept either.
+  // OTel attribute values must be primitives or arrays of primitives —
+  // object values are silently dropped by the SDK. So we look for
+  // attributes Mastra and the Vercel AI SDK actually emit: strings
+  // (often JSON-encoded), arrays of strings, or simple scalars.
+  //
+  // Order of preference reflects how widely each key is used in the
+  // Mastra/Vercel-AI ecosystem:
+  //   ai.prompt.messages / ai.response.text  — Vercel AI SDK (Mastra)
+  //   gen_ai.input.messages / .output.messages — newer OTel GenAI
+  //   gen_ai.prompt / .completion              — older OTel GenAI
+  //   ai.toolCall.args / .result               — Vercel AI tool calls
+  //   mastra.input / mastra.output             — pre-stringified
   const input =
+    attrs['ai.prompt.messages'] ??
+    attrs['ai.toolCall.args'] ??
     attrs['gen_ai.input.messages'] ??
     attrs['gen_ai.prompt'] ??
     attrs['mastra.input'] ??
     null;
   const output =
+    attrs['ai.response.text'] ??
+    attrs['ai.response.object'] ??
+    attrs['ai.toolCall.result'] ??
     attrs['gen_ai.output.messages'] ??
     attrs['gen_ai.completion'] ??
     attrs['mastra.output'] ??

--- a/packages/integrations/mastra/tests/exporter.test.ts
+++ b/packages/integrations/mastra/tests/exporter.test.ts
@@ -154,6 +154,62 @@ describe('otelSpanToSynaptic', () => {
     expect(out.output).toContain('c');
   });
 
+  test('Vercel AI SDK / Mastra ai.prompt.messages and ai.response.text', () => {
+    // These are the keys Mastra actually emits in production. OTel
+    // attribute constraints mean prompt.messages is JSON-encoded as
+    // a string; response.text is a plain string. Don't double-encode.
+    const promptJson = JSON.stringify([
+      { role: 'user', content: 'What is the capital of France?' },
+    ]);
+    const span = makeSpan({
+      attributes: {
+        'ai.prompt.messages': promptJson,
+        'ai.response.text': 'The capital of France is Paris.',
+      },
+    });
+    const out = otelSpanToSynaptic(span);
+    // The pre-stringified JSON must NOT be wrapped in extra quotes
+    expect(out.input).toBe(promptJson);
+    expect(out.output).toBe('The capital of France is Paris.');
+  });
+
+  test('Vercel AI tool call: ai.toolCall.args + .result', () => {
+    const argsJson = JSON.stringify({ query: 'capital of France' });
+    const resultJson = JSON.stringify({
+      results: ['Paris is the capital.'],
+    });
+    const span = makeSpan({
+      attributes: {
+        'ai.toolCall.args': argsJson,
+        'ai.toolCall.result': resultJson,
+        'gen_ai.tool.name': 'search_web',
+      },
+    });
+    const out = otelSpanToSynaptic(span);
+    expect(out.type).toBe('tool');
+    expect(out.tool_name).toBe('search_web');
+    expect(out.input).toBe(argsJson);
+    expect(out.output).toBe(resultJson);
+  });
+
+  test('array-of-strings attribute (e.g. message list) joins with newlines', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.prompt': ['system: be helpful', 'user: hello'],
+      },
+    });
+    const out = otelSpanToSynaptic(span);
+    expect(out.input).toBe('system: be helpful\nuser: hello');
+  });
+
+  test('numeric and boolean attributes get stringified, not dropped', () => {
+    const span = makeSpan({
+      attributes: { 'mastra.input': 42 },
+    });
+    const out = otelSpanToSynaptic(span);
+    expect(out.input).toBe('42');
+  });
+
   test('session_id resolves from common conventions', () => {
     const a = otelSpanToSynaptic(
       makeSpan({ attributes: { 'session.id': 's-123' } }),


### PR DESCRIPTION
## Summary
Bug fix following PR #7. The original `@synaptic/mastra` mapper read OTel attributes assuming they could be JS objects (`mastra.input` / `mastra.output`). OpenTelemetry attribute values must be primitives or arrays of primitives — the SDK silently drops object values — so the input/output fields ended up empty on the dashboard even when the user-facing demo set them.

## Reproduction
Trace `2e0f31db60051e925325b23adce489df` had a `search_web` tool span with no input or output visible. After this fix, trace `aae7c7a51ff360feb7f83405bc6e5428` shows the same span with the search query as input and the full result set as output.

## Fix
`otelSpanToSynaptic()` now reads the keys Mastra and the Vercel AI SDK actually emit:
- `ai.prompt.messages` (JSON-encoded message array)
- `ai.response.text` / `ai.response.object`
- `ai.toolCall.args` / `ai.toolCall.result` (tool spans)
- `gen_ai.input.messages` / `gen_ai.output.messages` (newer OTel GenAI)
- `gen_ai.prompt` / `gen_ai.completion` (older fallback)
- `mastra.input` / `mastra.output` (pre-stringified by user)

`serialize()` no longer double-encodes string values, joins arrays of strings with newlines, and coerces numeric/boolean attribute values via `String()` instead of dropping them.

## Test plan
- [x] 4 new tests covering Vercel AI SDK + Mastra conventions, array joining, primitive coercion
- [x] **38/38** `@synaptic/mastra` tests pass (was 34, +4)
- [x] Verified live: tool span input `{"query":"capital of France"}` and output `{"results":[…]}` render correctly in the dashboard
- [x] Existing 219 tests across other packages unaffected (no other package modified)