### PR TITLE
fix(api): persist session_id on span rows, not just on the trace

### DIFF
--- a/packages/api/db.py
+++ b/packages/api/db.py
@@ -46,7 +46,8 @@ CREATE TABLE IF NOT EXISTS spans (
     tool_name VARCHAR,
     metadata JSON,
     span_subtype VARCHAR,
-    thinking_tokens INTEGER
+    thinking_tokens INTEGER,
+    session_id VARCHAR
 );
 
 CREATE TABLE IF NOT EXISTS evals (
@@ -90,6 +91,7 @@ class Database:
             for migration in (
                 "ALTER TABLE spans ADD COLUMN IF NOT EXISTS span_subtype VARCHAR",
                 "ALTER TABLE spans ADD COLUMN IF NOT EXISTS thinking_tokens INTEGER",
+                "ALTER TABLE spans ADD COLUMN IF NOT EXISTS session_id VARCHAR",
             ):
                 try:
                     self._duck.execute(migration)

--- a/packages/api/models.py
+++ b/packages/api/models.py
@@ -106,6 +106,7 @@ class Span(BaseModel):
     metadata: Optional[Any] = None
     span_subtype: Optional[str] = None
     thinking_tokens: Optional[int] = None
+    session_id: Optional[str] = None
 
 
 class Session(BaseModel):

--- a/packages/api/routers/spans.py
+++ b/packages/api/routers/spans.py
@@ -57,8 +57,8 @@ def _insert_span(db: Database, span: SpanInput) -> None:
             id, trace_id, parent_span_id, type, name, input, output,
             model, provider, tokens_input, tokens_output, cost_usd,
             started_at, ended_at, status, error_message, tool_name, metadata,
-            span_subtype, thinking_tokens
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            span_subtype, thinking_tokens, session_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT (id) DO UPDATE SET
             trace_id = EXCLUDED.trace_id,
             parent_span_id = EXCLUDED.parent_span_id,
@@ -78,7 +78,8 @@ def _insert_span(db: Database, span: SpanInput) -> None:
             tool_name = EXCLUDED.tool_name,
             metadata = EXCLUDED.metadata,
             span_subtype = EXCLUDED.span_subtype,
-            thinking_tokens = EXCLUDED.thinking_tokens
+            thinking_tokens = EXCLUDED.thinking_tokens,
+            session_id = EXCLUDED.session_id
         """,
         [
             span.id,
@@ -101,6 +102,7 @@ def _insert_span(db: Database, span: SpanInput) -> None:
             metadata_str,
             span.span_subtype,
             span.thinking_tokens,
+            span.session_id,
         ],
     )
 

--- a/packages/api/routers/traces.py
+++ b/packages/api/routers/traces.py
@@ -122,6 +122,7 @@ def _row_to_span(row: dict) -> Span:
         metadata=metadata,
         span_subtype=row.get("span_subtype"),
         thinking_tokens=row.get("thinking_tokens"),
+        session_id=row.get("session_id"),
     )
 
 

--- a/packages/api/tests/test_sessions.py
+++ b/packages/api/tests/test_sessions.py
@@ -23,6 +23,64 @@ def _post_root(client, *, id_, session_id=None, name=None, started_at=None, ende
     )
 
 
+def test_span_session_id_round_trips_through_api(client):
+    """Regression: the spans table was missing a session_id column,
+    so POSTs that included session_id had it silently dropped on
+    the span row (only the trace metadata kept it). Confirm that
+    GET /v1/traces/{id}/spans now returns the value."""
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "sess-roundtrip-1",
+                    "trace_id": "sess-roundtrip-trace",
+                    "name": "test",
+                    "type": "custom",
+                    "started_at": "2026-05-04T10:00:00Z",
+                    "ended_at": "2026-05-04T10:00:01Z",
+                    "session_id": "user-abc-conversation-123",
+                },
+                {
+                    "id": "sess-roundtrip-2",
+                    "trace_id": "sess-roundtrip-trace",
+                    "parent_span_id": "sess-roundtrip-1",
+                    "name": "child",
+                    "type": "custom",
+                    "started_at": "2026-05-04T10:00:00.500Z",
+                    "ended_at": "2026-05-04T10:00:00.800Z",
+                    "session_id": "user-abc-conversation-123",
+                },
+            ]
+        },
+    )
+    spans = client.get("/v1/traces/sess-roundtrip-trace/spans").json()
+    assert len(spans) == 2
+    for s in spans:
+        assert s["session_id"] == "user-abc-conversation-123", (
+            f"{s['name']} span dropped session_id"
+        )
+
+
+def test_span_without_session_id_keeps_null(client):
+    """A span without an explicit session_id should round-trip as
+    null — not propagate from the trace's session_id."""
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [{
+                "id": "no-sess-1",
+                "trace_id": "no-sess-trace",
+                "name": "test",
+                "started_at": "2026-05-04T10:00:00Z",
+                "ended_at": "2026-05-04T10:00:01Z",
+            }]
+        },
+    )
+    spans = client.get("/v1/traces/no-sess-trace/spans").json()
+    assert spans[0]["session_id"] is None
+
+
 def test_list_sessions_groups_traces_by_session_id(client):
     s1 = "session-A"
     s2 = "session-B"


### PR DESCRIPTION
## Summary
The spans table had no `session_id` column — so a span ingested via `POST /v1/spans` with `session_id` set had the value silently dropped at storage time. Only the **trace's** `session_id` survived (via `_upsert_trace_from_span`'s explicit COALESCE on the trace row); `GET /v1/traces/{id}/spans` returned `session_id: null` on every span even when the SDK sent it correctly across the wire.

Found via cross-trace audit while testing `@synaptic/openclaw`: dashboard showed empty per-span session column on a 7-span trace whose root explicitly set `openclaw.channel.id`.

## Fix
- Add `session_id VARCHAR` column to the spans `CREATE TABLE`
- Add `ALTER TABLE … ADD COLUMN IF NOT EXISTS` migration so existing databases pick it up on next boot
- Update `_insert_span` SQL + parameter list to include session_id (and the ON CONFLICT DO UPDATE preserves it)
- Update `Span` Pydantic model to expose `session_id: Optional[str] = None`
- Update `_row_to_span` to read it

## Test plan
- [x] **2 new regression tests** in `test_sessions.py`:
  - `test_span_session_id_round_trips_through_api` — would have caught the original bug
  - `test_span_without_session_id_keeps_null` — ensures span doesn't accidentally inherit from trace
- [x] **All 61 existing API tests still pass** (63 total now)
- [x] **Live verified**: a fresh OpenClaw mega-trace with 7 spans shows `session_id=tg:academic_user_v2` on every span (was null before)
- [x] **Migration tested**: re-POSTed an old span (originally inserted before the column existed) — `ON CONFLICT DO UPDATE` correctly populates the new column