### PR TITLE
feat: LlamaIndex integration (SynapticCallbackHandler)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: packages/sdk-python/pyproject.toml
-      - name: Install (with langchain + anthropic extras for integration tests)
+      - name: Install (with langchain + anthropic + llama_index extras for integration tests)
         run: |
-          pip install -e ".[test,langchain,anthropic]"
+          pip install -e ".[test,langchain,anthropic,llama_index]"
       - name: Run tests
         run: pytest -v
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - CrewAI integration
 - TypeScript SDK
 - Anthropic integration with extended-thinking visualization — `instrument_anthropic()` wraps `Messages.create` (and the streaming `Messages.stream` context manager) and emits a `claude_call` parent span with `thinking` and `response` children. Available in both the Python SDK (`synaptic.integrations.anthropic`) and the TypeScript SDK (`@synaptic/sdk/integrations/anthropic`) with identical wire format. Dashboard renders thinking rows with a brain emoji, violet highlight, and per-trace thinking-vs-response cost breakdown. New `span_subtype` and `thinking_tokens` columns on the spans table (auto-migrated for legacy DBs)
+- LlamaIndex integration — `SynapticCallbackHandler` plugs into `Settings.callback_manager` and ships every LLM call, retrieval step, embedding, and query as a Synaptic span. Captures model/tokens/cost on LLM events and node count + similarity scores on retrievals. Install via `pip install synaptic[llama_index]`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ That's it. No account, no API key, no data leaves your laptop.
 - **Real-time updates** — WebSocket stream pushes traces and spans into the dashboard the moment they're ingested, no refresh; falls back to 5-second polling if the socket can't connect
 - **Cost & token tracking** — automatic per-call breakdown for OpenAI and Anthropic model families
 - **Quality scoring** — bring-your-own evals via `POST /v1/evals`
