### PR TITLE
chore(openclaw): rebrand npm package to @zistica-synaptic/openclaw

### DIFF
--- a/packages/integrations/openclaw/README.md
+++ b/packages/integrations/openclaw/README.md
@@ -1,13 +1,13 @@
-# @synaptic/openclaw
+# @zistica-synaptic/openclaw
 
 > Debug your [OpenClaw](https://github.com/openclaw/openclaw) agent locally. No account. No cloud. No telemetry leaving your laptop.
 
-`@synaptic/openclaw` is the Synaptic side of OpenClaw's OTel telemetry pipeline. OpenClaw ships diagnostics through `@openclaw/diagnostics-otel`; this package provides a drop-in `SpanExporter` that converts those spans to Synaptic's wire format and ships them to a local Synaptic instance — visible at `http://localhost:3000`.
+`@zistica-synaptic/openclaw` is the Synaptic side of OpenClaw's OTel telemetry pipeline. OpenClaw ships diagnostics through `@openclaw/diagnostics-otel`; this package provides a drop-in `SpanExporter` that converts those spans to Synaptic's wire format and ships them to a local Synaptic instance — visible at `http://localhost:3000`.
 
 ## Install
 
 ```bash
-npm install @synaptic/openclaw
+npm install @zistica-synaptic/openclaw
 ```
 
 You also need a running Synaptic instance:
@@ -21,7 +21,7 @@ docker run -p 3000:3000 -p 8000:8000 zistica/synaptic
 Build the processor and pass it to `@openclaw/diagnostics-otel`'s `spanProcessors:` array (or to any OTel `NodeTracerProvider` config you're already using):
 
 ```typescript
-import { synapticProcessor } from '@synaptic/openclaw';
+import { synapticProcessor } from '@zistica-synaptic/openclaw';
 
 // In your OpenClaw / OTel config:
 const tracerProvider = new NodeTracerProvider({
@@ -46,7 +46,7 @@ export SYNAPTIC_HOST=http://localhost:8000
 If you want full control over the OTel pipeline (e.g. `SimpleSpanProcessor` for tests), use the bare exporter:
 
 ```typescript
-import { SynapticExporter } from '@synaptic/openclaw';
+import { SynapticExporter } from '@zistica-synaptic/openclaw';
 import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 
 const exporter = new SynapticExporter({
@@ -65,7 +65,7 @@ export SYNAPTIC_TRACING=true
 ```
 
 ```typescript
-import '@synaptic/openclaw/auto';
+import '@zistica-synaptic/openclaw/auto';
 ```
 
 This path is best-effort — modern OTel (and OpenClaw's diagnostics-otel) requires processors to be supplied at construction time, in which case the import silently no-ops and you should fall back to `synapticProcessor()` above.

--- a/packages/integrations/openclaw/package-lock.json
+++ b/packages/integrations/openclaw/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@synaptic/openclaw",
+  "name": "@zistica-synaptic/openclaw",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@synaptic/openclaw",
+      "name": "@zistica-synaptic/openclaw",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/integrations/openclaw/package.json
+++ b/packages/integrations/openclaw/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@synaptic/openclaw",
+  "name": "@zistica-synaptic/openclaw",
   "version": "0.1.0",
   "description": "Synaptic exporter for OpenClaw agents — local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",

--- a/packages/integrations/openclaw/skill/SKILL.md
+++ b/packages/integrations/openclaw/skill/SKILL.md
@@ -75,7 +75,7 @@ This skill only reads from Synaptic. To get your OpenClaw agent's
 traces *into* Synaptic, install the companion exporter:
 
 ```bash
-npm install @synaptic/openclaw
+npm install @zistica-synaptic/openclaw
 ```
 
 …and pass `synapticProcessor()` into your OpenClaw OTel config. See

--- a/packages/integrations/openclaw/src/auto.ts
+++ b/packages/integrations/openclaw/src/auto.ts
@@ -1,5 +1,5 @@
 /**
- * Side-effect entry point — `import "@synaptic/openclaw/auto"` enables
+ * Side-effect entry point — `import "@zistica-synaptic/openclaw/auto"` enables
  * tracing when SYNAPTIC_TRACING is truthy.
  *
  * Honest caveat: modern OpenTelemetry (v2+) requires SpanProcessors
@@ -15,7 +15,7 @@
  * For OpenClaw v1+ the supported path is to wire the processor
  * directly into `@openclaw/diagnostics-otel`'s configuration, e.g.:
  *
- *     import { synapticProcessor } from '@synaptic/openclaw';
+ *     import { synapticProcessor } from '@zistica-synaptic/openclaw';
  *     // … pass synapticProcessor() into the diagnostics config
  *
  * This module is a courtesy hook for environments where late

--- a/packages/integrations/openclaw/src/config.ts
+++ b/packages/integrations/openclaw/src/config.ts
@@ -5,7 +5,7 @@
  *
  * Usage:
  *
- *     import { synapticProcessor } from '@synaptic/openclaw';
+ *     import { synapticProcessor } from '@zistica-synaptic/openclaw';
  *
  *     // Pass to the OTel SDK / OpenClaw diagnostics config:
  *     spanProcessors: [synapticProcessor()]

--- a/packages/integrations/openclaw/src/index.ts
+++ b/packages/integrations/openclaw/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @synaptic/openclaw — local-first observability for OpenClaw agents.
+ * @zistica-synaptic/openclaw — local-first observability for OpenClaw agents.
  *
  * OpenClaw emits OTel telemetry through `@openclaw/diagnostics-otel`.
  * This package provides the Synaptic side of that pipe — an OTel
@@ -16,7 +16,7 @@
  *     that want a SimpleSpanProcessor instead).
  *   - installSynapticTracing(): attaches a SynapticExporter to the
  *     active OTel tracer provider when SYNAPTIC_TRACING=true. Most
- *     users will use the `import "@synaptic/openclaw/auto"` form.
+ *     users will use the `import "@zistica-synaptic/openclaw/auto"` form.
  */
 
 export {


### PR DESCRIPTION
## Why
The `@synaptic` scope on npm is owned by another user — `npm publish` returns a 403/404 from `zistica`. Rebrand to `@zistica-synaptic`, which matches the GitHub repo name exactly and is owned by the project.

## Changes
- `package.json` name: `@synaptic/openclaw` → `@zistica-synaptic/openclaw`
- README install commands + import examples
- `SKILL.md` "Wire OpenClaw to Synaptic" section
- `src/{index,auto,config}.ts` docstring references
- `package-lock.json` regenerated

The product still shows as **Synaptic** in the dashboard. The exporter class is still `SynapticExporter`. Helpers are still `synapticProcessor()` / `synapticExporter()`. Only the **npm scope** changes.

Future packages stay under the same scope: `@zistica-synaptic/openclaw`, `@zistica-synaptic/mastra`, `@zistica-synaptic/llamaindex`, etc.

## Test plan
- [x] All 54 OpenClaw tests pass on the rebrand
- [x] Build green
- [x] No references to `@synaptic/openclaw` left in the package
- [x] awesome-openclaw-agents PR (#61 mergisi/awesome-openclaw-agents) updated to match
- [x] Issue + Discord drafts updated