### PR TITLE
fix(integrations): Mastra parity + tool-attribute fallback + span session inheritance

### DIFF
--- a/packages/api/routers/traces.py
+++ b/packages/api/routers/traces.py
@@ -211,4 +211,22 @@ def get_trace_spans(trace_id: str, db: Database = Depends(get_db)) -> List[Span]
         """,
         [trace_id],
     )
+
+    # session_id inheritance: when the SDK or framework emits child spans
+    # without a session_id (because the value is only set on the OTel
+    # resource of the *root span* attrs), every child should still appear
+    # in the right /sessions group. Inherit from the trace row.
+    #
+    # Done at read time rather than ingest time to avoid an extra query
+    # in the hot path, and because orphan-child ordering means the trace
+    # row may not yet know its session_id at insert time.
+    trace_row = db.fetchone_dict(
+        "SELECT session_id FROM traces WHERE id = ?", [trace_id]
+    )
+    trace_sid = trace_row.get("session_id") if trace_row else None
+    if trace_sid:
+        for r in rows:
+            if r.get("session_id") is None:
+                r["session_id"] = trace_sid
+
     return [_row_to_span(r) for r in rows]

--- a/packages/api/tests/test_sessions.py
+++ b/packages/api/tests/test_sessions.py
@@ -62,9 +62,9 @@ def test_span_session_id_round_trips_through_api(client):
         )
 
 
-def test_span_without_session_id_keeps_null(client):
-    """A span without an explicit session_id should round-trip as
-    null — not propagate from the trace's session_id."""
+def test_span_without_session_id_when_trace_also_has_none_stays_null(client):
+    """When neither the span nor its trace has a session_id, GET
+    returns null — there's nothing to inherit from."""
     client.post(
         "/v1/spans",
         json={
@@ -79,6 +79,45 @@ def test_span_without_session_id_keeps_null(client):
     )
     spans = client.get("/v1/traces/no-sess-trace/spans").json()
     assert spans[0]["session_id"] is None
+
+
+def test_child_span_inherits_trace_session_id_at_read_time(client):
+    """A child span ingested without session_id should inherit it from
+    the parent trace at read time. Real-world driver: OTel-based SDKs
+    (Mastra, OpenClaw via @lumin-io/*) often set the session id only on
+    the root span — children would otherwise show as belonging to no
+    session in the dashboard's per-session view."""
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "root-sid",
+                    "trace_id": "trace-with-sid",
+                    "name": "root",
+                    "started_at": "2026-05-04T10:00:00Z",
+                    "ended_at": "2026-05-04T10:00:02Z",
+                    "session_id": "discord-research-001",
+                },
+                {
+                    "id": "child-no-sid",
+                    "trace_id": "trace-with-sid",
+                    "parent_span_id": "root-sid",
+                    "name": "child",
+                    "started_at": "2026-05-04T10:00:00.100Z",
+                    "ended_at": "2026-05-04T10:00:00.500Z",
+                    # session_id deliberately omitted — the framework
+                    # only set it on the root.
+                },
+            ]
+        },
+    )
+    spans = client.get("/v1/traces/trace-with-sid/spans").json()
+    assert len(spans) == 2
+    by_name = {s["name"]: s for s in spans}
+    assert by_name["root"]["session_id"] == "discord-research-001"
+    # The child should inherit from the trace, not show null
+    assert by_name["child"]["session_id"] == "discord-research-001"
 
 
 def test_list_sessions_groups_traces_by_session_id(client):