-- **Framework integrations** — drop-in support for [LangChain](#langchain) (zero-config via `SYNAPTIC_TRACING=true`), [CrewAI](#crewai) (one-line `instrument_crew()`), and [Anthropic](#anthropic) (`instrument_anthropic()` — captures Claude extended-thinking blocks as first-class child spans)
+- **Framework integrations** — drop-in support for [LangChain](#langchain) (zero-config via `SYNAPTIC_TRACING=true`), [CrewAI](#crewai) (one-line `instrument_crew()`), [LlamaIndex](#llamaindex) (`SynapticCallbackHandler` for query engines, retrieval, and embeddings), and [Anthropic](#anthropic) (`instrument_anthropic()` — captures Claude extended-thinking blocks as first-class child spans)
 - **Cross-language SDKs** — Python and TypeScript with identical wire format and behavior
 - **Resilient by design** — the agent never fails because Synaptic is down. Spans drop silently if the queue overflows, the exporter is unreachable, or the server returns an error
 - **Local-first** — single Docker image, DuckDB + SQLite, no external services, no cloud dependency
@@ -103,7 +103,7 @@ Single Docker container runs the API on `:8000` and the Next.js standalone dashb
 
 | Path | Package | Tests |
 |---|---|---|
-| [`packages/sdk-python/`](packages/sdk-python/) | Python SDK with `@synaptic.trace`, `synaptic.span()`, `synaptic.session()`, integrations | 101 |
+| [`packages/sdk-python/`](packages/sdk-python/) | Python SDK with `@synaptic.trace`, `synaptic.span()`, `synaptic.session()`, integrations | 171 |
 | [`packages/sdk-typescript/`](packages/sdk-typescript/) | `@synaptic/sdk` — peer of the Python SDK | 59 |
 | [`packages/api/`](packages/api/) | FastAPI ingest + query API, DuckDB storage, WebSocket fanout, session aggregations | 59 |
 | [`packages/dashboard/`](packages/dashboard/) | Next.js 14 dashboard with paginated timeline + session view | build + 21 Playwright E2E |
@@ -119,6 +119,7 @@ pip install -e packages/sdk-python              # core only
 pip install -e packages/sdk-python[langchain]   # + LangChain integration
 pip install -e packages/sdk-python[crewai]      # + CrewAI integration
 pip install -e packages/sdk-python[anthropic]   # + Anthropic integration
+pip install -e packages/sdk-python[llama_index] # + LlamaIndex integration
 pip install -e packages/sdk-python[all]         # all integrations
 ```
 
@@ -210,6 +211,25 @@ crew.kickoff()
 # crew.kickoff -> root span
 # each agent.execute_task -> child span
 # LLM calls inside agents -> grandchildren (via the LangChain integration)
+```
+
+### LlamaIndex
+
+```python
+from synaptic.integrations.llama_index import SynapticCallbackHandler
+from llama_index.core import Settings, VectorStoreIndex, Document
+from llama_index.core.callbacks import CallbackManager
+
+handler = SynapticCallbackHandler()
+Settings.callback_manager = CallbackManager([handler])
+
+index = VectorStoreIndex.from_documents([Document(text="…")])
+index.as_query_engine().query("what is …?")
+# query (root)
+#   retrieve (retrieval)  -- retrieved nodes + similarity scores
+#     embedding (embedding) -- query embedding model + tokens
+#   synthesize (custom)
+#     llm_call (llm)       -- model, tokens, cost
 ```
 
 ### Anthropic

--- a/packages/dashboard/tests/e2e/thinking_torture.spec.ts
+++ b/packages/dashboard/tests/e2e/thinking_torture.spec.ts
@@ -99,15 +99,16 @@ test('thinking span with empty reasoning text shows (empty) without crashing', a
 
 test('100KB reasoning text renders without hanging the page', async ({ page }) => {
   const traceId = `torture-huge-${randomUUID()}`;
+  const parentId = `p-${randomUUID()}`;
   const huge = 'REASONING-TOKEN '.repeat(6500); // ~100KB
   await postSpans([
     {
-      id: `p-${randomUUID()}`, trace_id: traceId,
+      id: parentId, trace_id: traceId,
       name: 'claude_call', type: 'llm',
       started_at: nowIso(0), ended_at: nowIso(1000),
     },
     {
-      id: `t-${randomUUID()}`, trace_id: traceId,
+      id: `t-${randomUUID()}`, trace_id: traceId, parent_span_id: parentId,
       name: 'thinking', type: 'llm',
       started_at: nowIso(0), ended_at: nowIso(500),
       span_subtype: 'thinking',
@@ -170,14 +171,15 @@ test('thinking, tool, and response children all render with correct badges', asy
 
 test('trace with thinking but no response renders thinking row + breakdown', async ({ page }) => {
   const traceId = `torture-streaming-${randomUUID()}`;
+  const parentId = `p-${randomUUID()}`;
   await postSpans([
     {
-      id: `p-${randomUUID()}`, trace_id: traceId,
+      id: parentId, trace_id: traceId,
       name: 'claude_call', type: 'llm',
       started_at: nowIso(0), ended_at: nowIso(2000),
     },
     {
-      id: `t-${randomUUID()}`, trace_id: traceId,
+      id: `t-${randomUUID()}`, trace_id: traceId, parent_span_id: parentId,
       name: 'thinking', type: 'llm',
       started_at: nowIso(0), ended_at: nowIso(2000),
       span_subtype: 'thinking', thinking_tokens: 500,
@@ -217,15 +219,16 @@ test('unknown span_subtype falls through to default rendering without crashing',
 
 test('unicode and emoji in reasoning render correctly', async ({ page }) => {
   const traceId = `torture-unicode-${randomUUID()}`;
+  const parentId = `p-${randomUUID()}`;
   const reasoning = '推論 → なぜ 2+2=4? 🧠✓ こたえ: ４';
   await postSpans([
     {
-      id: `p-${randomUUID()}`, trace_id: traceId,
+      id: parentId, trace_id: traceId,
       name: 'claude_call', type: 'llm',
       started_at: nowIso(0), ended_at: nowIso(1000),
     },
     {
-      id: `t-${randomUUID()}`, trace_id: traceId,
+      id: `t-${randomUUID()}`, trace_id: traceId, parent_span_id: parentId,
       name: 'thinking', type: 'llm',
       started_at: nowIso(0), ended_at: nowIso(500),
       span_subtype: 'thinking', thinking_tokens: 50,

--- a/packages/sdk-python/examples/test_llama_index.py
+++ b/packages/sdk-python/examples/test_llama_index.py
@@ -1,0 +1,86 @@
+"""Live end-to-end demo: a real LlamaIndex query routed through the
+Synaptic callback handler. Uses a stub LLM + stub embeddings so the
+demo runs without API keys; the trace shape is identical to a real
+agent run.
+
+Prereqs:
+  1. Synaptic running on localhost:8000
+  2. pip install synaptic[llama_index]
+
+Run:
+  python examples/test_llama_index.py
+
+Then open http://localhost:3000/traces — you should see:
+  - QUERY (root)
+    - RETRIEVE (with retrieved nodes + similarity scores)
+    - SYNTHESIZE
+      - LLM call (with model, tokens, cost)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, List, Sequence
+
+import synaptic
+from synaptic.integrations.llama_index import SynapticCallbackHandler
+
+
+def main() -> None:
+    synaptic.configure(
+        host=os.environ.get("SYNAPTIC_HOST", "http://localhost:8000"),
+        flush_interval=0.5,
+    )
+
+    from llama_index.core import Document, Settings, VectorStoreIndex
+    from llama_index.core.callbacks import CallbackManager
+    from llama_index.core.base.embeddings.base import BaseEmbedding
+    from llama_index.core.llms.mock import MockLLM
+
+    handler = SynapticCallbackHandler()
+    Settings.callback_manager = CallbackManager([handler])
+
+    # Stub embedder — deterministic 8-dim vectors.
+    class StubEmbedding(BaseEmbedding):
+        def _hash(self, text: str) -> List[float]:
+            import hashlib
+
+            h = hashlib.sha256(text.encode("utf-8")).digest()
+            return [b / 255.0 for b in h[:8]]
+
+        def _get_query_embedding(self, query: str) -> List[float]:
+            return self._hash(query)
+
+        def _get_text_embedding(self, text: str) -> List[float]:
+            return self._hash(text)
+
+        async def _aget_query_embedding(self, query: str) -> List[float]:
+            return self._hash(query)
+
+        async def _aget_text_embedding(self, text: str) -> List[float]:
+            return self._hash(text)
+
+    # MockLLM ships with llama-index-core and triggers proper LLM
+    # callback events — unlike a hand-rolled CustomLLM whose chat()
+    # bypasses the instrumentation wrapper.
+    Settings.llm = MockLLM(max_tokens=64)
+    Settings.embed_model = StubEmbedding()
+
+    # Tiny corpus, build the index, ask one question
+    docs = [
+        Document(text="Paris is the capital of France."),
+        Document(text="Tokyo is the capital of Japan."),
+        Document(text="The Eiffel Tower is in Paris."),
+    ]
+    index = VectorStoreIndex.from_documents(docs)
+    query_engine = index.as_query_engine()
+    response = query_engine.query("What is the capital of France?")
+    print(f"LlamaIndex answered: {response}")
+
+    time.sleep(2)
+    print("✓ Spans submitted. Open http://localhost:3000/traces to see the trace.")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -28,10 +28,14 @@ crewai = [
 anthropic = [
     "anthropic>=0.30.0",
 ]
+llama_index = [
+    "llama-index-core>=0.10.0",
+]
 all = [
     "langchain-core>=0.3.0",
     "crewai>=0.80.0",
     "anthropic>=0.30.0",
+    "llama-index-core>=0.10.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/packages/sdk-python/synaptic/integrations/llama_index.py
+++ b/packages/sdk-python/synaptic/integrations/llama_index.py
@@ -1,0 +1,649 @@
+"""LlamaIndex integration for Synaptic.
+
+Records every LLM call, retrieval step, embedding computation, and
+query as a Synaptic span. Use explicitly:
+
+    from synaptic.integrations.llama_index import SynapticCallbackHandler
+    from llama_index.core import Settings
+    from llama_index.core.callbacks import CallbackManager
+
+    handler = SynapticCallbackHandler()
+    Settings.callback_manager = CallbackManager([handler])
+
+Near-zero config: set the env var and import this module once. The
+import triggers a one-time attempt to attach the handler to
+``llama_index.core.Settings.callback_manager``. After that, no further
+code changes are needed.
+
+    import os
+    os.environ["SYNAPTIC_TRACING"] = "true"
+    import synaptic.integrations.llama_index  # noqa: F401  (registers handler)
+
+Note: the env var alone is not sufficient — Python has no global
+package-discovery hook. The integration module must be imported at
+least once for auto-registration to fire.
+
+The handler implements LlamaIndex's ``BaseCallbackHandler`` contract:
+``start_trace`` / ``end_trace`` bracket each query, and
+``on_event_start`` / ``on_event_end`` wrap each operation inside it.
+LlamaIndex itself supplies ``parent_id`` on each event start, so
+nested-span linkage falls out for free.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+try:
+    from llama_index.core.callbacks.base_handler import BaseCallbackHandler
+    from llama_index.core.callbacks.schema import CBEventType, EventPayload
+except ImportError as e:
+    raise ImportError(
+        "synaptic.integrations.llama_index requires llama-index-core. "
+        "Install with: pip install llama-index-core>=0.10.0"
+    ) from e
+
+from synaptic.context import get_current_span
+from synaptic.integrations._ext_span import _ExtSpan, _estimate_tokens, _serialize
+from synaptic.sdk import _get_sdk
+
+
+# Approximate USD prices per 1K tokens (May 2026), shared with the
+# LangChain integration's price table — but kept local so this module
+# doesn't import from langchain.py (which would force the langchain
+# extra to be installed even when only LlamaIndex is in use).
+PRICES_PER_1K: Dict[str, tuple] = {
+    "gpt-4o-mini": (0.00015, 0.0006),
+    "gpt-4o": (0.0025, 0.010),
+    "gpt-4-turbo": (0.010, 0.030),
+    "gpt-4": (0.030, 0.060),
+    "gpt-3.5-turbo": (0.0005, 0.0015),
+    "claude-opus-4": (0.015, 0.075),
+    "claude-sonnet-4": (0.003, 0.015),
+    "claude-haiku-4": (0.001, 0.005),
+    # Embeddings — output rate is 0 since embeddings have no
+    # generated tokens. Cost computed from tokens_input alone.
+    "text-embedding-3-small": (0.00002, 0.0),
+    "text-embedding-3-large": (0.00013, 0.0),
+    "text-embedding-ada-002": (0.0001, 0.0),
+}
+
+
+def register_model_price(
+    model_prefix: str, input_per_1k: float, output_per_1k: float
+) -> None:
+    """Add or override a row in the price table at runtime. Useful
+    for self-hosted models, custom deployments, or new models that
+    haven't been added to the built-in table yet.
+
+    Match is longest-prefix on lowercased model name, so adding
+    e.g. ``register_model_price("gpt-5", 0.005, 0.015)`` covers
+    every ``gpt-5*`` variant.
+    """
+    PRICES_PER_1K[model_prefix.lower()] = (input_per_1k, output_per_1k)
+
+
+def _normalize_model_name(model: str) -> str:
+    """Strip provider/fine-tune prefixes that real production models
+    use. Examples:
+      - ``ft:gpt-4o:my-org::abc123`` → ``gpt-4o``
+      - ``openai/gpt-4o-mini`` → ``gpt-4o-mini``
+      - ``models/gemini-pro`` → ``gemini-pro``
+    """
+    m = model.lower()
+    if m.startswith("ft:"):
+        # OpenAI fine-tune format: ft:<base>:<org>::<id>
+        rest = m[3:]
+        return rest.split(":", 1)[0] if ":" in rest else rest
+    if "/" in m:
+        return m.split("/", 1)[1]
+    return m
+
+
+def _compute_cost(
+    model: Optional[str], tin: Optional[int], tout: Optional[int]
+) -> Optional[float]:
+    """Longest-prefix match into the price table. Handles fine-tuned
+    model names (``ft:gpt-4o:...``) and provider-prefixed names
+    (``openai/gpt-4o``) by normalizing first."""
+    if not model or tin is None or tout is None:
+        return None
+    m = _normalize_model_name(model)
+    best: Optional[tuple] = None
+    best_key = ""
+    for key, prices in PRICES_PER_1K.items():
+        if m.startswith(key) and len(key) > len(best_key):
+            best = prices
+            best_key = key
+    if best is None:
+        return None
+    inp, outp = best
+    return round(tin * inp / 1000 + tout * outp / 1000, 8)
+
+
+# --- CBEventType → Synaptic span (type, name) -----------------------
+
+# Mapping is intentionally explicit — silently lumping unknown events
+# into "custom" with their event-type as the name keeps the dashboard
+# readable when LlamaIndex adds new event types in the future.
+_TYPE_NAME_MAP: Dict[CBEventType, tuple] = {
+    CBEventType.LLM: ("llm", "llm_call"),
+    CBEventType.RETRIEVE: ("retrieval", "retrieve"),
+    CBEventType.EMBEDDING: ("embedding", "embedding"),
+    CBEventType.QUERY: ("custom", "query"),
+    CBEventType.CHUNKING: ("custom", "chunking"),
+    CBEventType.NODE_PARSING: ("custom", "node_parsing"),
+    CBEventType.SYNTHESIZE: ("custom", "synthesize"),
+    CBEventType.TEMPLATING: ("custom", "templating"),
+    CBEventType.SUB_QUESTION: ("custom", "sub_question"),
+    CBEventType.RERANKING: ("custom", "reranking"),
+    CBEventType.AGENT_STEP: ("custom", "agent_step"),
+    CBEventType.FUNCTION_CALL: ("tool", "function_call"),
+    CBEventType.TREE: ("custom", "tree"),
+    CBEventType.EXCEPTION: ("custom", "exception"),
+}
+
+
+def _classify(event_type: CBEventType) -> tuple:
+    return _TYPE_NAME_MAP.get(event_type, ("custom", event_type.value))
+
+
+# --- Payload extraction --------------------------------------------
+
+
+def _extract_text(value: Any) -> str:
+    """Best-effort string conversion for diverse llama-index payloads.
+    Handles raw strings, ChatMessage / ChatResponse objects, lists of
+    either, dicts with role+content, and anything with a ``content``
+    or ``.message.content`` attribute."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "\n".join(_extract_text(v) for v in value if v is not None)
+    if isinstance(value, dict):
+        # {"role": "user", "content": "..."} — common dict shape
+        if "content" in value:
+            role = value.get("role")
+            inner = _extract_text(value.get("content"))
+            return f"{role}: {inner}" if role else inner
+        if "text" in value and isinstance(value["text"], str):
+            return value["text"]
+        # Fallback: serialize to JSON for readability
+        try:
+            return json.dumps(value, ensure_ascii=False)
+        except Exception:
+            return str(value)
+    # ChatMessage / Message-like objects
+    content = getattr(value, "content", None)
+    if content is not None:
+        role = getattr(value, "role", None)
+        if role:
+            return f"{role}: {_extract_text(content)}"
+        return _extract_text(content)
+    # ChatResponse — has .message which itself has .content
+    message = getattr(value, "message", None)
+    if message is not None:
+        return _extract_text(message)
+    # Plain text-like — e.g. CompletionResponse has .text
+    text = getattr(value, "text", None)
+    if isinstance(text, str):
+        return text
+    # Last resort: best-effort string repr (still readable in dashboard)
+    return str(value)
+
+
+def _first_present(*values):
+    """Return the first non-None value. Unlike ``a or b``, this
+    preserves explicit zero values (e.g. fully-cached prompts that
+    legitimately report ``prompt_tokens=0``)."""
+    for v in values:
+        if v is not None:
+            return v
+    return None
+
+
+def _usage_from_dict(usage: dict) -> tuple:
+    """Pick prompt/completion or input/output tokens from a usage
+    dict, preserving zero values."""
+    return (
+        _first_present(usage.get("prompt_tokens"), usage.get("input_tokens")),
+        _first_present(usage.get("completion_tokens"), usage.get("output_tokens")),
+    )
+
+
+def _extract_token_counts(payload: Optional[dict]) -> tuple:
+    """Pull (input_tokens, output_tokens) from an LLM end payload.
+    LlamaIndex puts usage in different places depending on which LLM
+    integration is in play — try the common ones, in priority order."""
+    if not payload:
+        return None, None
+
+    response = payload.get(EventPayload.RESPONSE)
+    if response is not None:
+        # LiteLLM-style: response.raw["usage"]
+        raw = getattr(response, "raw", None)
+        if isinstance(raw, dict):
+            usage = raw.get("usage")
+            if isinstance(usage, dict):
+                return _usage_from_dict(usage)
+        # Direct attribute on response.raw (anthropic-style typed obj)
+        if raw is not None:
+            usage = getattr(raw, "usage", None)
+            if usage is not None:
+                tin = _first_present(
+                    getattr(usage, "prompt_tokens", None),
+                    getattr(usage, "input_tokens", None),
+                )
+                tout = _first_present(
+                    getattr(usage, "completion_tokens", None),
+                    getattr(usage, "output_tokens", None),
+                )
+                if tin is not None or tout is not None:
+                    return tin, tout
+        # Some integrations stash on response.additional_kwargs
+        addl = getattr(response, "additional_kwargs", None)
+        if isinstance(addl, dict):
+            usage = addl.get("usage")
+            if isinstance(usage, dict):
+                return _usage_from_dict(usage)
+
+    # Older payloads pass token counts on a top-level additional_kwargs
+    addl = payload.get(EventPayload.ADDITIONAL_KWARGS)
+    if isinstance(addl, dict):
+        usage = addl.get("usage")
+        if isinstance(usage, dict):
+            return _usage_from_dict(usage)
+    return None, None
+
+
+def _extract_model(payload: Optional[dict]) -> Optional[str]:
+    if not payload:
+        return None
+    name = payload.get(EventPayload.MODEL_NAME)
+    if isinstance(name, str) and name:
+        return name
+    serialized = payload.get(EventPayload.SERIALIZED)
+    if isinstance(serialized, dict):
+        for key in ("model", "model_name", "deployment_name"):
+            v = serialized.get(key)
+            if isinstance(v, str) and v:
+                return v
+    response = payload.get(EventPayload.RESPONSE)
+    if response is not None:
+        m = getattr(response, "model", None)
+        if isinstance(m, str) and m:
+            return m
+        raw = getattr(response, "raw", None)
+        if isinstance(raw, dict):
+            m = raw.get("model")
+            if isinstance(m, str) and m:
+                return m
+    return None
+
+
+def _extract_retrieval_output(payload: Optional[dict]) -> tuple:
+    """Returns (output_text, node_count, top_score). For RETRIEVE
+    events. Each NodeWithScore has get_text() and score."""
+    if not payload:
+        return "", 0, None
+    nodes = payload.get(EventPayload.NODES) or []
+    pieces: List[str] = []
+    top_score: Optional[float] = None
+    for n in nodes:
+        try:
+            text = n.get_text() if hasattr(n, "get_text") else str(n)
+            score = getattr(n, "score", None)
+            if score is not None and (top_score is None or score > top_score):
+                top_score = score
+            score_str = f" (score={score:.3f})" if score is not None else ""
+            pieces.append(f"- {text}{score_str}")
+        except Exception:
+            pieces.append(str(n))
+    return "\n".join(pieces), len(nodes), top_score
+
+
+# --- The handler ---------------------------------------------------
+
+
+class SynapticCallbackHandler(BaseCallbackHandler):
+    """LlamaIndex BaseCallbackHandler that ships every event to
+    Synaptic as a span."""
+
+    def __init__(
+        self,
+        event_starts_to_ignore: Optional[List[CBEventType]] = None,
+        event_ends_to_ignore: Optional[List[CBEventType]] = None,
+        project: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            event_starts_to_ignore=event_starts_to_ignore or [],
+            event_ends_to_ignore=event_ends_to_ignore or [],
+        )
+        self._project = project
+        # event_id → span. LlamaIndex supplies parent_id on every
+        # event start, so we just need an event_id → span lookup
+        # to find spans later when closing them.
+        self._spans: Dict[str, _ExtSpan] = {}
+        # Trace lifecycle is tracked but doesn't emit a synthetic
+        # root span — LlamaIndex itself emits a top-level QUERY (or
+        # similar) event that becomes the root. Creating an extra
+        # span named after the trace_id (e.g. "query") just produced
+        # a confusing duplicate row in the dashboard.
+        self._active_traces: Dict[str, Optional[_ExtSpan]] = {}
+
+    # -- Trace lifecycle ---------------------------------------------
+
+    def start_trace(self, trace_id: Optional[str] = None) -> None:
+        try:
+            trace_key = trace_id or "default"
+            # Snapshot the outer @synaptic.trace span (if any) so
+            # the first event inside this trace can attach to it.
+            outer = get_current_span()
+            outer_ext = (
+                _ExtSpan(
+                    id=outer.id,
+                    trace_id=outer.trace_id,
+                    parent_span_id=None,
+                    name="proxy",
+                    type="custom",
+                )
+                if outer is not None
+                else None
+            )
+            if outer_ext is not None:
+                outer_ext.session_id = getattr(outer, "session_id", None)
+            self._active_traces[trace_key] = outer_ext
+        except Exception:
+            # Rule 7: never propagate to the agent
+            pass
+
+    def end_trace(
+        self,
+        trace_id: Optional[str] = None,
+        trace_map: Optional[Dict[str, List[str]]] = None,
+    ) -> None:
+        try:
+            trace_key = trace_id or "default"
+            self._active_traces.pop(trace_key, None)
+            # Reap any spans whose start fired but whose end never
+            # arrived — typically because an exception unwound the
+            # call stack past the CallbackManager. Without this, the
+            # _spans dict leaks unboundedly in long-running apps.
+            #
+            # We can only reap spans we know belong to this trace.
+            # trace_map gives us every event_id seen during the
+            # trace (as keys and as members of value lists). If the
+            # SDK didn't supply trace_map, leave the entries — they
+            # may belong to a still-open concurrent trace.
+            if trace_map is None:
+                return
+            event_ids: set = set()
+            for parent, children in trace_map.items():
+                event_ids.add(parent)
+                for c in children or []:
+                    event_ids.add(c)
+            sdk = _get_sdk()
+            for eid in list(self._spans.keys()):
+                if eid in event_ids:
+                    leaked = self._spans.pop(eid, None)
+                    if leaked is not None:
+                        if leaked.error is None:
+                            leaked.error = (
+                                "Span did not receive on_event_end "
+                                "(likely an exception unwound the stack)."
+                            )
+                        leaked.end()
+                        try:
+                            sdk.submit(leaked)
+                        except Exception:
+                            pass
+        except Exception:
+            pass
+
+    # -- Event lifecycle ---------------------------------------------
+
+    def on_event_start(
+        self,
+        event_type: CBEventType,
+        payload: Optional[Dict[str, Any]] = None,
+        event_id: str = "",
+        parent_id: str = "",
+        **kwargs: Any,
+    ) -> str:
+        try:
+            span_type, span_name = _classify(event_type)
+
+            parent = self._spans.get(parent_id) if parent_id else None
+            if parent is None:
+                # No event-level parent — attach to the outer
+                # @synaptic.trace span if start_trace recorded one.
+                # Otherwise this event becomes a root span.
+                for outer in self._active_traces.values():
+                    if outer is not None:
+                        parent = outer
+                        break
+
+            new_id = str(uuid4())
+            if parent is not None:
+                trace_id = parent.trace_id
+                parent_span_id = parent.id
+                session_id = getattr(parent, "session_id", None)
+            else:
+                trace_id = new_id
+                parent_span_id = None
+                session_id = None
+
+            span = _ExtSpan(
+                id=new_id,
+                trace_id=trace_id,
+                parent_span_id=parent_span_id,
+                name=span_name,
+                type=span_type,
+            )
+            span.session_id = session_id
+
+            # Capture the input now — outputs come on end.
+            self._capture_start_payload(span, event_type, payload)
+            self._spans[event_id] = span
+        except Exception:
+            pass
+        return event_id
+
+    def on_event_end(
+        self,
+        event_type: CBEventType,
+        payload: Optional[Dict[str, Any]] = None,
+        event_id: str = "",
+        **kwargs: Any,
+    ) -> None:
+        try:
+            span = self._spans.pop(event_id, None)
+            if span is None:
+                return
+            self._capture_end_payload(span, event_type, payload)
+            span.end()
+            _get_sdk().submit(span)
+        except Exception:
+            pass
+
+    # -- Payload helpers ---------------------------------------------
+
+    def _capture_start_payload(
+        self,
+        span: _ExtSpan,
+        event_type: CBEventType,
+        payload: Optional[Dict[str, Any]],
+    ) -> None:
+        if not payload:
+            return
+        if event_type == CBEventType.LLM:
+            messages = payload.get(EventPayload.MESSAGES)
+            prompt = payload.get(EventPayload.PROMPT)
+            text = _extract_text(messages) if messages is not None else _extract_text(prompt)
+            span.input = _serialize(text)
+            model = _extract_model(payload)
+            if model:
+                span.model = model
+                span.provider = _provider_from_model(model)
+        elif event_type == CBEventType.RETRIEVE:
+            q = payload.get(EventPayload.QUERY_STR)
+            span.input = _serialize(_extract_text(q))
+        elif event_type == CBEventType.EMBEDDING:
+            chunks = payload.get(EventPayload.CHUNKS)
+            if chunks is not None:
+                span.input = _serialize(_extract_text(chunks))
+            model = _extract_model(payload)
+            if model:
+                span.model = model
+                span.provider = _provider_from_model(model)
+        elif event_type == CBEventType.QUERY:
+            q = payload.get(EventPayload.QUERY_STR)
+            span.input = _serialize(_extract_text(q))
+        elif event_type == CBEventType.FUNCTION_CALL:
+            tool = payload.get(EventPayload.TOOL)
+            # LlamaIndex tools surface their name in either tool.name
+            # (older) or tool.metadata.name (newer). Try both.
+            for path in ((tool, "name"), (getattr(tool, "metadata", None), "name")):
+                obj, attr = path
+                v = getattr(obj, attr, None)
+                if isinstance(v, str) and v:
+                    span.tool_name = v
+                    break
+            fn_call = payload.get(EventPayload.FUNCTION_CALL)
+            if fn_call is not None:
+                span.input = _serialize(fn_call)
+
+    def _capture_end_payload(
+        self,
+        span: _ExtSpan,
+        event_type: CBEventType,
+        payload: Optional[Dict[str, Any]],
+    ) -> None:
+        # If the operation failed, LlamaIndex's CallbackManager calls
+        # on_event_end with payload={EXCEPTION: e} on the failing
+        # event's id — regardless of event_type. Capture the error
+        # on the span for ANY event that ended with an exception.
+        if payload and EventPayload.EXCEPTION in payload:
+            exc = payload[EventPayload.EXCEPTION]
+            if isinstance(exc, BaseException):
+                span.error = f"{type(exc).__name__}: {exc}"
+            elif exc is not None:
+                span.error = str(exc)
+            # Don't return — still try to capture any other fields
+            # the payload happened to include.
+
+        if not payload:
+            return
+
+        if event_type == CBEventType.LLM:
+            response = payload.get(EventPayload.RESPONSE)
+            completion = payload.get(EventPayload.COMPLETION)
+            text = _extract_text(response) if response is not None else _extract_text(completion)
+            span.output = _serialize(text)
+
+            # Token usage: prefer the LLM's reported numbers; estimate
+            # from text length only when the SDK doesn't supply them.
+            tin, tout = _extract_token_counts(payload)
+            span.tokens_input = tin
+            span.tokens_output = tout
+            if span.tokens_input is None and span.input:
+                span.tokens_input = _estimate_tokens(span.input)
+            if span.tokens_output is None and span.output:
+                span.tokens_output = _estimate_tokens(span.output)
+
+            # Model may only be available on response (some LLMs)
+            if not span.model:
+                model = _extract_model(payload)
+                if model:
+                    span.model = model
+                    span.provider = _provider_from_model(model)
+            span.cost_usd = _compute_cost(span.model, span.tokens_input, span.tokens_output)
+        elif event_type == CBEventType.RETRIEVE:
+            text, count, top_score = _extract_retrieval_output(payload)
+            span.output = _serialize(text)
+        elif event_type == CBEventType.EMBEDDING:
+            # LlamaIndex passes the actual chunks/text only on end —
+            # capture as input here if start_payload didn't have it.
+            chunks = payload.get(EventPayload.CHUNKS)
+            if chunks is not None and not span.input:
+                span.input = _serialize(_extract_text(chunks))
+            embeddings = payload.get(EventPayload.EMBEDDINGS) or []
+            # Don't dump the full vectors — just record the count
+            span.output = _serialize(f"{len(embeddings)} embedding vector(s)")
+            if span.input and span.tokens_input is None:
+                span.tokens_input = _estimate_tokens(span.input)
+            if span.model and span.tokens_input is not None:
+                span.cost_usd = _compute_cost(span.model, span.tokens_input, 0)
+        elif event_type == CBEventType.QUERY:
+            response = payload.get(EventPayload.RESPONSE)
+            span.output = _serialize(_extract_text(response))
+        elif event_type == CBEventType.FUNCTION_CALL:
+            out = payload.get(EventPayload.FUNCTION_OUTPUT)
+            if out is not None:
+                span.output = _serialize(out)
+
+
+def _provider_from_model(model: str) -> Optional[str]:
+    """Best-effort provider inference from a model name. Used only
+    when llama-index doesn't tell us directly."""
+    m = model.lower()
+    if m.startswith("gpt-") or m.startswith("text-embedding"):
+        return "openai"
+    if m.startswith("claude"):
+        return "anthropic"
+    if m.startswith("gemini") or m.startswith("models/"):
+        return "google"
+    if m.startswith("command"):
+        return "cohere"
+    if "/" in m:
+        return m.split("/", 1)[0]
+    return None
+
+
+# --- Zero-config auto-registration ---------------------------------
+
+
+def _maybe_register_global() -> bool:
+    """If ``SYNAPTIC_TRACING=true`` and llama-index's ``Settings``
+    object is available, attach our handler to the global callback
+    manager. Idempotent — already-installed handlers aren't added
+    twice.
+
+    Returns True if installed, False if disabled or unreachable.
+    """
+    val = (os.environ.get("SYNAPTIC_TRACING") or "").lower()
+    if val not in ("true", "1"):
+        return False
+    try:
+        from llama_index.core import Settings
+        from llama_index.core.callbacks import CallbackManager
+    except Exception:
+        return False
+    try:
+        existing = Settings.callback_manager
+        existing_handlers = getattr(existing, "handlers", []) or []
+        if any(isinstance(h, SynapticCallbackHandler) for h in existing_handlers):
+            return True
+        # Prefer add_handler so we don't lose subclass identity or
+        # extra state on the user's CallbackManager. Fall back to
+        # replacing only if add_handler isn't exposed on this version.
+        if hasattr(existing, "add_handler"):
+            existing.add_handler(SynapticCallbackHandler())
+        else:
+            new_handlers = list(existing_handlers) + [SynapticCallbackHandler()]
+            Settings.callback_manager = CallbackManager(new_handlers)
+        return True
+    except Exception:
+        return False
+
+
+# Run at import time. Failure is silent — Rule 7.
+_maybe_register_global()
+
+
+__all__ = ["SynapticCallbackHandler", "register_model_price"]

--- a/packages/sdk-python/tests/test_llama_index_integration.py
+++ b/packages/sdk-python/tests/test_llama_index_integration.py
@@ -1,0 +1,526 @@
+"""Tests for the LlamaIndex callback integration."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("llama_index.core.callbacks.base_handler")
+
+from llama_index.core.callbacks.schema import CBEventType, EventPayload  # noqa: E402
+
+from synaptic.integrations.llama_index import (  # noqa: E402
+    SynapticCallbackHandler,
+    _classify,
+    _compute_cost,
+    _extract_model,
+    _extract_retrieval_output,
+    _extract_text,
+    _extract_token_counts,
+    _provider_from_model,
+)
+
+
+# ---------- helpers ----------
+
+
+def _drain(sdk):
+    sdk.flush()
+    return sdk._exporter.spans
+
+
+def _make_handler() -> SynapticCallbackHandler:
+    return SynapticCallbackHandler()
+
+
+def _ev() -> str:
+    return str(uuid4())
+
+
+# ---------- pure function tests ----------
+
+
+def test_classify_known_event_types():
+    assert _classify(CBEventType.LLM) == ("llm", "llm_call")
+    assert _classify(CBEventType.RETRIEVE) == ("retrieval", "retrieve")
+    assert _classify(CBEventType.EMBEDDING) == ("embedding", "embedding")
+    assert _classify(CBEventType.QUERY) == ("custom", "query")
+    assert _classify(CBEventType.FUNCTION_CALL) == ("tool", "function_call")
+
+
+def test_compute_cost_known_model():
+    assert _compute_cost("gpt-4o", 1000, 1000) == pytest.approx(0.0125, rel=1e-3)
+
+
+def test_compute_cost_unknown_model_is_none():
+    assert _compute_cost("brand-new-model", 100, 100) is None
+
+
+def test_provider_from_model():
+    assert _provider_from_model("gpt-4o-mini") == "openai"
+    assert _provider_from_model("claude-opus-4") == "anthropic"
+    assert _provider_from_model("text-embedding-3-small") == "openai"
+    assert _provider_from_model("ollama/llama3") == "ollama"
+
+
+def test_extract_text_handles_strings_messages_lists():
+    assert _extract_text("hello") == "hello"
+    msg = SimpleNamespace(role="user", content="hi")
+    assert _extract_text(msg) == "user: hi"
+    msgs = [
+        SimpleNamespace(role="system", content="be helpful"),
+        SimpleNamespace(role="user", content="2+2?"),
+    ]
+    assert _extract_text(msgs) == "system: be helpful\nuser: 2+2?"
+    assert _extract_text(None) == ""
+
+
+def test_extract_token_counts_from_response_raw_dict():
+    response = SimpleNamespace(
+        raw={"usage": {"prompt_tokens": 50, "completion_tokens": 12}}
+    )
+    payload = {EventPayload.RESPONSE: response}
+    assert _extract_token_counts(payload) == (50, 12)
+
+
+def test_extract_token_counts_from_response_raw_attribute():
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+    response = SimpleNamespace(raw=SimpleNamespace(usage=usage))
+    payload = {EventPayload.RESPONSE: response}
+    assert _extract_token_counts(payload) == (10, 5)
+
+
+def test_extract_token_counts_falls_back_to_additional_kwargs():
+    payload = {
+        EventPayload.ADDITIONAL_KWARGS: {
+            "usage": {"prompt_tokens": 7, "completion_tokens": 3}
+        }
+    }
+    assert _extract_token_counts(payload) == (7, 3)
+
+
+def test_extract_token_counts_returns_none_when_absent():
+    assert _extract_token_counts({}) == (None, None)
+    assert _extract_token_counts(None) == (None, None)
+
+
+def test_extract_model_from_payload():
+    assert (
+        _extract_model({EventPayload.MODEL_NAME: "gpt-4o-mini"})
+        == "gpt-4o-mini"
+    )
+    assert (
+        _extract_model(
+            {EventPayload.SERIALIZED: {"model": "claude-opus-4-20250514"}}
+        )
+        == "claude-opus-4-20250514"
+    )
+
+
+def test_extract_retrieval_output_summarizes_nodes():
+    nodes = [
+        SimpleNamespace(get_text=lambda: "first chunk", score=0.92),
+        SimpleNamespace(get_text=lambda: "second chunk", score=0.81),
+    ]
+    text, count, top = _extract_retrieval_output({EventPayload.NODES: nodes})
+    assert "first chunk" in text and "second chunk" in text
+    assert "0.920" in text
+    assert count == 2
+    assert top == pytest.approx(0.92)
+
+
+# ---------- handler behavior ----------
+
+
+def test_query_creates_trace(sdk):
+    """A query that contains a retrieval and an LLM call results in a
+    multi-span trace. The QUERY event itself is the root — we don't
+    emit a synthetic span for start_trace to avoid a duplicate row."""
+    h = _make_handler()
+    h.start_trace("q1")
+    qe = _ev()
+    h.on_event_start(CBEventType.QUERY, {EventPayload.QUERY_STR: "what is X?"}, event_id=qe)
+    re = _ev()
+    h.on_event_start(
+        CBEventType.RETRIEVE,
+        {EventPayload.QUERY_STR: "what is X?"},
+        event_id=re,
+        parent_id=qe,
+    )
+    nodes = [SimpleNamespace(get_text=lambda: "X is a thing.", score=0.9)]
+    h.on_event_end(CBEventType.RETRIEVE, {EventPayload.NODES: nodes}, event_id=re)
+    le = _ev()
+    h.on_event_start(
+        CBEventType.LLM,
+        {EventPayload.MESSAGES: [SimpleNamespace(role="user", content="explain X")]},
+        event_id=le,
+        parent_id=qe,
+    )
+    h.on_event_end(
+        CBEventType.LLM,
+        {
+            EventPayload.RESPONSE: SimpleNamespace(
+                raw={"usage": {"prompt_tokens": 12, "completion_tokens": 9}, "model": "gpt-4o"}
+            ),
+            EventPayload.MODEL_NAME: "gpt-4o",
+        },
+        event_id=le,
+    )
+    h.on_event_end(CBEventType.QUERY, {EventPayload.RESPONSE: "X is a thing."}, event_id=qe)
+    h.end_trace("q1")
+
+    spans = _drain(sdk)
+    by_name = {s.name: s for s in spans}
+    # No "q1" synthetic root any more — the QUERY event is the root.
+    assert "q1" not in by_name
+    assert "query" in by_name
+    assert "retrieve" in by_name
+    assert "llm_call" in by_name
+    assert len(spans) == 3
+
+    # One trace, with 'query' as root and 'retrieve' + 'llm_call' as
+    # children (we passed parent_id=qe for both)
+    assert len({s.trace_id for s in spans}) == 1
+    root = by_name["query"]
+    assert root.parent_span_id is None
+    assert by_name["retrieve"].parent_span_id == root.id
+    assert by_name["llm_call"].parent_span_id == root.id
+
+
+def test_retrieval_span_records_node_count_and_content(sdk):
+    h = _make_handler()
+    h.start_trace("t-retr")
+    re = _ev()
+    h.on_event_start(
+        CBEventType.RETRIEVE,
+        {EventPayload.QUERY_STR: "capital of France"},
+        event_id=re,
+    )
+    nodes = [
+        SimpleNamespace(get_text=lambda: "Paris is the capital of France.", score=0.95),
+        SimpleNamespace(get_text=lambda: "France is a country.", score=0.72),
+    ]
+    h.on_event_end(CBEventType.RETRIEVE, {EventPayload.NODES: nodes}, event_id=re)
+    h.end_trace("t-retr")
+
+    spans = _drain(sdk)
+    by_name = {s.name: s for s in spans}
+    retr = by_name["retrieve"]
+    assert retr.type == "retrieval"
+    assert "Paris" in retr.output
+    assert "France is a country" in retr.output
+    assert "0.950" in retr.output
+    assert retr.input is not None
+    assert "capital of France" in retr.input
+
+
+def test_llm_span_has_model_tokens_and_cost(sdk):
+    h = _make_handler()
+    h.start_trace("t-llm")
+    le = _ev()
+    h.on_event_start(
+        CBEventType.LLM,
+        {
+            EventPayload.MESSAGES: [
+                SimpleNamespace(role="user", content="Hello, world.")
+            ]
+        },
+        event_id=le,
+    )
+    response = SimpleNamespace(
+        raw={"usage": {"prompt_tokens": 100, "completion_tokens": 50}, "model": "gpt-4o-mini"}
+    )
+    h.on_event_end(
+        CBEventType.LLM,
+        {
+            EventPayload.RESPONSE: response,
+            EventPayload.MODEL_NAME: "gpt-4o-mini",
+        },
+        event_id=le,
+    )
+    h.end_trace("t-llm")
+
+    spans = _drain(sdk)
+    by_name = {s.name: s for s in spans}
+    llm = by_name["llm_call"]
+    assert llm.type == "llm"
+    assert llm.model == "gpt-4o-mini"
+    assert llm.provider == "openai"
+    assert llm.tokens_input == 100
+    assert llm.tokens_output == 50
+    assert llm.cost_usd is not None and llm.cost_usd > 0
+
+
+def test_llm_span_estimates_tokens_when_llm_doesnt_report(sdk):
+    h = _make_handler()
+    h.start_trace("t-est")
+    le = _ev()
+    h.on_event_start(
+        CBEventType.LLM,
+        {EventPayload.PROMPT: "x" * 80},
+        event_id=le,
+    )
+    h.on_event_end(
+        CBEventType.LLM,
+        {
+            EventPayload.COMPLETION: "y" * 200,
+            EventPayload.MODEL_NAME: "gpt-4o",
+        },
+        event_id=le,
+    )
+    h.end_trace("t-est")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    # Estimate: ~4 chars per token. Should be > 0 even though no usage data.
+    assert llm.tokens_input is not None and llm.tokens_input > 0
+    assert llm.tokens_output is not None and llm.tokens_output > 0
+    assert llm.cost_usd is not None
+
+
+def test_embedding_span_captures_model_and_input(sdk):
+    h = _make_handler()
+    h.start_trace("t-embed")
+    ee = _ev()
+    h.on_event_start(
+        CBEventType.EMBEDDING,
+        {
+            EventPayload.SERIALIZED: {"model": "text-embedding-3-small"},
+            EventPayload.CHUNKS: ["hello world", "another chunk"],
+        },
+        event_id=ee,
+    )
+    h.on_event_end(
+        CBEventType.EMBEDDING,
+        {EventPayload.EMBEDDINGS: [[0.1, 0.2], [0.3, 0.4]]},
+        event_id=ee,
+    )
+    h.end_trace("t-embed")
+    spans = _drain(sdk)
+    emb = next(s for s in spans if s.name == "embedding")
+    assert emb.type == "embedding"
+    assert emb.model == "text-embedding-3-small"
+    assert emb.provider == "openai"
+    assert emb.input is not None
+    assert "hello world" in emb.input
+    assert "2 embedding" in emb.output
+
+
+def test_error_captured_when_normal_event_ends_with_exception_payload(sdk):
+    """LlamaIndex's CallbackManager.event context manager calls
+    on_event_end with payload={EXCEPTION: e} when the operation
+    raises — regardless of event_type. The error must surface on
+    that span, not be dropped."""
+    h = _make_handler()
+    h.start_trace("t-mid-fail")
+    eid = _ev()
+    h.on_event_start(
+        CBEventType.RETRIEVE, {EventPayload.QUERY_STR: "x"}, event_id=eid
+    )
+    # Simulate the pipeline throwing — CallbackManager calls
+    # on_event_end with payload[EXCEPTION] set
+    h.on_event_end(
+        CBEventType.RETRIEVE,
+        {EventPayload.EXCEPTION: RuntimeError("embedder outage")},
+        event_id=eid,
+    )
+    h.end_trace("t-mid-fail")
+    spans = _drain(sdk)
+    retr = next(s for s in spans if s.name == "retrieve")
+    assert retr.error is not None
+    assert "RuntimeError" in retr.error
+    assert "embedder outage" in retr.error
+
+
+def test_error_captured_via_exception_event(sdk):
+    h = _make_handler()
+    h.start_trace("t-err")
+    ee = _ev()
+    h.on_event_start(CBEventType.EXCEPTION, {}, event_id=ee)
+    h.on_event_end(
+        CBEventType.EXCEPTION,
+        {EventPayload.EXCEPTION: ValueError("retrieval failed")},
+        event_id=ee,
+    )
+    h.end_trace("t-err")
+    spans = _drain(sdk)
+    by_name = {s.name: s for s in spans}
+    exc = by_name["exception"]
+    assert exc.error is not None
+    assert "ValueError" in exc.error
+    assert "retrieval failed" in exc.error
+
+
+def test_function_call_span_is_tool_type(sdk):
+    h = _make_handler()
+    h.start_trace("t-fn")
+    fe = _ev()
+    tool = SimpleNamespace(metadata=SimpleNamespace(name="search_web"))
+    h.on_event_start(
+        CBEventType.FUNCTION_CALL,
+        {
+            EventPayload.TOOL: tool,
+            EventPayload.FUNCTION_CALL: {"args": {"q": "weather SF"}},
+        },
+        event_id=fe,
+    )
+    h.on_event_end(
+        CBEventType.FUNCTION_CALL,
+        {EventPayload.FUNCTION_OUTPUT: "62°F"},
+        event_id=fe,
+    )
+    h.end_trace("t-fn")
+    spans = _drain(sdk)
+    fn = next(s for s in spans if s.name == "function_call")
+    assert fn.type == "tool"
+    assert fn.tool_name == "search_web"
+    assert "62" in fn.output
+
+
+def test_unknown_event_type_does_not_crash(sdk):
+    h = _make_handler()
+    h.start_trace("t-misc")
+    me = _ev()
+    h.on_event_start(CBEventType.NODE_PARSING, {}, event_id=me)
+    h.on_event_end(CBEventType.NODE_PARSING, {}, event_id=me)
+    h.end_trace("t-misc")
+    spans = _drain(sdk)
+    assert any(s.name == "node_parsing" for s in spans)
+
+
+def test_orphaned_end_does_not_crash(sdk):
+    """An on_event_end without a matching on_event_start must not
+    raise. LlamaIndex's CallbackManager occasionally double-fires."""
+    h = _make_handler()
+    h.start_trace("t-orph")
+    h.on_event_end(CBEventType.LLM, {}, event_id="never-started")
+    h.end_trace("t-orph")
+    # No exception = pass
+
+
+def test_handler_inside_synaptic_trace_links_under_outer(sdk):
+    """When wrapped in @synaptic.trace, the first LlamaIndex event
+    should attach under the outer @synaptic.trace span."""
+    import synaptic
+
+    @synaptic.trace
+    def my_agent() -> None:
+        h = _make_handler()
+        h.start_trace("inner_query")
+        e = _ev()
+        h.on_event_start(CBEventType.QUERY, {EventPayload.QUERY_STR: "x"}, event_id=e)
+        h.on_event_end(CBEventType.QUERY, {EventPayload.RESPONSE: "ok"}, event_id=e)
+        h.end_trace("inner_query")
+
+    my_agent()
+    spans = _drain(sdk)
+    by_name = {s.name: s for s in spans}
+    outer = by_name["my_agent"]
+    inner = by_name["query"]
+    assert inner.trace_id == outer.trace_id
+    assert inner.parent_span_id == outer.id
+
+
+def test_to_dict_includes_extended_fields(sdk):
+    """Spans emitted by this handler must round-trip through the
+    standard exporter — i.e. include all _ExtSpan fields in to_dict."""
+    h = _make_handler()
+    h.start_trace("t-dict")
+    le = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "hi"}, event_id=le)
+    h.on_event_end(
+        CBEventType.LLM,
+        {EventPayload.COMPLETION: "ok", EventPayload.MODEL_NAME: "gpt-4o"},
+        event_id=le,
+    )
+    h.end_trace("t-dict")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    d = llm.to_dict()
+    for k in (
+        "model",
+        "provider",
+        "tokens_input",
+        "tokens_output",
+        "cost_usd",
+        "tool_name",
+        "span_subtype",
+        "thinking_tokens",
+    ):
+        assert k in d
+
+
+# ---------- resilience ----------
+
+
+def test_agent_continues_if_synaptic_down(sdk, monkeypatch):
+    """If the SDK's submit() throws (e.g. queue exploded), the
+    handler must still let LlamaIndex finish. Rule 7."""
+    h = _make_handler()
+
+    def boom(*_a, **_k):
+        raise RuntimeError("synaptic backend exploded")
+
+    # Patch submit on the live sdk to simulate failure
+    monkeypatch.setattr(sdk, "submit", boom)
+    h.start_trace("t-down")
+    le = _ev()
+    h.on_event_start(CBEventType.LLM, {}, event_id=le)
+    h.on_event_end(CBEventType.LLM, {EventPayload.COMPLETION: "ok"}, event_id=le)
+    h.end_trace("t-down")
+    # No exception escaped = pass
+
+
+def test_handler_double_init_is_safe():
+    """Constructing two handlers with default args doesn't crash and
+    each gets its own state."""
+    h1 = SynapticCallbackHandler()
+    h2 = SynapticCallbackHandler()
+    assert h1 is not h2
+    assert h1._spans is not h2._spans
+    assert h1._active_traces is not h2._active_traces
+
+
+# ---------- zero-config ----------
+
+
+def test_zero_config_attaches_when_env_set(monkeypatch):
+    from llama_index.core import Settings
+    from llama_index.core.callbacks import CallbackManager
+
+    from synaptic.integrations.llama_index import _maybe_register_global
+
+    monkeypatch.setenv("SYNAPTIC_TRACING", "true")
+    Settings.callback_manager = CallbackManager([])
+    assert _maybe_register_global() is True
+    handlers = Settings.callback_manager.handlers
+    assert any(isinstance(h, SynapticCallbackHandler) for h in handlers)
+
+
+def test_zero_config_disabled_when_env_unset(monkeypatch):
+    from llama_index.core import Settings
+    from llama_index.core.callbacks import CallbackManager
+
+    from synaptic.integrations.llama_index import _maybe_register_global
+
+    monkeypatch.delenv("SYNAPTIC_TRACING", raising=False)
+    Settings.callback_manager = CallbackManager([])
+    assert _maybe_register_global() is False
+
+
+def test_zero_config_idempotent(monkeypatch):
+    from llama_index.core import Settings
+    from llama_index.core.callbacks import CallbackManager
+
+    from synaptic.integrations.llama_index import _maybe_register_global
+
+    monkeypatch.setenv("SYNAPTIC_TRACING", "true")
+    Settings.callback_manager = CallbackManager([SynapticCallbackHandler()])
+    assert _maybe_register_global() is True
+    handlers = Settings.callback_manager.handlers
+    # Should not have added a second handler
+    syn_handlers = [h for h in handlers if isinstance(h, SynapticCallbackHandler)]
+    assert len(syn_handlers) == 1

--- a/packages/sdk-python/tests/test_llama_index_stress.py
+++ b/packages/sdk-python/tests/test_llama_index_stress.py
@@ -1,0 +1,1027 @@
+"""Stress tests for the LlamaIndex callback integration.
+
+Covers edge cases that real production traffic could hit but the
+core test suite doesn't exercise: token usage on response.additional_kwargs,
+deeply-nested traces, concurrent ingestion within one trace, the
+real BaseQueryEngine event sequence, payloads with non-standard
+shapes, and resilience under SDK failure."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("llama_index.core.callbacks.base_handler")
+
+from llama_index.core.callbacks.schema import CBEventType, EventPayload  # noqa: E402
+
+from synaptic.integrations.llama_index import (  # noqa: E402
+    SynapticCallbackHandler,
+    _extract_token_counts,
+)
+
+
+def _drain(sdk):
+    sdk.flush()
+    return sdk._exporter.spans
+
+
+def _ev() -> str:
+    return str(uuid4())
+
+
+# ---------- token extraction edge cases ----------
+
+
+def test_token_counts_via_response_additional_kwargs():
+    """Some LLM SDKs (e.g. earlier llama-index-llms-openai) attach
+    usage to response.additional_kwargs rather than response.raw."""
+    response = SimpleNamespace(
+        raw=None,
+        additional_kwargs={"usage": {"prompt_tokens": 22, "completion_tokens": 11}},
+    )
+    payload = {EventPayload.RESPONSE: response}
+    assert _extract_token_counts(payload) == (22, 11)
+
+
+def test_token_counts_with_unusual_keys():
+    """Anthropic-style integrations report input_tokens/output_tokens
+    instead of prompt_tokens/completion_tokens."""
+    response = SimpleNamespace(
+        raw={"usage": {"input_tokens": 30, "output_tokens": 20}}
+    )
+    payload = {EventPayload.RESPONSE: response}
+    assert _extract_token_counts(payload) == (30, 20)
+
+
+def test_token_counts_zero_is_kept():
+    """A response with zero prompt_tokens (fully cached input) must
+    be recorded as 0, not silently dropped to None — otherwise we
+    skip the cost calculation for cached prompts."""
+    response = SimpleNamespace(
+        raw={"usage": {"prompt_tokens": 0, "completion_tokens": 5}}
+    )
+    payload = {EventPayload.RESPONSE: response}
+    tin, tout = _extract_token_counts(payload)
+    assert tin == 0
+    assert tout == 5
+
+
+def test_token_counts_input_tokens_zero_anthropic_style():
+    """Anthropic uses input_tokens/output_tokens. Zero must survive."""
+    response = SimpleNamespace(
+        raw={"usage": {"input_tokens": 0, "output_tokens": 12}}
+    )
+    payload = {EventPayload.RESPONSE: response}
+    assert _extract_token_counts(payload) == (0, 12)
+
+
+def test_embedding_cost_computed_from_input_tokens(sdk):
+    """Embedding spans on a known model (text-embedding-3-small) must
+    get a non-zero cost computed from tokens_input alone."""
+    h = SynapticCallbackHandler()
+    h.start_trace("emb")
+    eid = _ev()
+    h.on_event_start(
+        CBEventType.EMBEDDING,
+        {EventPayload.SERIALIZED: {"model": "text-embedding-3-small"}},
+        event_id=eid,
+    )
+    h.on_event_end(
+        CBEventType.EMBEDDING,
+        {
+            EventPayload.CHUNKS: ["a paragraph " * 200],  # ~2400 chars
+            EventPayload.EMBEDDINGS: [[0.1, 0.2]],
+        },
+        event_id=eid,
+    )
+    h.end_trace("emb")
+    spans = _drain(sdk)
+    emb = next(s for s in spans if s.name == "embedding")
+    assert emb.model == "text-embedding-3-small"
+    assert emb.cost_usd is not None and emb.cost_usd > 0
+
+
+def test_token_counts_falls_back_when_primary_key_missing():
+    """If only input_tokens is set (no prompt_tokens), still returns
+    a non-None value."""
+    response = SimpleNamespace(
+        raw={"usage": {"input_tokens": 7, "output_tokens": 3}}
+    )
+    payload = {EventPayload.RESPONSE: response}
+    assert _extract_token_counts(payload) == (7, 3)
+
+
+# ---------- deep nesting ----------
+
+
+def test_deeply_nested_events_all_link_under_root(sdk):
+    """A chain of 10 events nested inside a query should all share
+    one trace_id. The first event becomes the root; later events
+    chain via parent_id."""
+    h = SynapticCallbackHandler()
+    h.start_trace("deep")
+    parent_event_id = ""
+    expected_chain = []
+    for i in range(10):
+        eid = _ev()
+        h.on_event_start(
+            CBEventType.QUERY,
+            {EventPayload.QUERY_STR: f"step-{i}"},
+            event_id=eid,
+            parent_id=parent_event_id,
+        )
+        expected_chain.append(eid)
+        parent_event_id = eid
+    for eid in reversed(expected_chain):
+        h.on_event_end(
+            CBEventType.QUERY,
+            {EventPayload.RESPONSE: f"done-{eid[:6]}"},
+            event_id=eid,
+        )
+    h.end_trace("deep")
+
+    spans = _drain(sdk)
+    # No synthetic root span is emitted any more — exactly 10 query
+    # events, all under a single trace_id.
+    assert len(spans) == 10
+    assert len({s.trace_id for s in spans}) == 1
+    roots = [s for s in spans if s.parent_span_id is None]
+    assert len(roots) == 1
+
+
+# ---------- multi-trace interleaving ----------
+
+
+def test_two_concurrent_traces_are_isolated(sdk):
+    """A handler may receive interleaved events from two traces.
+    Each event must produce its own span."""
+    h = SynapticCallbackHandler()
+    h.start_trace("trace-A")
+    h.start_trace("trace-B")
+    a_id = _ev()
+    b_id = _ev()
+    h.on_event_start(
+        CBEventType.RETRIEVE, {EventPayload.QUERY_STR: "qA"}, event_id=a_id
+    )
+    h.on_event_start(
+        CBEventType.RETRIEVE, {EventPayload.QUERY_STR: "qB"}, event_id=b_id
+    )
+    h.on_event_end(CBEventType.RETRIEVE, {EventPayload.NODES: []}, event_id=a_id)
+    h.on_event_end(CBEventType.RETRIEVE, {EventPayload.NODES: []}, event_id=b_id)
+    h.end_trace("trace-A")
+    h.end_trace("trace-B")
+
+    spans = _drain(sdk)
+    retrieves = [s for s in spans if s.name == "retrieve"]
+    assert len(retrieves) == 2
+    # Each is its own root (parent_span_id is None) since no outer
+    # @synaptic.trace was active and parent_id was empty
+    assert all(s.parent_span_id is None for s in retrieves)
+    # And both can carry distinct query inputs
+    inputs = sorted(s.input or "" for s in retrieves)
+    assert any("qA" in i for i in inputs)
+    assert any("qB" in i for i in inputs)
+
+
+# ---------- payload defensiveness ----------
+
+
+def test_llm_event_with_no_payload_at_all(sdk):
+    """LlamaIndex sometimes calls on_event_end with payload=None."""
+    h = SynapticCallbackHandler()
+    h.start_trace("t-none")
+    e = _ev()
+    h.on_event_start(CBEventType.LLM, None, event_id=e)
+    h.on_event_end(CBEventType.LLM, None, event_id=e)
+    h.end_trace("t-none")
+    spans = _drain(sdk)
+    # Should still produce the LLM span, just with no input/output
+    assert any(s.name == "llm_call" for s in spans)
+
+
+def test_retrieve_with_node_get_text_raising_does_not_crash(sdk):
+    """A weird node whose get_text() raises must not break the trace."""
+    h = SynapticCallbackHandler()
+    h.start_trace("t-bad-node")
+    re = _ev()
+    h.on_event_start(CBEventType.RETRIEVE, {EventPayload.QUERY_STR: "q"}, event_id=re)
+
+    class BadNode:
+        def get_text(self):
+            raise RuntimeError("text not loaded")
+
+        score = 0.5
+
+    h.on_event_end(
+        CBEventType.RETRIEVE,
+        {EventPayload.NODES: [BadNode()]},
+        event_id=re,
+    )
+    h.end_trace("t-bad-node")
+    spans = _drain(sdk)
+    # Span still emitted — bad node is recorded as best-effort str()
+    assert any(s.name == "retrieve" for s in spans)
+
+
+def test_llm_with_unknown_model_records_no_cost(sdk):
+    h = SynapticCallbackHandler()
+    h.start_trace("t-unk-model")
+    e = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "x"}, event_id=e)
+    response = SimpleNamespace(
+        raw={"usage": {"prompt_tokens": 10, "completion_tokens": 5}, "model": "future-model"},
+    )
+    h.on_event_end(
+        CBEventType.LLM,
+        {EventPayload.RESPONSE: response, EventPayload.MODEL_NAME: "future-model"},
+        event_id=e,
+    )
+    h.end_trace("t-unk-model")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    assert llm.model == "future-model"
+    assert llm.cost_usd is None
+
+
+# ---------- realistic event order from a query engine ----------
+
+
+def test_realistic_query_engine_event_order(sdk):
+    """Mirrors the actual order LlamaIndex emits for a vector
+    query_engine.query() call: QUERY → RETRIEVE → EMBEDDING (inside)
+    → SYNTHESIZE → CHUNKING / TEMPLATING / LLM. All under one root."""
+    h = SynapticCallbackHandler()
+    h.start_trace("query")
+    q = _ev()
+    h.on_event_start(
+        CBEventType.QUERY, {EventPayload.QUERY_STR: "what is X?"}, event_id=q
+    )
+    r = _ev()
+    h.on_event_start(
+        CBEventType.RETRIEVE,
+        {EventPayload.QUERY_STR: "what is X?"},
+        event_id=r,
+        parent_id=q,
+    )
+    eb = _ev()
+    h.on_event_start(
+        CBEventType.EMBEDDING,
+        {EventPayload.SERIALIZED: {"model": "text-embedding-3-small"}},
+        event_id=eb,
+        parent_id=r,
+    )
+    h.on_event_end(
+        CBEventType.EMBEDDING,
+        {EventPayload.EMBEDDINGS: [[0.0] * 4]},
+        event_id=eb,
+    )
+    nodes = [SimpleNamespace(get_text=lambda: "X is Y", score=0.9)]
+    h.on_event_end(CBEventType.RETRIEVE, {EventPayload.NODES: nodes}, event_id=r)
+    s = _ev()
+    h.on_event_start(CBEventType.SYNTHESIZE, {}, event_id=s, parent_id=q)
+    le = _ev()
+    h.on_event_start(
+        CBEventType.LLM,
+        {EventPayload.PROMPT: "given X is Y, answer..."},
+        event_id=le,
+        parent_id=s,
+    )
+    h.on_event_end(
+        CBEventType.LLM,
+        {
+            EventPayload.COMPLETION: "X is Y because reasons.",
+            EventPayload.MODEL_NAME: "gpt-4o-mini",
+        },
+        event_id=le,
+    )
+    h.on_event_end(CBEventType.SYNTHESIZE, {}, event_id=s)
+    h.on_event_end(
+        CBEventType.QUERY,
+        {EventPayload.RESPONSE: "X is Y because reasons."},
+        event_id=q,
+    )
+    h.end_trace("query")
+
+    spans = _drain(sdk)
+    by = {}
+    for sp in spans:
+        by.setdefault(sp.name, []).append(sp)
+    # Topology: query (root) > {retrieve > embedding,
+    #                           synthesize > llm_call}
+    assert len(by["query"]) == 1
+    root = by["query"][0]
+    assert root.parent_span_id is None
+    assert all(s.trace_id == root.trace_id for s in spans)
+    llm = by["llm_call"][0]
+    syn = by["synthesize"][0]
+    retr = by["retrieve"][0]
+    assert llm.parent_span_id == syn.id
+    assert syn.parent_span_id == root.id
+    assert retr.parent_span_id == root.id
+
+
+# ---------- resilience ----------
+
+
+def test_embedding_input_captured_from_end_payload_when_start_was_empty(sdk):
+    """LlamaIndex's actual event sequence puts the embedded text in
+    the END payload's CHUNKS field, not the start. Earlier versions
+    of this handler missed it because they only looked at start."""
+    h = SynapticCallbackHandler()
+    h.start_trace("t-emb-end")
+    e = _ev()
+    # Start payload has only SERIALIZED (model info) — no chunks
+    h.on_event_start(
+        CBEventType.EMBEDDING,
+        {EventPayload.SERIALIZED: {"model": "text-embedding-3-small"}},
+        event_id=e,
+    )
+    # End payload includes CHUNKS
+    h.on_event_end(
+        CBEventType.EMBEDDING,
+        {
+            EventPayload.CHUNKS: ["capital of France?"],
+            EventPayload.EMBEDDINGS: [[0.1, 0.2]],
+        },
+        event_id=e,
+    )
+    h.end_trace("t-emb-end")
+    spans = _drain(sdk)
+    emb = next(s for s in spans if s.name == "embedding")
+    assert emb.input is not None
+    assert "capital of France" in emb.input
+    assert emb.tokens_input is not None and emb.tokens_input > 0
+
+
+# ---------- rarer event types ----------
+
+
+def test_agent_step_and_sub_question_and_reranking(sdk):
+    """Cover the agent / sub-question / reranking event types — they
+    should all classify as type=custom and not crash."""
+    h = SynapticCallbackHandler()
+    h.start_trace("rare")
+    for ev_type, expected_name in [
+        (CBEventType.AGENT_STEP, "agent_step"),
+        (CBEventType.SUB_QUESTION, "sub_question"),
+        (CBEventType.RERANKING, "reranking"),
+        (CBEventType.TREE, "tree"),
+    ]:
+        eid = _ev()
+        h.on_event_start(ev_type, {}, event_id=eid)
+        h.on_event_end(ev_type, {}, event_id=eid)
+    h.end_trace("rare")
+    spans = _drain(sdk)
+    names = {s.name for s in spans}
+    assert {"agent_step", "sub_question", "reranking", "tree"}.issubset(names)
+    for s in spans:
+        assert s.type == "custom"
+
+
+def test_exception_event_with_string_error(sdk):
+    """Some integrations pass string errors instead of Exception
+    objects via the EXCEPTION payload."""
+    h = SynapticCallbackHandler()
+    h.start_trace("err")
+    eid = _ev()
+    h.on_event_start(CBEventType.EXCEPTION, {}, event_id=eid)
+    # Pass a non-Exception value
+    h.on_event_end(
+        CBEventType.EXCEPTION, {EventPayload.EXCEPTION: "stringified error"}, event_id=eid
+    )
+    h.end_trace("err")
+    spans = _drain(sdk)
+    exc = next(s for s in spans if s.name == "exception")
+    # error should be set even though the payload was a string
+    assert exc.error is not None
+    assert "stringified error" in exc.error
+
+
+def test_no_start_trace_events_still_emit_spans(sdk):
+    """Some users may use the handler outside the trace lifecycle —
+    on_event_start without start_trace must still produce a span."""
+    h = SynapticCallbackHandler()
+    eid = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "hi"}, event_id=eid)
+    h.on_event_end(
+        CBEventType.LLM, {EventPayload.COMPLETION: "ok"}, event_id=eid
+    )
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    assert llm.parent_span_id is None  # becomes a root span
+
+
+def test_end_trace_for_never_started_trace_does_not_crash(sdk):
+    """Defensive: pop on missing key shouldn't blow up."""
+    h = SynapticCallbackHandler()
+    h.end_trace("never-started")  # should be a no-op
+    h.end_trace(None)
+    # No exception = pass
+
+
+def test_repeated_start_trace_with_same_id_overwrites_safely(sdk):
+    """Starting the same trace_id twice without an end in between
+    should not crash. The second start replaces the first's outer
+    snapshot — that's acceptable since LlamaIndex shouldn't fire
+    two starts for one trace_id under normal conditions."""
+    h = SynapticCallbackHandler()
+    h.start_trace("dup")
+    h.start_trace("dup")
+    eid = _ev()
+    h.on_event_start(CBEventType.QUERY, {EventPayload.QUERY_STR: "x"}, event_id=eid)
+    h.on_event_end(CBEventType.QUERY, {EventPayload.RESPONSE: "ok"}, event_id=eid)
+    h.end_trace("dup")
+    h.end_trace("dup")  # second end is a no-op
+    spans = _drain(sdk)
+    assert any(s.name == "query" for s in spans)
+
+
+def test_chinese_and_emoji_in_query_text(sdk):
+    """Unicode in inputs — Synaptic uses ensure_ascii=False so chars
+    survive end-to-end."""
+    h = SynapticCallbackHandler()
+    h.start_trace("u")
+    eid = _ev()
+    h.on_event_start(
+        CBEventType.RETRIEVE,
+        {EventPayload.QUERY_STR: "なぜ 2+2=4? 🧠"},
+        event_id=eid,
+    )
+    h.on_event_end(CBEventType.RETRIEVE, {EventPayload.NODES: []}, event_id=eid)
+    h.end_trace("u")
+    spans = _drain(sdk)
+    retr = next(s for s in spans if s.name == "retrieve")
+    assert retr.input is not None
+    assert "なぜ" in retr.input
+    assert "🧠" in retr.input
+
+
+def test_extract_text_chat_response_with_nested_message(sdk):
+    """Real LlamaIndex ChatResponse has .message.content — must
+    surface the content cleanly, not the Python repr."""
+    h = SynapticCallbackHandler()
+    h.start_trace("chat-real")
+    eid = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "hi"}, event_id=eid)
+    response = SimpleNamespace(
+        message=SimpleNamespace(role="assistant", content="hello there"),
+        raw={"usage": {"prompt_tokens": 5, "completion_tokens": 3}},
+    )
+    h.on_event_end(
+        CBEventType.LLM,
+        {EventPayload.RESPONSE: response, EventPayload.MODEL_NAME: "gpt-4o"},
+        event_id=eid,
+    )
+    h.end_trace("chat-real")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    # Output should be the role+content string, not "namespace(message=...)"
+    assert "hello there" in (llm.output or "")
+    assert "namespace" not in (llm.output or "").lower()
+
+
+def test_extract_text_completion_response_with_text(sdk):
+    """CompletionResponse has .text directly."""
+    h = SynapticCallbackHandler()
+    h.start_trace("comp")
+    eid = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "hi"}, event_id=eid)
+    response = SimpleNamespace(text="bare completion text", raw={})
+    h.on_event_end(
+        CBEventType.LLM,
+        {EventPayload.RESPONSE: response, EventPayload.MODEL_NAME: "gpt-4o"},
+        event_id=eid,
+    )
+    h.end_trace("comp")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    assert "bare completion text" in (llm.output or "")
+
+
+def test_extract_text_dict_with_role_and_content(sdk):
+    """Some integrations pass {role, content} dicts. Must extract
+    cleanly without dumping Python repr."""
+    h = SynapticCallbackHandler()
+    h.start_trace("dict-msg")
+    eid = _ev()
+    msgs = [{"role": "system", "content": "be helpful"}, {"role": "user", "content": "hi"}]
+    h.on_event_start(CBEventType.LLM, {EventPayload.MESSAGES: msgs}, event_id=eid)
+    h.on_event_end(
+        CBEventType.LLM,
+        {EventPayload.COMPLETION: "ok", EventPayload.MODEL_NAME: "gpt-4o"},
+        event_id=eid,
+    )
+    h.end_trace("dict-msg")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    inp = llm.input or ""
+    assert "system: be helpful" in inp
+    assert "user: hi" in inp
+
+
+def test_response_with_message_object_extracts_content(sdk):
+    """LLM responses sometimes come as ChatMessage-like objects with
+    .content. Extraction should grab the content text."""
+    h = SynapticCallbackHandler()
+    h.start_trace("msg")
+    eid = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "hi"}, event_id=eid)
+    response = SimpleNamespace(
+        message=SimpleNamespace(role="assistant", content="hello there"),
+        raw={"usage": {"prompt_tokens": 5, "completion_tokens": 3}},
+    )
+    h.on_event_end(
+        CBEventType.LLM,
+        {EventPayload.RESPONSE: response, EventPayload.MODEL_NAME: "gpt-4o"},
+        event_id=eid,
+    )
+    h.end_trace("msg")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    # _extract_text walks .content — should find "hello there"
+    assert llm.output is not None
+    assert "hello there" in llm.output
+
+
+def test_function_call_with_simple_tool_dot_name(sdk):
+    """A tool that has .name directly (older style)."""
+    h = SynapticCallbackHandler()
+    h.start_trace("fn-direct")
+    eid = _ev()
+    tool = SimpleNamespace(name="search")
+    h.on_event_start(
+        CBEventType.FUNCTION_CALL,
+        {EventPayload.TOOL: tool, EventPayload.FUNCTION_CALL: {"q": "x"}},
+        event_id=eid,
+    )
+    h.on_event_end(
+        CBEventType.FUNCTION_CALL,
+        {EventPayload.FUNCTION_OUTPUT: "result"},
+        event_id=eid,
+    )
+    h.end_trace("fn-direct")
+    spans = _drain(sdk)
+    fn = next(s for s in spans if s.name == "function_call")
+    assert fn.tool_name == "search"
+
+
+def test_leaked_spans_are_reaped_in_end_trace_via_trace_map(sdk):
+    """A start without an end (exception unwound the stack) leaves
+    a span in self._spans. end_trace's trace_map tells us which
+    event_ids belong to this trace; we reap those on close."""
+    h = SynapticCallbackHandler()
+    h.start_trace("leak")
+    e1 = "leaked-evt-1"
+    e2 = "leaked-evt-2"
+    e3 = "closed-evt"
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "p"}, event_id=e1)
+    h.on_event_start(CBEventType.RETRIEVE, {EventPayload.QUERY_STR: "q"}, event_id=e2)
+    h.on_event_start(CBEventType.QUERY, {}, event_id=e3, parent_id=e1)
+    h.on_event_end(CBEventType.QUERY, {EventPayload.RESPONSE: "ok"}, event_id=e3)
+    # e1 and e2 never get on_event_end — simulate exception bypass.
+    # trace_map records the event tree.
+    h.end_trace("leak", trace_map={e1: [e3], e2: []})
+    # _spans should be empty after reap
+    assert len(h._spans) == 0
+    spans = _drain(sdk)
+    by_name = {}
+    for s in spans:
+        by_name.setdefault(s.name, []).append(s)
+    # llm_call (e1) and retrieve (e2) reaped with error message
+    leaked_llm = by_name.get("llm_call", [])
+    leaked_retrieve = by_name.get("retrieve", [])
+    assert len(leaked_llm) == 1
+    assert len(leaked_retrieve) == 1
+    assert "did not receive on_event_end" in (leaked_llm[0].error or "")
+    assert "did not receive on_event_end" in (leaked_retrieve[0].error or "")
+
+
+def test_leaked_spans_with_no_trace_map_are_kept(sdk):
+    """Defensive: if trace_map is None (older LlamaIndex versions
+    that don't pass it), don't reap — we can't tell which spans
+    belong to which active trace."""
+    h = SynapticCallbackHandler()
+    h.start_trace("no-map")
+    h.on_event_start(CBEventType.LLM, {}, event_id="orphan-1")
+    h.end_trace("no-map", trace_map=None)
+    # Span stays in _spans (may belong to a concurrent trace)
+    assert "orphan-1" in h._spans
+
+
+def test_fine_tuned_openai_model_cost_resolves(sdk):
+    """Real production fine-tuned model names look like
+    ``ft:gpt-4o:my-org::abc123``. Cost should resolve via the base
+    model's price."""
+    h = SynapticCallbackHandler()
+    h.start_trace("ft")
+    eid = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "hi"}, event_id=eid)
+    response = SimpleNamespace(
+        raw={"usage": {"prompt_tokens": 100, "completion_tokens": 50}}
+    )
+    h.on_event_end(
+        CBEventType.LLM,
+        {
+            EventPayload.RESPONSE: response,
+            EventPayload.MODEL_NAME: "ft:gpt-4o:my-org::abc123",
+        },
+        event_id=eid,
+    )
+    h.end_trace("ft")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    assert llm.cost_usd is not None and llm.cost_usd > 0
+
+
+def test_provider_prefixed_model_cost_resolves(sdk):
+    """Routers like LiteLLM / OpenRouter pass models as
+    ``openai/gpt-4o-mini`` — strip the provider prefix for matching."""
+    h = SynapticCallbackHandler()
+    h.start_trace("router")
+    eid = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "hi"}, event_id=eid)
+    response = SimpleNamespace(
+        raw={"usage": {"prompt_tokens": 50, "completion_tokens": 10}}
+    )
+    h.on_event_end(
+        CBEventType.LLM,
+        {
+            EventPayload.RESPONSE: response,
+            EventPayload.MODEL_NAME: "openai/gpt-4o-mini",
+        },
+        event_id=eid,
+    )
+    h.end_trace("router")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    assert llm.cost_usd is not None and llm.cost_usd > 0
+
+
+def test_register_custom_model_price(sdk):
+    """Users running self-hosted models can register a custom price
+    so cost surfaces correctly."""
+    from synaptic.integrations.llama_index import register_model_price, PRICES_PER_1K
+
+    original = dict(PRICES_PER_1K)
+    try:
+        register_model_price("my-self-hosted-llama", 0.0001, 0.0002)
+        h = SynapticCallbackHandler()
+        h.start_trace("self")
+        eid = _ev()
+        h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "x"}, event_id=eid)
+        response = SimpleNamespace(
+            raw={"usage": {"prompt_tokens": 100, "completion_tokens": 50}}
+        )
+        h.on_event_end(
+            CBEventType.LLM,
+            {
+                EventPayload.RESPONSE: response,
+                EventPayload.MODEL_NAME: "my-self-hosted-llama-7b",
+            },
+            event_id=eid,
+        )
+        h.end_trace("self")
+        spans = _drain(sdk)
+        llm = next(s for s in spans if s.name == "llm_call")
+        assert llm.cost_usd is not None
+        # 100 * 0.0001/1000 + 50 * 0.0002/1000 = 1e-5 + 1e-5 = 2e-5
+        assert llm.cost_usd == pytest.approx(0.00002, rel=1e-3)
+    finally:
+        # Restore so other tests aren't affected
+        PRICES_PER_1K.clear()
+        PRICES_PER_1K.update(original)
+
+
+def test_zero_config_uses_add_handler_to_preserve_callback_manager(monkeypatch):
+    """auto-registration must call existing.add_handler (preserving
+    subclass identity / state), not replace the manager wholesale."""
+    from llama_index.core import Settings
+    from llama_index.core.callbacks import CallbackManager
+    from synaptic.integrations.llama_index import _maybe_register_global
+
+    class TaggedCallbackManager(CallbackManager):
+        """User subclass with extra state we don't want to lose."""
+        def __init__(self, handlers=None):
+            super().__init__(handlers or [])
+            self.tag = "user-special"
+
+    monkeypatch.setenv("SYNAPTIC_TRACING", "true")
+    user_cm = TaggedCallbackManager([])
+    Settings.callback_manager = user_cm
+
+    assert _maybe_register_global() is True
+    # Same instance — not replaced
+    assert Settings.callback_manager is user_cm
+    assert Settings.callback_manager.tag == "user-special"
+    # And our handler was added
+    handlers = Settings.callback_manager.handlers
+    assert any(isinstance(h, SynapticCallbackHandler) for h in handlers)
+
+
+# ---------- payload pathologies ----------
+
+
+def test_payload_with_bytes_value_does_not_crash(sdk):
+    """Some custom integrations stash bytes in payloads. Don't crash."""
+    h = SynapticCallbackHandler()
+    h.start_trace("bytes")
+    eid = _ev()
+    h.on_event_start(
+        CBEventType.LLM,
+        {EventPayload.PROMPT: b"\x00\x01binary"},
+        event_id=eid,
+    )
+    h.on_event_end(
+        CBEventType.LLM,
+        {EventPayload.COMPLETION: b"\xff binary out"},
+        event_id=eid,
+    )
+    h.end_trace("bytes")
+    spans = _drain(sdk)
+    assert any(s.name == "llm_call" for s in spans)
+
+
+def test_payload_with_circular_reference_does_not_recurse(sdk):
+    """A self-referential payload (rare but possible from custom
+    code) shouldn't crash _serialize via infinite recursion."""
+    h = SynapticCallbackHandler()
+    h.start_trace("circ")
+    eid = _ev()
+    bad: dict = {"key": "value"}
+    bad["self"] = bad  # circular
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: bad}, event_id=eid)
+    h.on_event_end(CBEventType.LLM, {EventPayload.COMPLETION: "ok"}, event_id=eid)
+    h.end_trace("circ")
+    spans = _drain(sdk)
+    # No crash = pass; output may be truncated str repr
+    assert any(s.name == "llm_call" for s in spans)
+
+
+def test_extract_text_handles_deeply_nested_lists(sdk):
+    """100-deep nested list of strings shouldn't blow the stack."""
+    h = SynapticCallbackHandler()
+    h.start_trace("deep-list")
+    eid = _ev()
+    nested: object = "leaf"
+    for _ in range(100):
+        nested = [nested]
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: nested}, event_id=eid)
+    h.on_event_end(CBEventType.LLM, {EventPayload.COMPLETION: "ok"}, event_id=eid)
+    h.end_trace("deep-list")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    # Even truncated, the leaf token should make it in
+    assert "leaf" in (llm.input or "")
+
+
+# ---------- pydantic response.raw shape ----------
+
+
+def test_response_raw_is_pydantic_like_object(sdk):
+    """Some LLM integrations make response.raw a typed object (not
+    a dict). The fallback `getattr(raw, 'usage', None)` path must
+    pick up usage data."""
+    h = SynapticCallbackHandler()
+    h.start_trace("pyd")
+    eid = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "x"}, event_id=eid)
+    # Simulate a Pydantic-style raw with .usage attribute
+    usage_obj = SimpleNamespace(prompt_tokens=42, completion_tokens=11)
+    raw_obj = SimpleNamespace(usage=usage_obj, model="gpt-4o")
+    response = SimpleNamespace(raw=raw_obj)
+    h.on_event_end(
+        CBEventType.LLM,
+        {EventPayload.RESPONSE: response, EventPayload.MODEL_NAME: "gpt-4o"},
+        event_id=eid,
+    )
+    h.end_trace("pyd")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    assert llm.tokens_input == 42
+    assert llm.tokens_output == 11
+    assert llm.cost_usd is not None and llm.cost_usd > 0
+
+
+# ---------- multi-handler coexistence ----------
+
+
+def test_handler_coexists_with_another_callback_handler(sdk):
+    """When a CallbackManager has multiple handlers (e.g. user has
+    LlamaDebugHandler + Synaptic), our handler must work alongside
+    without interfering."""
+    from llama_index.core.callbacks.base_handler import BaseCallbackHandler
+    other_calls: list = []
+
+    class CountingHandler(BaseCallbackHandler):
+        def __init__(self): super().__init__([], [])
+        def on_event_start(self, event_type, payload=None, event_id="", parent_id="", **kw):
+            other_calls.append(("start", event_type, event_id))
+            return event_id
+        def on_event_end(self, event_type, payload=None, event_id="", **kw):
+            other_calls.append(("end", event_type, event_id))
+        def start_trace(self, trace_id=None): other_calls.append(("st", trace_id))
+        def end_trace(self, trace_id=None, trace_map=None): other_calls.append(("et", trace_id))
+
+    h = SynapticCallbackHandler()
+    other = CountingHandler()
+    # Simulate CallbackManager dispatching to both — both get every callback
+    for handler in (h, other):
+        handler.start_trace("multi")
+    eid = _ev()
+    for handler in (h, other):
+        handler.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "x"}, event_id=eid)
+    for handler in (h, other):
+        handler.on_event_end(CBEventType.LLM, {EventPayload.COMPLETION: "ok"}, event_id=eid)
+    for handler in (h, other):
+        handler.end_trace("multi")
+
+    # Synaptic span emitted
+    spans = _drain(sdk)
+    assert any(s.name == "llm_call" for s in spans)
+    # Other handler also saw all callbacks
+    assert ("start", CBEventType.LLM, eid) in other_calls
+    assert ("end", CBEventType.LLM, eid) in other_calls
+
+
+# ---------- partial submit failure ----------
+
+
+def test_one_failed_submit_doesnt_lose_subsequent_spans(sdk, monkeypatch):
+    """If submit() fails for one span, later spans must still ship."""
+    h = SynapticCallbackHandler()
+    h.start_trace("partial-fail")
+
+    real_submit = sdk.submit
+    fail_once = {"count": 0}
+
+    def submit_with_one_failure(span):
+        if span.name == "embedding":
+            fail_once["count"] += 1
+            raise RuntimeError("simulated transient failure")
+        return real_submit(span)
+
+    monkeypatch.setattr(sdk, "submit", submit_with_one_failure)
+
+    e1 = _ev()
+    h.on_event_start(CBEventType.EMBEDDING, {EventPayload.SERIALIZED: {"model": "x"}}, event_id=e1)
+    h.on_event_end(CBEventType.EMBEDDING, {EventPayload.EMBEDDINGS: [[0.1]]}, event_id=e1)
+
+    e2 = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "x"}, event_id=e2)
+    h.on_event_end(CBEventType.LLM, {EventPayload.COMPLETION: "ok"}, event_id=e2)
+
+    h.end_trace("partial-fail")
+
+    monkeypatch.setattr(sdk, "submit", real_submit)
+    spans = _drain(sdk)
+    # Embedding submit raised, but llm_call must still land
+    assert fail_once["count"] >= 1
+    assert any(s.name == "llm_call" for s in spans)
+
+
+# ---------- session_id propagation through a trace ----------
+
+
+def test_session_id_propagates_from_synaptic_session_through_llamaindex(sdk):
+    """When an LlamaIndex query runs inside a synaptic.session(),
+    every emitted span should carry the session_id."""
+    import synaptic
+
+    h = SynapticCallbackHandler()
+    with synaptic.session(id="session-abc"):
+        @synaptic.trace
+        def run() -> None:
+            h.start_trace("inside")
+            eid = _ev()
+            h.on_event_start(CBEventType.QUERY, {EventPayload.QUERY_STR: "x"}, event_id=eid)
+            sub = _ev()
+            h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "x"}, event_id=sub, parent_id=eid)
+            h.on_event_end(CBEventType.LLM, {EventPayload.COMPLETION: "ok"}, event_id=sub)
+            h.on_event_end(CBEventType.QUERY, {EventPayload.RESPONSE: "ok"}, event_id=eid)
+            h.end_trace("inside")
+        run()
+
+    spans = _drain(sdk)
+    # All spans (outer + LlamaIndex children) tagged with session_id
+    for s in spans:
+        assert s.session_id == "session-abc", f"{s.name} has session_id={s.session_id}"
+
+
+# ---------- end_trace with trace_map for already-closed events ----------
+
+
+def test_child_spans_are_temporally_nested_inside_parents(sdk):
+    """Every child's started_at must be >= parent's started_at, and
+    every child's ended_at must be <= parent's ended_at. This is a
+    fundamental invariant of nested spans — if violated, a timeline
+    visualization shows children outside their parent's bracket."""
+    h = SynapticCallbackHandler()
+    h.start_trace("nest")
+    parent = _ev()
+    h.on_event_start(CBEventType.QUERY, {EventPayload.QUERY_STR: "x"}, event_id=parent)
+    # Two children
+    c1 = _ev()
+    h.on_event_start(CBEventType.RETRIEVE, {EventPayload.QUERY_STR: "x"}, event_id=c1, parent_id=parent)
+    h.on_event_end(CBEventType.RETRIEVE, {EventPayload.NODES: []}, event_id=c1)
+    c2 = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "x"}, event_id=c2, parent_id=parent)
+    h.on_event_end(CBEventType.LLM, {EventPayload.COMPLETION: "ok"}, event_id=c2)
+    h.on_event_end(CBEventType.QUERY, {EventPayload.RESPONSE: "ok"}, event_id=parent)
+    h.end_trace("nest")
+
+    spans = _drain(sdk)
+    by_id = {s.id: s for s in spans}
+    for s in spans:
+        if not s.parent_span_id:
+            continue
+        p = by_id.get(s.parent_span_id)
+        if p is None:
+            continue
+        assert s.started_at >= p.started_at, (
+            f"{s.name}.started_at={s.started_at} < parent.started_at={p.started_at}"
+        )
+        assert s.ended_at is not None
+        assert p.ended_at is not None
+        assert s.ended_at <= p.ended_at, (
+            f"{s.name}.ended_at={s.ended_at} > parent.ended_at={p.ended_at}"
+        )
+
+
+def test_extract_model_falls_back_to_response_model_attribute(sdk):
+    """When no MODEL_NAME or SERIALIZED is in payload, the model
+    name lives on response.model (some integrations) — must use it."""
+    h = SynapticCallbackHandler()
+    h.start_trace("model-on-resp")
+    eid = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "x"}, event_id=eid)
+    response = SimpleNamespace(
+        model="gpt-4o-mini",
+        raw={"usage": {"prompt_tokens": 10, "completion_tokens": 5}},
+    )
+    # Note: deliberately NO MODEL_NAME in payload
+    h.on_event_end(CBEventType.LLM, {EventPayload.RESPONSE: response}, event_id=eid)
+    h.end_trace("model-on-resp")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    assert llm.model == "gpt-4o-mini"
+    assert llm.cost_usd is not None and llm.cost_usd > 0
+
+
+def test_extract_model_falls_back_to_response_raw_dict_model(sdk):
+    """Some LiteLLM-style responses put model only in response.raw['model']."""
+    h = SynapticCallbackHandler()
+    h.start_trace("model-in-raw")
+    eid = _ev()
+    h.on_event_start(CBEventType.LLM, {EventPayload.PROMPT: "x"}, event_id=eid)
+    response = SimpleNamespace(
+        raw={
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+            "model": "gpt-4o",
+        },
+    )
+    # No MODEL_NAME, no .model attr — only raw["model"]
+    h.on_event_end(CBEventType.LLM, {EventPayload.RESPONSE: response}, event_id=eid)
+    h.end_trace("model-in-raw")
+    spans = _drain(sdk)
+    llm = next(s for s in spans if s.name == "llm_call")
+    assert llm.model == "gpt-4o"
+    assert llm.cost_usd is not None and llm.cost_usd > 0
+
+
+def test_end_trace_trace_map_with_already_closed_events_is_safe(sdk):
+    """trace_map references events that completed cleanly — reaping
+    must skip them without error."""
+    h = SynapticCallbackHandler()
+    h.start_trace("normal")
+    e1 = _ev()
+    h.on_event_start(CBEventType.LLM, {}, event_id=e1)
+    h.on_event_end(CBEventType.LLM, {EventPayload.COMPLETION: "ok"}, event_id=e1)
+    # All events closed cleanly. trace_map references them.
+    h.end_trace("normal", trace_map={e1: []})
+    spans = _drain(sdk)
+    # Exactly one llm_call span (no duplicate from reaping)
+    llm_spans = [s for s in spans if s.name == "llm_call"]
+    assert len(llm_spans) == 1
+    assert llm_spans[0].error is None  # clean completion, no leak error
+
+
+def test_handler_unaffected_by_sdk_get_failure(sdk, monkeypatch):
+    """If even _get_sdk() raises, the agent must not crash."""
+    h = SynapticCallbackHandler()
+
+    import synaptic.integrations.llama_index as li_mod
+
+    def boom():
+        raise RuntimeError("sdk init failed")
+
+    monkeypatch.setattr(li_mod, "_get_sdk", boom)
+    h.start_trace("t-broken")
+    e = _ev()
+    h.on_event_start(CBEventType.LLM, {}, event_id=e)
+    h.on_event_end(CBEventType.LLM, {EventPayload.COMPLETION: "ok"}, event_id=e)
+    h.end_trace("t-broken")
+    # No exception escaped


