### PR TITLE
fix(anthropic): nest child span timestamps inside parent

### DIFF
--- a/packages/sdk-python/synaptic/integrations/anthropic.py
+++ b/packages/sdk-python/synaptic/integrations/anthropic.py
@@ -141,6 +141,23 @@ def _extract_blocks(response: Any) -> Tuple[List[Any], List[Any]]:
     return thinking, text
 
 
+def _midpoint(start: Optional[str], end: Optional[str], fraction: float = 0.5) -> Optional[str]:
+    """Return the ISO-8601 timestamp `fraction` of the way from
+    `start` to `end`. Used to split a parent span's interval into
+    sequential child intervals when Anthropic doesn't tell us the
+    exact thinking-vs-response boundary."""
+    if start is None or end is None:
+        return end or start
+    try:
+        from datetime import datetime
+        s = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        e = datetime.fromisoformat(end.replace("Z", "+00:00"))
+        delta = (e - s) * fraction
+        return (s + delta).isoformat()
+    except Exception:
+        return end
+
+
 def _block_text(block: Any, key: str) -> str:
     """Pull the inner text from a content block — works for both the
     typed ``ContentBlock`` objects and dict-shaped blocks."""
@@ -201,21 +218,26 @@ def _record_call(
         response_text = "".join(_block_text(b, "text") for b in text_blocks)
         parent.output = _serialize({"text": response_text})
         parent.end()
-        # Backdate started_at so the duration looks right (parent.end()
-        # uses now()). We adjusted started_at via the timing measurement.
-        # _ExtSpan exposes started_at from Span; we reset both to bracket
-        # the actual call.
-        # NOTE: keeping the auto-set started_at is acceptable; duration_ms
-        # is computed by the API from started_at and ended_at, so what
-        # matters is that ended_at > started_at and they bracket the call.
+        # Snapshot parent's interval. Children must fall WITHIN it
+        # so trace timelines render correctly. Without this, each
+        # child gets `now()` for started_at — strictly *after*
+        # parent.ended_at — and audit invariants break.
+        parent_started = parent.started_at
+        parent_ended = parent.ended_at
 
         sdk = _get_sdk()
         sdk.submit(parent)
 
         # Thinking span: one combined span aggregating all thinking
-        # blocks (Anthropic typically returns a single block, but the
-        # API allows multiple — we sum their text and tokens so the
-        # dashboard renders one row).
+        # blocks. Anthropic doesn't break thinking out of the wall
+        # clock — we don't know exactly when thinking ended and
+        # response began. Treat them as a sequence inside the
+        # parent's interval: thinking covers the FIRST 80% of the
+        # call (Claude spends most of the latency reasoning), and
+        # the response span covers the LAST 20%. This is a heuristic
+        # but it keeps the visual ordering correct in the timeline.
+        thinking_split = _midpoint(parent_started, parent_ended, 0.8)
+
         if thinking_blocks:
             thinking_span = _make_span(parent, "thinking", type="llm", subtype="thinking")
             thinking_span.model = model
@@ -224,7 +246,8 @@ def _record_call(
             thinking_span.input = _serialize({"thinking": thinking_text_total})
             # Thinking is billed at the output rate per Anthropic
             thinking_span.cost_usd = _compute_cost(model, 0, thinking_tokens_est)
-            thinking_span.end()
+            thinking_span.started_at = parent_started
+            thinking_span.ended_at = thinking_split
             sdk.submit(thinking_span)
 
         # Response span: final text answer
@@ -242,7 +265,10 @@ def _record_call(
                 model, 0, response_span.tokens_output
             )
             response_span.output = _serialize({"text": response_text})
-            response_span.end()
+            # If we had thinking, response starts where thinking ended.
+            # Otherwise, response covers the full parent interval.
+            response_span.started_at = thinking_split if thinking_blocks else parent_started
+            response_span.ended_at = parent_ended
             sdk.submit(response_span)
     except Exception:
         # Best-effort — agent must never see exceptions from Synaptic.

--- a/packages/sdk-python/tests/test_anthropic_integration.py
+++ b/packages/sdk-python/tests/test_anthropic_integration.py
@@ -383,6 +383,35 @@ def test_streaming_does_not_record_when_user_exits_with_exception(sdk):
     assert len(spans) == 0
 
 
+def test_child_spans_temporally_nested_inside_parent(sdk):
+    """Regression for a bug found by trace audit — every child's
+    [started_at, ended_at] interval must fall inside the parent's
+    interval. Originally children were created with `now()` after
+    `parent.end()` ran, putting them strictly after the parent's
+    bracket and breaking the timeline-nesting invariant."""
+    Cls = _make_messages_class(_response_with_thinking)
+    AsyncCls = _make_async_messages_class(_response_with_thinking)
+    instrument_anthropic(messages_cls=Cls, async_messages_cls=AsyncCls)
+
+    Cls().create(model="claude-opus-4-20250514", messages=[])
+    spans = _drain(sdk)
+    by_name = {s.name: s for s in spans}
+    parent = by_name["claude_call"]
+    for child_name in ("thinking", "response"):
+        if child_name not in by_name:
+            continue
+        c = by_name[child_name]
+        assert c.started_at >= parent.started_at, (
+            f"{child_name}.started_at={c.started_at} < parent.started_at={parent.started_at}"
+        )
+        assert c.ended_at <= parent.ended_at, (
+            f"{child_name}.ended_at={c.ended_at} > parent.ended_at={parent.ended_at}"
+        )
+    # And: thinking ends where response starts (sequential, not overlapping)
+    if "thinking" in by_name and "response" in by_name:
+        assert by_name["thinking"].ended_at == by_name["response"].started_at
+
+
 def test_to_dict_shape_for_thinking_span(sdk):
     Cls = _make_messages_class(_response_with_thinking)
     AsyncCls = _make_async_messages_class(_response_with_thinking)


### PR DESCRIPTION
## Summary
The Anthropic integration created `thinking` and `response` child spans **after** calling `parent.end()`, so each child got `started_at = now()` — strictly later than `parent.ended_at`. Sub-millisecond skew, but it breaks a fundamental invariant: every child's interval must fall inside its parent's, otherwise timeline visualizers misalign.

Found by running a cross-trace audit script that checks `child.started_at <= parent.ended_at` for every parent-child pair across all stored traces.

## Fix
- Snapshot `parent.started_at` / `parent.ended_at` immediately after `parent.end()` and BEFORE submitting it.
- New `_midpoint(start, end, fraction)` helper does ISO-timestamp arithmetic to split the parent's interval.
- Heuristic: `thinking` covers the first 80% (Claude spends most of the latency reasoning), `response` covers the last 20%. Both strictly nested inside parent, sequential, non-overlapping.

The integration captures the FINAL message after the Claude call returns — there's no real wall-clock signal for "when did thinking end and response begin," so an explicit heuristic is the honest choice.

## Test plan
- [x] **New regression test** `test_child_spans_temporally_nested_inside_parent` — asserts `child.started_at >= parent.started_at` and `child.ended_at <= parent.ended_at` for both children, plus `thinking.ended_at == response.started_at`
- [x] **All 30 Anthropic tests pass** (was 29; +1 timing regression)
- [x] Live verified: `parent: 645598 → 645800, thinking: 645598 → 645760, response: 645760 → 645800` — perfectly nested
- [x] Pre-existing trace-audit anomaly `child_starts_after_parent` — gone for new traces; old traces in the DB still show the historical artifacts (can't retroactively rewrite)