### PR TITLE
chore(openclaw-skill): match ClawHub frontmatter schema

### DIFF
--- a/packages/integrations/openclaw/skill/SKILL.md
+++ b/packages/integrations/openclaw/skill/SKILL.md
@@ -1,16 +1,32 @@
 ---
 name: synaptic
-description: >
-  Observe and debug your OpenClaw agent with Synaptic — local-first
-  AI observability. Use when the user asks:
-  - "show my agent traces"
-  - "why did my agent fail"
-  - "how much did my last run cost"
-  - "open synaptic"
-  - "debug my agent"
-  - "show recent traces"
-  - "what did my agent do"
-  - "trace details for <id>"
+description: >-
+  Observe and debug your OpenClaw agent with Synaptic — local-first AI
+  observability. Records every LLM call, tool call, and decision; view
+  at localhost:3000. Use when the user asks: "show my agent traces",
+  "why did my agent fail", "how much did my last run cost", "open
+  synaptic", "debug my agent", or "show recent traces".
+version: 0.1.0
+metadata:
+  openclaw:
+    primaryEnv: SYNAPTIC_HOST
+    envVars:
+      - name: SYNAPTIC_HOST
+        required: false
+        description: >-
+          Synaptic API base URL. Defaults to http://localhost:8000.
+          Override only if Synaptic is running on a non-default host.
+      - name: SYNAPTIC_API_KEY
+        required: false
+        description: >-
+          Optional bearer token. Required only when talking to a hosted
+          Synaptic instance; not used for the default localhost setup.
+    requires:
+      anyBins:
+        - node
+        - bun
+    emoji: "📊"
+    homepage: https://github.com/amitbidlan/zistica-synaptic
 ---
 
 ## Synaptic — Local Agent Observability
@@ -19,22 +35,24 @@ Synaptic records every LLM call, tool call, and decision your OpenClaw
 agent makes. View them at <http://localhost:3000>. Data never leaves
 the machine — everything runs in a single Docker container.
 
-This skill provides commands to check Synaptic's status and pull
-trace data without leaving the chat.
+This skill provides three commands that hit Synaptic's local HTTP API
+so you can check status and pull trace data without leaving the chat.
 
 ### Check if Synaptic is running
 
 Run: `node $SKILL_DIR/synaptic.mjs status`
 
 Returns one of:
+
 - `Synaptic is running on http://localhost:8000`
-- `Synaptic is not running. Start with: docker run -p 3000:3000 -p 8000:8000 zistica/synaptic`
+- `Synaptic is not running on …. Start with: docker run -p 3000:3000 -p 8000:8000 zistica/synaptic`
 
 ### Show recent traces
 
 Run: `node $SKILL_DIR/synaptic.mjs traces`
 
-Returns the last 5 agent traces formatted as:
+Returns the last 5 agent traces formatted like:
+
 ```
 Recent agent traces:
   1. openclaw_session  3.2s  $0.0023  OK
@@ -51,15 +69,17 @@ Run: `node $SKILL_DIR/synaptic.mjs trace <id>`
 Returns the trace metadata plus every span with type, model, tokens,
 cost, and any error message.
 
-### Configuration
+### Wire OpenClaw to Synaptic
 
-Set `SYNAPTIC_HOST` to point at a non-default Synaptic instance:
+This skill only reads from Synaptic. To get your OpenClaw agent's
+traces *into* Synaptic, install the companion exporter:
 
 ```bash
-export SYNAPTIC_HOST=http://my-synaptic:8000
+npm install @synaptic/openclaw
 ```
 
-Default is `http://localhost:8000`.
+…and pass `synapticProcessor()` into your OpenClaw OTel config. See
+<https://github.com/amitbidlan/zistica-synaptic/tree/main/packages/integrations/openclaw>.
 
 ### Start Synaptic (if not running)
 


### PR DESCRIPTION
## Summary
Tighten `packages/integrations/openclaw/skill/SKILL.md` to match the schema documented in [ClawHub's `docs/skill-format.md`](https://github.com/openclaw/clawhub/blob/main/docs/skill-format.md). Pre-req for `clawhub skill publish`.

- Adds `version: 0.1.0` (semver — required for publish)
- Moves `SYNAPTIC_HOST` out of `requires.env` (it's optional — has a default of `http://localhost:8000`) into `envVars` with `required: false` per the docs' explicit guidance
- Declares `requires.anyBins: [node, bun]` since the helper runs on either
- Adds `primaryEnv`, `emoji: 📊`, `homepage` for registry display
- Documents optional `SYNAPTIC_API_KEY` for hosted-Synaptic users
- Adds a "Wire OpenClaw to Synaptic" section pointing users at `@synaptic/openclaw`

## Test plan
- [x] YAML frontmatter parses cleanly (verified with `yaml.safe_load`)
- [x] `synaptic.mjs status / traces / trace <id>` still work end-to-end
- [x] No code changes