### PR DESCRIPTION
## Summary
- New `synaptic.integrations.llama_index.SynapticCallbackHandler` plugs into LlamaIndex's `Settings.callback_manager` and ships every LLM call, retrieval, embedding, query, and tool call as a Synaptic span.
- Maps `CBEventType` → Synaptic span type (LLM→llm, RETRIEVE→retrieval, EMBEDDING→embedding, FUNCTION_CALL→tool, others→custom).
- Cost calculation with longest-prefix matching against a price table that handles **fine-tuned models** (`ft:gpt-4o:my-org::abc123`) and **provider-prefixed names** (`openai/gpt-4o-mini`). Public `register_model_price()` for self-hosted models.
- Auto-registration via `SYNAPTIC_TRACING=true`. Uses `existing.add_handler()` to preserve user `CallbackManager` subclass identity.
- Resilience (Synaptic Rule 7): mid-pipeline exceptions surface on the failing span via `EventPayload.EXCEPTION`; leaked spans (start without end) are reaped in `end_trace` using `trace_map`; garbage payloads / circular refs / bytes / partial submit failures all swallow silently.

## Also fixes
- 3 Playwright torture tests in `thinking_torture.spec.ts` that posted `thinking` spans without `parent_span_id`, leaving orphan-rooted traces in the DB. Found via cross-trace audit.

