### PR TITLE
fix: correct GitHub repo URL after Synaptic → Lumin rebrand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,4 +36,4 @@ Each release has sections for:
 - **Removed** — removed features
 - **Security** — security fixes (always upgrade immediately)
 
-[Unreleased]: https://github.com/zistica/lumin/compare/HEAD
+[Unreleased]: https://github.com/amitbidlan/zistica-lumin/compare/HEAD

--- a/GOOD_FIRST_ISSUES.md
+++ b/GOOD_FIRST_ISSUES.md
@@ -275,14 +275,14 @@ If you have not contributed to Lumin before, start with a `good first issue` fir
 
 ## HOW TO CREATE THESE ON GITHUB
 
-1. Go to `github.com/zistica/lumin/issues/new`
+1. Go to `github.com/amitbidlan/zistica-lumin/issues/new`
 2. Copy the Title and Body from above
 3. Add the Labels listed (create labels first if they don't exist)
 4. Submit
 
 ## LABELS TO CREATE FIRST
 
-Go to github.com/zistica/lumin/labels and create these:
+Go to github.com/amitbidlan/zistica-lumin/labels and create these:
 
 | Label | Color | Description |
 |---|---|---|

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -71,7 +71,7 @@ export default function RootLayout({
                 API
               </a>
               <a
-                href="https://github.com/zistica/lumin"
+                href="https://github.com/amitbidlan/zistica-lumin"
                 target="_blank"
                 rel="noreferrer"
                 className="text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"

--- a/packages/dashboard/package-lock.json
+++ b/packages/dashboard/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "synaptic-dashboard",
+  "name": "lumin-dashboard",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "synaptic-dashboard",
+      "name": "lumin-dashboard",
       "version": "0.1.0",
       "dependencies": {
         "next": "14.2.18",


### PR DESCRIPTION
## Summary

The mass substitution in #17 turned the old `zistica/synaptic` org/repo references into `zistica/lumin`, but no `zistica` GitHub org exists — the repo lives at `amitbidlan/zistica-lumin`. The "GitHub" link in the dashboard header was 404ing.

Patches 4 broken refs:

- `packages/dashboard/app/layout.tsx` — visible header link
- `CHANGELOG.md` — `[Unreleased]` compare URL
- `GOOD_FIRST_ISSUES.md` — two contributor instructions

Also includes a regenerated `packages/dashboard/package-lock.json` (the `name` field was a leftover `synaptic-dashboard`; `package.json` already said `lumin-dashboard` after #17).

## Test plan

- [x] `curl -sSL http://localhost:3000/traces/test-123 | grep github.com` returns `https://github.com/amitbidlan/zistica-lumin` (was `zistica/lumin`, 404).
- [x] No remaining `github.com/zistica/lumin` strings in tracked source.