--- a/packages/integrations/mastra/src/exporter.ts
+++ b/packages/integrations/mastra/src/exporter.ts
@@ -68,6 +68,71 @@ const DEFAULT_PROJECT = 'mastra';
 const DEFAULT_MAX_PAYLOAD = 10_240;
 
 /**
+ * Per-1k-token USD prices for cost estimation. Same shape and entries
+ * as the OpenClaw integration so cost numbers are consistent across
+ * frameworks. Longest-prefix match against the (lowercased) model name.
+ *
+ * Real production model names often look like `ft:gpt-4o:my-org::abc123`
+ * or `openai/gpt-4o-mini` — `normalizeModel` strips those wrappers
+ * before matching.
+ */
+const PRICES_PER_1K: Record<string, [number, number]> = {
+  'gpt-4o-mini': [0.00015, 0.0006],
+  'gpt-4o': [0.0025, 0.010],
+  'gpt-4-turbo': [0.010, 0.030],
+  'gpt-4': [0.030, 0.060],
+  'gpt-3.5-turbo': [0.0005, 0.0015],
+  'claude-opus-4': [0.015, 0.075],
+  'claude-sonnet-4': [0.003, 0.015],
+  'claude-haiku-4': [0.001, 0.005],
+  'text-embedding-3-small': [0.00002, 0],
+  'text-embedding-3-large': [0.00013, 0],
+  'text-embedding-ada-002': [0.0001, 0],
+};
+
+function normalizeModel(model: string): string {
+  const m = model.toLowerCase();
+  if (m.startsWith('ft:')) {
+    const rest = m.slice(3);
+    return rest.includes(':') ? rest.slice(0, rest.indexOf(':')) : rest;
+  }
+  if (m.includes('/')) return m.slice(m.indexOf('/') + 1);
+  return m;
+}
+
+function computeCost(
+  model: string | null | undefined,
+  tin: number | null | undefined,
+  tout: number | null | undefined,
+): number | null {
+  if (!model || tin == null || tout == null) return null;
+  const m = normalizeModel(model);
+  let bestKey = '';
+  let best: [number, number] | null = null;
+  for (const [key, prices] of Object.entries(PRICES_PER_1K)) {
+    if (m.startsWith(key) && key.length > bestKey.length) {
+      bestKey = key;
+      best = prices;
+    }
+  }
+  if (!best) return null;
+  const [inp, outp] = best;
+  return Math.round(((tin * inp) / 1000 + (tout * outp) / 1000) * 1e8) / 1e8;
+}
+
+/**
+ * Public hook to register a custom price for self-hosted or
+ * not-yet-supported models. Same algorithm as OpenClaw.
+ */
+export function registerModelPrice(
+  modelPrefix: string,
+  inputPer1k: number,
+  outputPer1k: number,
+): void {
+  PRICES_PER_1K[modelPrefix.toLowerCase()] = [inputPer1k, outputPer1k];
+}
+
+/**
  * Convert an OTel attribute value to a string suitable for the
  * Lumin `input` / `output` field. OTel only delivers primitives
  * or arrays of primitives, so the cases are:
@@ -110,25 +175,46 @@ function safeStringify(v: unknown): string {
   }
 }
 
-/** OTel `[seconds, nanos]` HrTime → ISO-8601 string in UTC. */
+/**
+ * OTel `[seconds, nanos]` HrTime → ISO-8601 string in UTC with
+ * microsecond precision (ISO8601 allows up to 9 fractional digits).
+ *
+ * `new Date(ms).toISOString()` only preserves millisecond precision —
+ * adjacent rapid spans that straddle a ms boundary lose their
+ * ordering. Construct the ISO string from the hr_time tuple so
+ * children that end within microseconds of a parent stay temporally
+ * nested.
+ */
 function hrTimeToIso(time: [number, number] | undefined | null): string | null {
   if (!time) return null;
   const [seconds, nanos] = time;
-  const millis = seconds * 1000 + Math.floor(nanos / 1_000_000);
-  return new Date(millis).toISOString();
+  const ms = seconds * 1000 + Math.floor(nanos / 1_000_000);
+  const micros = Math.floor(nanos / 1_000) % 1_000_000;
+  const isoMs = new Date(ms).toISOString();
+  return isoMs.slice(0, -5) + '.' + String(micros).padStart(6, '0') + 'Z';
 }
 
 /**
  * Map an OTel `SpanKind` and the GenAI attributes to a Lumin
  * span `type`. The mapping mirrors how the LangChain/CrewAI
  * integrations classify spans elsewhere in the codebase.
+ *
+ * Tool detection accepts either OTel GenAI semconv keys
+ * (`gen_ai.tool.name`) or the bare-attribute conventions Mastra
+ * and the Vercel AI SDK actually emit in real workflows
+ * (`tool.name`, `mastra.tool.name`).
  */
 function classifySpanType(span: ReadableSpan): string {
   const attrs = span.attributes ?? {};
   if (attrs['gen_ai.operation.name'] || attrs['gen_ai.request.model']) {
     return 'llm';
   }
-  if (attrs['gen_ai.tool.name'] || attrs['gen_ai.tool.type']) {
+  if (
+    attrs['gen_ai.tool.name'] ||
+    attrs['gen_ai.tool.type'] ||
+    attrs['tool.name'] ||
+    attrs['mastra.tool.name']
+  ) {
     return 'tool';
   }
   switch (span.kind) {
@@ -171,6 +257,7 @@ export function otelSpanToLumin(
 ): LuminSpan {
   const ctx = span.spanContext();
   const attrs = (span.attributes ?? {}) as Record<string, unknown>;
+  const resourceAttrs = ((span.resource as { attributes?: Record<string, unknown> })?.attributes ?? {}) as Record<string, unknown>;
 
   const luminType = classifySpanType(span);
   const model =
@@ -179,7 +266,27 @@ export function otelSpanToLumin(
   const provider = attrString(attrs, 'gen_ai.system');
   const tokensIn = attrNumber(attrs, 'gen_ai.usage.input_tokens');
   const tokensOut = attrNumber(attrs, 'gen_ai.usage.output_tokens');
-  const toolName = attrString(attrs, 'gen_ai.tool.name');
+  const toolName =
+    attrString(attrs, 'gen_ai.tool.name') ??
+    attrString(attrs, 'mastra.tool.name') ??
+    attrString(attrs, 'tool.name');
+  const costUsd = computeCost(model, tokensIn, tokensOut);
+
+  // Detect Claude extended-thinking spans. The Anthropic SDK and
+  // many wrappers (Mastra-via-Anthropic-provider, Vercel AI SDK
+  // when reasoning is on) surface reasoning text via
+  // `gen_ai.response.thinking`. Stamp `span_subtype="thinking"`
+  // so the dashboard renders the brain-emoji thinking row and
+  // the Reasoning panel.
+  const thinkingText =
+    attrString(attrs, 'gen_ai.response.thinking') ??
+    attrString(attrs, 'anthropic.thinking') ??
+    null;
+  const isThinking = thinkingText !== null && thinkingText.length > 0;
+  const spanSubtype: 'thinking' | null = isThinking ? 'thinking' : null;
+  const thinkingTokens = isThinking
+    ? Math.max(1, Math.floor(thinkingText!.length / 4))
+    : null;
 
   // OTel attribute values must be primitives or arrays of primitives —
   // object values are silently dropped by the SDK. So we look for
@@ -199,6 +306,7 @@ export function otelSpanToLumin(
     attrs['gen_ai.input.messages'] ??
     attrs['gen_ai.prompt'] ??
     attrs['mastra.input'] ??
+    attrs['ai.input'] ??
     null;
   const output =
     attrs['ai.response.text'] ??
@@ -207,6 +315,7 @@ export function otelSpanToLumin(
     attrs['gen_ai.output.messages'] ??
     attrs['gen_ai.completion'] ??
     attrs['mastra.output'] ??
+    attrs['ai.output'] ??
     null;
 
   // Lumin native error_message is a string. OTel tracks status code
@@ -224,11 +333,18 @@ export function otelSpanToLumin(
     }
   }
 
-  // Session/user identifiers — accepted from common conventions
+  // Session/user identifiers — accepted from common conventions.
+  // Look on the span's own attrs first, then fall back to the
+  // *resource* attributes (which all spans in a process share).
+  // Resource fallback propagates a session id from the
+  // TracerProvider down to every child without each span needing
+  // to set the attribute itself.
   const sessionId =
     attrString(attrs, 'session.id') ??
     attrString(attrs, 'gen_ai.conversation.id') ??
     attrString(attrs, 'mastra.session_id') ??
+    attrString(resourceAttrs, 'session.id') ??
+    attrString(resourceAttrs, 'mastra.session_id') ??
     null;
 
   // OTel SDK has moved from `parentSpanId` to `parentSpanContext.spanId`
@@ -240,23 +356,35 @@ export function otelSpanToLumin(
     .parentSpanId;
   const parentSpanId = parentFromCtx ?? parentLegacy ?? null;
 
+  // For thinking spans, prefer the reasoning text as `input` (so
+  // the dashboard's "Reasoning" panel renders it) and clear the
+  // confusingly-similar `output` field.
+  const finalInput = isThinking
+    ? serialize({ thinking: thinkingText }, maxPayloadSize)
+    : serialize(input, maxPayloadSize);
+  const finalOutput = isThinking
+    ? null
+    : serialize(output, maxPayloadSize);
+
   return {
     id: ctx.spanId,
     trace_id: ctx.traceId,
     parent_span_id: parentSpanId,
-    name: span.name,
-    type: luminType,
-    input: serialize(input, maxPayloadSize),
-    output: serialize(output, maxPayloadSize),
+    name: isThinking ? 'thinking' : span.name,
+    type: isThinking ? 'llm' : luminType,
+    input: finalInput,
+    output: finalOutput,
     started_at: hrTimeToIso(span.startTime) ?? new Date().toISOString(),
     ended_at: hrTimeToIso(span.endTime),
     error: errorMessage,
     session_id: sessionId,
+    span_subtype: spanSubtype,
+    thinking_tokens: thinkingTokens,
     model,
     provider,
     tokens_input: tokensIn,
     tokens_output: tokensOut,
-    cost_usd: null,
+    cost_usd: costUsd,
     tool_name: toolName,
     metadata: attrs as Record<string, unknown>,
   };

--- a/packages/integrations/mastra/src/index.ts
+++ b/packages/integrations/mastra/src/index.ts
@@ -11,7 +11,11 @@
  *     users will use the `import "@lumin-io/mastra/auto"` form.
  */
 
-export { LuminExporter, otelSpanToLumin } from './exporter.js';
+export {
+  LuminExporter,
+  otelSpanToLumin,
+  registerModelPrice,
+} from './exporter.js';
 export type { LuminExporterConfig } from './exporter.js';
 
 export { luminConfig } from './config.js';

--- a/packages/integrations/mastra/tests/exporter.test.ts
+++ b/packages/integrations/mastra/tests/exporter.test.ts
@@ -5,6 +5,7 @@ import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import {
   LuminExporter,
   otelSpanToLumin,
+  registerModelPrice,
 } from '../src/exporter.js';
 
 /** Build a ReadableSpan-shaped object good enough for the mapper. */
@@ -55,8 +56,11 @@ describe('otelSpanToLumin', () => {
     expect(out.trace_id).toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     expect(out.name).toBe('my_agent.run');
     expect(out.parent_span_id).toBeNull();
-    expect(out.started_at).toBe('2023-11-14T22:13:20.000Z');
-    expect(out.ended_at).toBe('2023-11-14T22:13:21.500Z');
+    // Microsecond-precision ISO format preserves sub-ms ordering
+    // (matches OpenClaw mapper). Old format ".000Z" is gone — the
+    // mapper now always returns ".000000Z".
+    expect(out.started_at).toBe('2023-11-14T22:13:20.000000Z');
+    expect(out.ended_at).toBe('2023-11-14T22:13:21.500000Z');
   });
 
   test('GenAI attributes populate model/provider/tokens', () => {
@@ -89,6 +93,29 @@ describe('otelSpanToLumin', () => {
     const out = otelSpanToLumin(span);
     expect(out.type).toBe('tool');
     expect(out.tool_name).toBe('search_web');
+  });
+
+  test('tool span: bare tool.name (Vercel/Mastra style) yields type=tool', () => {
+    // The Vercel AI SDK and Mastra in-the-wild emit `tool.name`
+    // without the `gen_ai.` prefix. Real demos hit this path far
+    // more often than the formal semconv key.
+    const span = makeSpan({
+      kind: SpanKind.INTERNAL,
+      attributes: { 'tool.name': 'pinecone_query' },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.type).toBe('tool');
+    expect(out.tool_name).toBe('pinecone_query');
+  });
+
+  test('tool span: mastra.tool.name namespace also recognized', () => {
+    const span = makeSpan({
+      kind: SpanKind.INTERNAL,
+      attributes: { 'mastra.tool.name': 'shopify_get_order' },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.type).toBe('tool');
+    expect(out.tool_name).toBe('shopify_get_order');
   });
 
   test('SpanKind.INTERNAL with no GenAI attrs → custom', () => {
@@ -225,6 +252,164 @@ describe('otelSpanToLumin', () => {
       makeSpan({ attributes: { 'mastra.session_id': 's-789' } }),
     );
     expect(c.session_id).toBe('s-789');
+  });
+
+  test('session_id falls back to the resource attributes', () => {
+    // The TracerProvider-level resource is the natural place to put a
+    // process- or workflow-wide session id; spans that don't set their
+    // own should inherit it.
+    const span = makeSpan({
+      attributes: {},
+      resource: {
+        attributes: { 'session.id': 'resource-sess-001' },
+        merge: () => null as never,
+      } as ReadableSpan['resource'],
+    });
+    expect(otelSpanToLumin(span).session_id).toBe('resource-sess-001');
+  });
+
+  test('span-level session.id wins over resource', () => {
+    const span = makeSpan({
+      attributes: { 'session.id': 'span-sess' },
+      resource: {
+        attributes: { 'session.id': 'resource-sess' },
+        merge: () => null as never,
+      } as ReadableSpan['resource'],
+    });
+    expect(otelSpanToLumin(span).session_id).toBe('span-sess');
+  });
+
+  // ---------- cost computation ----------
+
+  test('cost_usd is computed for known models', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.system': 'anthropic',
+        'gen_ai.request.model': 'claude-sonnet-4',
+        'gen_ai.response.model': 'claude-sonnet-4-20250514',
+        'gen_ai.usage.input_tokens': 1000,
+        'gen_ai.usage.output_tokens': 500,
+      },
+    });
+    const out = otelSpanToLumin(span);
+    // claude-sonnet-4: $0.003/1k in, $0.015/1k out
+    // 1000*0.003/1000 + 500*0.015/1000 = 0.003 + 0.0075 = 0.0105
+    expect(out.cost_usd).toBeCloseTo(0.0105, 6);
+  });
+
+  test('cost_usd is null when model has no price entry', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.request.model': 'mystery-llm-9000',
+        'gen_ai.usage.input_tokens': 100,
+        'gen_ai.usage.output_tokens': 50,
+      },
+    });
+    expect(otelSpanToLumin(span).cost_usd).toBeNull();
+  });
+
+  test('cost_usd is null when token counts are absent', () => {
+    const span = makeSpan({
+      attributes: { 'gen_ai.request.model': 'gpt-4o' },
+    });
+    expect(otelSpanToLumin(span).cost_usd).toBeNull();
+  });
+
+  test('fine-tuned model (ft:gpt-4o:org::abc) maps to base price', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.request.model': 'ft:gpt-4o:my-org::abc123',
+        'gen_ai.usage.input_tokens': 1000,
+        'gen_ai.usage.output_tokens': 1000,
+      },
+    });
+    const out = otelSpanToLumin(span);
+    // gpt-4o: $0.0025/1k in, $0.010/1k out → 0.0025 + 0.010 = 0.0125
+    expect(out.cost_usd).toBeCloseTo(0.0125, 6);
+  });
+
+  test('provider-prefixed model (openai/gpt-4o-mini) is normalized', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.request.model': 'openai/gpt-4o-mini',
+        'gen_ai.usage.input_tokens': 1000,
+        'gen_ai.usage.output_tokens': 1000,
+      },
+    });
+    const out = otelSpanToLumin(span);
+    // gpt-4o-mini: $0.00015/1k in, $0.0006/1k out
+    expect(out.cost_usd).toBeCloseTo(0.00075, 8);
+  });
+
+  test('registerModelPrice teaches the table about a self-hosted model', () => {
+    registerModelPrice('llama-3-70b-vendor-x', 0.0008, 0.0024);
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.request.model': 'llama-3-70b-vendor-x',
+        'gen_ai.usage.input_tokens': 1000,
+        'gen_ai.usage.output_tokens': 1000,
+      },
+    });
+    expect(otelSpanToLumin(span).cost_usd).toBeCloseTo(0.0032, 6);
+  });
+
+  // ---------- Claude extended-thinking detection ----------
+
+  test('thinking span: gen_ai.response.thinking sets span_subtype + name', () => {
+    const span = makeSpan({
+      name: 'agent.reason',
+      attributes: {
+        'gen_ai.system': 'anthropic',
+        'gen_ai.request.model': 'claude-sonnet-4',
+        'gen_ai.response.thinking':
+          'Let me think step by step. The user wants X. The constraints are Y. Therefore Z.',
+        'gen_ai.usage.input_tokens': 100,
+        'gen_ai.usage.output_tokens': 200,
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.span_subtype).toBe('thinking');
+    expect(out.name).toBe('thinking');
+    expect(out.type).toBe('llm');
+    // Reasoning text moves into `input` so the dashboard's Reasoning
+    // panel renders it
+    expect(out.input).toContain('think step by step');
+    // And `output` is cleared (dashboard doesn't render duplicate text)
+    expect(out.output).toBeNull();
+    // thinking_tokens estimated from text length (chars/4)
+    expect(out.thinking_tokens).toBeGreaterThan(0);
+  });
+
+  test('non-thinking LLM span keeps span_subtype null', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.request.model': 'gpt-4o',
+        'ai.response.text': 'just a normal answer',
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.span_subtype).toBeNull();
+    expect(out.thinking_tokens).toBeNull();
+  });
+
+  test('anthropic.thinking attribute also recognized as thinking', () => {
+    const span = makeSpan({
+      attributes: {
+        'anthropic.thinking': 'reasoning content',
+        'gen_ai.request.model': 'claude-opus-4',
+      },
+    });
+    expect(otelSpanToLumin(span).span_subtype).toBe('thinking');
+  });
+
+  test('empty thinking string is NOT treated as thinking', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.response.thinking': '',
+        'gen_ai.request.model': 'claude-sonnet-4',
+      },
+    });
+    expect(otelSpanToLumin(span).span_subtype).toBeNull();
   });
 
   test('large input is truncated to maxPayloadSize', () => {

--- a/packages/integrations/openclaw/src/exporter.ts
+++ b/packages/integrations/openclaw/src/exporter.ts
@@ -211,7 +211,15 @@ function classifySpanType(span: ReadableSpan): string {
   if (attrs['gen_ai.operation.name'] || attrs['gen_ai.request.model']) {
     return 'llm';
   }
-  if (attrs['gen_ai.tool.name'] || attrs['gen_ai.tool.type']) {
+  // Tool detection accepts the OTel GenAI semconv keys as well as the
+  // bare-attribute conventions OpenClaw and ad-hoc OTel pipelines emit
+  // in real workflows (`tool.name`, `openclaw.tool.name`).
+  if (
+    attrs['gen_ai.tool.name'] ||
+    attrs['gen_ai.tool.type'] ||
+    attrs['tool.name'] ||
+    attrs['openclaw.tool.name']
+  ) {
     return 'tool';
   }
   switch (span.kind) {
@@ -259,7 +267,10 @@ export function otelSpanToLumin(
   const provider = attrString(attrs, 'gen_ai.system');
   const tokensIn = attrNumber(attrs, 'gen_ai.usage.input_tokens');
   const tokensOut = attrNumber(attrs, 'gen_ai.usage.output_tokens');
-  const toolName = attrString(attrs, 'gen_ai.tool.name');
+  const toolName =
+    attrString(attrs, 'gen_ai.tool.name') ??
+    attrString(attrs, 'openclaw.tool.name') ??
+    attrString(attrs, 'tool.name');
   const costUsd = computeCost(model, tokensIn, tokensOut);
 
   // Detect Claude extended-thinking spans. OpenClaw / Anthropic

--- a/packages/integrations/openclaw/tests/exporter.test.ts
+++ b/packages/integrations/openclaw/tests/exporter.test.ts
@@ -171,6 +171,28 @@ describe('otelSpanToLumin', () => {
     expect(out.tool_name).toBe('web_search');
   });
 
+  test('tool span: bare tool.name (Vercel/OTel ad-hoc) yields type=tool', () => {
+    // Many real-world OTel pipelines emit `tool.name` without the
+    // `gen_ai.` prefix; OpenClaw exporter must accept that too.
+    const span = makeSpan({
+      kind: SpanKind.INTERNAL,
+      attributes: { 'tool.name': 'calculator' },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.type).toBe('tool');
+    expect(out.tool_name).toBe('calculator');
+  });
+
+  test('tool span: openclaw.tool.name namespace also recognized', () => {
+    const span = makeSpan({
+      kind: SpanKind.INTERNAL,
+      attributes: { 'openclaw.tool.name': 'whatsapp_send' },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.type).toBe('tool');
+    expect(out.tool_name).toBe('whatsapp_send');
+  });
+
   test('SpanKind.INTERNAL with no GenAI attrs → custom', () => {
     const span = makeSpan({ kind: SpanKind.INTERNAL });
     expect(otelSpanToLumin(span).type).toBe('custom');


### PR DESCRIPTION
## Summary

Stress-testing the live OpenClaw + Mastra demos surfaced four real gaps the unit suites didn't cover. Closes all four.

1. **`@lumin-io/mastra` had no cost computation** — `cost_usd` was hardcoded `null`. Ported the OpenClaw price table + `normalizeModel()` + `computeCost()`. Also exports `registerModelPrice()` for self-hosted models.
2. **`@lumin-io/mastra` had no Claude extended-thinking detection** — `gen_ai.response.thinking` was ignored, so the brain-emoji subtype + Reasoning panel stayed empty. Ported the OpenClaw thinking branch.
3. **Tool spans defaulted to `type=custom` in BOTH integrations** — `classifySpanType()` only matched `gen_ai.tool.name`, but Mastra / Vercel AI SDK emit the bare `tool.name` far more often. Added fallback to `tool.name`, `mastra.tool.name`, `openclaw.tool.name`.
4. **Child spans without explicit `session_id` showed null in `/sessions`** — when the framework only sets session id on the root, children went into the wrong sessions group. Fixed at the API read path: `GET /v1/traces/{id}/spans` now COALESCEs each span's null `session_id` with the trace's. Done at read time so orphan-child ordering doesn't matter.

Plus parity backfills on the Mastra exporter (microsecond timestamps, resource-attribute fallback for session id, `ai.input`/`ai.output` as additional payload sources).

## Verification

| package | before | after | delta |
|---|---|---|---|
| sdk-python | 172 | 172 | — |
| api | 63 | **64** | +1 inheritance test |
| sdk-typescript | 59 | 59 | — |
| integrations/mastra | 38 | **52** | +14 |
| integrations/openclaw | 54 | **56** | +2 |
| **total** | **386** | **403** | **+17** |

Live demo re-run after the fix:
- Mastra LLM costs now compute (refund_check $0.0185, enrich_lead $0.0085 — were both $0.00)
- Mastra thinking spans light up the brain-emoji subtype
- All 26 tool-using spans across both demos (was 0) classify as `type=tool` with `tool_name` populated
- Every Mastra child span shares its trace's session_id in the `/sessions` view

## Test plan

- [x] `npm test` in `packages/integrations/mastra` — 52 passed
- [x] `npm test` in `packages/integrations/openclaw` — 56 passed
- [x] `pytest` in `packages/api` — 64 passed
- [x] `pytest` in `packages/sdk-python` — 172 passed
- [x] `npm test` in `packages/sdk-typescript` — 59 passed
- [x] Live demo: 5 fresh traces with correct types/costs/thinking/sessions visible at `localhost:3000`

## Notes

- Tests that explicitly set `session_id` on spans are not affected — only true nulls inherit.
- The existing `test_span_without_session_id_keeps_null` was renamed to `test_span_without_session_id_when_trace_also_has_none_stays_null` to reflect its narrowed scope.