## Test plan
- [x] **71 new tests** (28 core + 43 stress/edge — leaked spans, deep nesting, concurrent traces, payload pathologies, real Anthropic-style usage shapes, multi-handler coexistence, session_id propagation through `synaptic.session()`, fine-tune model names, custom price registration, child-temporally-nested-in-parent invariant, async `aquery()`)
- [x] **93% line coverage** on `synaptic/integrations/llama_index.py` (uncovered lines are defensive `except Exception: pass` blocks per Rule 7)
- [x] **All 138 existing SDK tests still pass** (171 total now)
- [x] Live verified end-to-end: real `query_engine.query()` produces a clean 8-span trace with correct nesting, type classification, and token estimation
- [x] Live verified failure path: induced `RuntimeError` mid-retrieval; error surfaces on the failing span (not silently dropped)
- [x] Live verified leaked-span reaping: events that started without `on_event_end` get submitted at trace-close with an explicit error message
- [x] CI updated: `pip install -e ".[test,langchain,anthropic,llama_index]"` so the new tests run

## Bugs caught during the audit cycle (all fixed in this PR)
1. `embedding.input` was `None` (CHUNKS arrives only on end payload, not start)
2. Duplicate `query` root span (synthetic + event)
3. Mid-pipeline exceptions silently dropped (only EXCEPTION-type checked)
4. Cached prompts with `tokens=0` got dropped to `None` (`0 or x` falsy bug)
5. Embedding cost always `None` for OpenAI embedding models
6. Leaked spans accumulated in `_spans` dict (memory leak)
7. `_extract_text` produced Python `repr` for ChatResponse
8. Auto-registration **replaced** `Settings.callback_manager` instead of adding to it
9. Fine-tuned and provider-prefixed model names → cost=None