### PR TITLE
fix(api): aggregate trace.total_cost_usd and total_tokens from child spans

### DIFF
--- a/packages/api/routers/traces.py
+++ b/packages/api/routers/traces.py
@@ -63,6 +63,28 @@ def _row_to_trace(row: dict) -> Trace:
     )
 
 
+# SQL fragment that aggregates cost + tokens from a trace's spans
+# and returns the larger of the user-supplied value (set via POST
+# /v1/traces) or the computed sum. Lets the trace list and detail
+# show meaningful totals even when only spans were ingested.
+_TRACE_WITH_AGGREGATES = """
+SELECT
+    t.*,
+    GREATEST(
+        COALESCE(t.total_cost_usd, 0),
+        COALESCE((SELECT SUM(cost_usd) FROM spans WHERE trace_id = t.id), 0)
+    ) AS total_cost_usd,
+    GREATEST(
+        COALESCE(t.total_tokens, 0),
+        COALESCE((
+            SELECT SUM(COALESCE(tokens_input, 0) + COALESCE(tokens_output, 0))
+            FROM spans WHERE trace_id = t.id
+        ), 0)
+    ) AS total_tokens
+FROM traces t
+"""
+
+
 def _row_to_span(row: dict) -> Span:
     started = row.get("started_at")
     ended = row.get("ended_at")
@@ -162,11 +184,7 @@ def list_traces(
     db: Database = Depends(get_db),
 ) -> List[Trace]:
     rows = db.fetchall_dict(
-        """
-        SELECT * FROM traces
-        ORDER BY started_at DESC
-        LIMIT ? OFFSET ?
-        """,
+        _TRACE_WITH_AGGREGATES + " ORDER BY t.started_at DESC LIMIT ? OFFSET ?",
         [limit, offset],
     )
     return [_row_to_trace(r) for r in rows]
@@ -174,7 +192,9 @@ def list_traces(
 
 @router.get("/v1/traces/{trace_id}", response_model=Trace)
 def get_trace(trace_id: str, db: Database = Depends(get_db)) -> Trace:
-    row = db.fetchone_dict("SELECT * FROM traces WHERE id = ?", [trace_id])
+    row = db.fetchone_dict(
+        _TRACE_WITH_AGGREGATES + " WHERE t.id = ?", [trace_id]
+    )
     if row is None:
         raise HTTPException(status_code=404, detail="trace not found")
     return _row_to_trace(row)

--- a/packages/api/tests/test_query.py
+++ b/packages/api/tests/test_query.py
@@ -130,6 +130,61 @@ def test_post_traces_creates_trace_directly(client):
     assert response.json()["name"] == "manual"
 
 
+def test_trace_total_cost_is_aggregated_from_child_spans(client):
+    """When only spans are POSTed (no explicit /v1/traces upsert),
+    GET /v1/traces/{id} should still report total_cost_usd as the
+    sum of child span costs — previously it returned 0."""
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "p", "trace_id": "agg-1", "name": "claude_call",
+                    "type": "llm",
+                    "started_at": "2026-05-02T10:00:00Z",
+                    "ended_at": "2026-05-02T10:00:03Z",
+                    "tokens_input": 100, "tokens_output": 50, "cost_usd": 0.01,
+                },
+                {
+                    "id": "c", "trace_id": "agg-1", "parent_span_id": "p",
+                    "name": "tool", "type": "tool",
+                    "started_at": "2026-05-02T10:00:01Z",
+                    "ended_at": "2026-05-02T10:00:02Z",
+                    "tokens_input": 10, "tokens_output": 5, "cost_usd": 0.0001,
+                },
+            ]
+        },
+    )
+    body = client.get("/v1/traces/agg-1").json()
+    assert body["total_cost_usd"] == 0.0101
+    # tokens: 100+50 + 10+5 = 165
+    assert body["total_tokens"] == 165
+
+
+def test_explicit_trace_total_overrides_smaller_aggregate(client):
+    """When the user POSTs /v1/traces with an explicit total higher
+    than the span sum, the explicit value wins (GREATEST semantics)."""
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [{
+                "id": "s", "trace_id": "agg-2", "name": "x", "type": "llm",
+                "started_at": "2026-05-02T10:00:00Z",
+                "ended_at": "2026-05-02T10:00:01Z",
+                "cost_usd": 0.001,
+            }]
+        },
+    )
+    client.post("/v1/traces", json={
+        "id": "agg-2", "name": "manual",
+        "started_at": "2026-05-02T10:00:00Z",
+        "ended_at": "2026-05-02T10:00:01Z",
+        "total_cost_usd": 99.99,
+    })
+    body = client.get("/v1/traces/agg-2").json()
+    assert body["total_cost_usd"] == 99.99
+
+
 def test_post_eval_creates_eval(client):
     _post_span(client, id="t", trace_id="t")
     response = client.post(


### PR DESCRIPTION
## Summary
A trace ingested via `POST /v1/spans` (the SDK path) always reported `total_cost_usd=0` and `total_tokens=0` because the trace row's totals are stub-initialized when the first span lands and never updated as more spans arrive. The dashboard's *Total cost* / *Total tokens* metrics on every spans-only trace showed `$0` / `0` even when LLM children had real cost and token data.

Found via cross-trace audit during the LlamaIndex integration work — caught a Claude trace with `llm_call.cost_usd=$0.0125` but `trace.total_cost_usd=$0.0`.

## Fix
`GET /v1/traces` and `GET /v1/traces/{id}` now run a subquery that computes `SUM(cost_usd)` and `SUM(tokens_input + tokens_output)` across the trace's spans, and returns `GREATEST(stored, computed)`. This:
- Preserves `test_post_traces_creates_trace_directly` semantics — explicit `POST /v1/traces` totals win when larger
- Surfaces meaningful totals for spans-only traces without requiring the SDK to also POST to `/v1/traces`
- Single SQL roundtrip (no N+1), via `_TRACE_WITH_AGGREGATES` SQL fragment

## Test plan
- [x] `test_trace_total_cost_is_aggregated_from_child_spans` — POST 2 spans with cost, GET trace, expect summed cost/tokens
- [x] `test_explicit_trace_total_overrides_smaller_aggregate` — explicit POST `/v1/traces` value of $99.99 wins over span sum of $0.001
- [x] **All 59 existing API tests still pass** (61 total now)
- [x] Live verified: a Claude trace that previously showed `total_cost_usd: 0.0` now correctly reports `total_cost_usd: 0.00315, total_tokens: 46`