### PR TITLE
fix(integrations): match real upstream attribute keys (unblocks 0.1.0)

### DIFF
--- a/packages/integrations/mastra/src/exporter.ts
+++ b/packages/integrations/mastra/src/exporter.ts
@@ -260,25 +260,41 @@ export function otelSpanToLumin(
   const resourceAttrs = ((span.resource as { attributes?: Record<string, unknown> })?.attributes ?? {}) as Record<string, unknown>;
 
   const luminType = classifySpanType(span);
+  // Mastra / Vercel AI SDK emit `ai.model.id` and `ai.model.provider`
+  // alongside (and sometimes instead of) the OTel GenAI semconv keys.
+  // Verified against @mastra/core's actual emission.
   const model =
     attrString(attrs, 'gen_ai.response.model') ??
-    attrString(attrs, 'gen_ai.request.model');
-  const provider = attrString(attrs, 'gen_ai.system');
-  const tokensIn = attrNumber(attrs, 'gen_ai.usage.input_tokens');
-  const tokensOut = attrNumber(attrs, 'gen_ai.usage.output_tokens');
+    attrString(attrs, 'gen_ai.request.model') ??
+    attrString(attrs, 'ai.response.model') ??
+    attrString(attrs, 'ai.model.id');
+  const provider =
+    attrString(attrs, 'gen_ai.system') ??
+    attrString(attrs, 'ai.model.provider');
+  // Legacy GenAI token names (`prompt_tokens` / `completion_tokens`)
+  // are still emitted by older Mastra builds and Vercel AI SDK
+  // versions — accept them as fallbacks.
+  const tokensIn =
+    attrNumber(attrs, 'gen_ai.usage.input_tokens') ??
+    attrNumber(attrs, 'gen_ai.usage.prompt_tokens');
+  const tokensOut =
+    attrNumber(attrs, 'gen_ai.usage.output_tokens') ??
+    attrNumber(attrs, 'gen_ai.usage.completion_tokens');
   const toolName =
     attrString(attrs, 'gen_ai.tool.name') ??
     attrString(attrs, 'mastra.tool.name') ??
     attrString(attrs, 'tool.name');
   const costUsd = computeCost(model, tokensIn, tokensOut);
 
-  // Detect Claude extended-thinking spans. The Anthropic SDK and
-  // many wrappers (Mastra-via-Anthropic-provider, Vercel AI SDK
-  // when reasoning is on) surface reasoning text via
-  // `gen_ai.response.thinking`. Stamp `span_subtype="thinking"`
-  // so the dashboard renders the brain-emoji thinking row and
-  // the Reasoning panel.
+  // Detect Claude / Gemini extended-thinking spans. Real Mastra
+  // (verified against @mastra/core) surfaces reasoning text via
+  // `ai.response.reasoning` — that's the Vercel AI SDK convention
+  // it inherits. Other GenAI-attribute pipelines may use the
+  // `gen_ai.response.thinking` or `anthropic.thinking` keys; accept
+  // all three so the dashboard's brain-emoji subtype + Reasoning
+  // panel light up regardless of which framework is in play.
   const thinkingText =
+    attrString(attrs, 'ai.response.reasoning') ??
     attrString(attrs, 'gen_ai.response.thinking') ??
     attrString(attrs, 'anthropic.thinking') ??
     null;

--- a/packages/integrations/mastra/tests/exporter.test.ts
+++ b/packages/integrations/mastra/tests/exporter.test.ts
@@ -82,6 +82,39 @@ describe('otelSpanToLumin', () => {
     expect(out.tokens_output).toBe(18);
   });
 
+  test('Mastra ai.model.id / ai.model.provider used as fallback', () => {
+    // Real @mastra/core emits `ai.model.id` and `ai.model.provider`
+    // in addition to (and on some span types instead of) the OTel
+    // GenAI semconv keys. Verified against the actual upstream.
+    const span = makeSpan({
+      attributes: {
+        'ai.model.id': 'gpt-4o-mini',
+        'ai.model.provider': 'openai',
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.model).toBe('gpt-4o-mini');
+    expect(out.provider).toBe('openai');
+  });
+
+  test('legacy gen_ai.usage.{prompt,completion}_tokens are accepted', () => {
+    // Older Mastra builds + earlier Vercel AI SDK versions still
+    // emit the prompt_tokens / completion_tokens names from the
+    // pre-2025 GenAI semconv revision.
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.request.model': 'gpt-4o',
+        'gen_ai.usage.prompt_tokens': 1000,
+        'gen_ai.usage.completion_tokens': 200,
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.tokens_input).toBe(1000);
+    expect(out.tokens_output).toBe(200);
+    // And cost still computes correctly via the legacy names
+    expect(out.cost_usd).toBeCloseTo(0.0045, 6);
+  });
+
   test('tool span: gen_ai.tool.name yields type=tool', () => {
     const span = makeSpan({
       kind: SpanKind.INTERNAL,
@@ -400,6 +433,28 @@ describe('otelSpanToLumin', () => {
       },
     });
     expect(otelSpanToLumin(span).span_subtype).toBe('thinking');
+  });
+
+  test('real Mastra ai.response.reasoning is detected as thinking', () => {
+    // Verified against @mastra/core: Mastra surfaces extended-thinking
+    // text under `ai.response.reasoning` (Vercel AI SDK convention,
+    // not the OTel GenAI semconv key). Without this fallback Mastra
+    // thinking spans never get the brain-emoji subtype.
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.system': 'anthropic',
+        'gen_ai.request.model': 'claude-sonnet-4',
+        'ai.response.reasoning':
+          'The user is asking about pricing tiers — let me think about which plan fits their team size before answering.',
+        'gen_ai.usage.input_tokens': 200,
+        'gen_ai.usage.output_tokens': 350,
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.span_subtype).toBe('thinking');
+    expect(out.name).toBe('thinking');
+    expect(out.input).toContain('pricing tiers');
+    expect(out.output).toBeNull();
   });
 
   test('empty thinking string is NOT treated as thinking', () => {

--- a/packages/integrations/openclaw/src/exporter.ts
+++ b/packages/integrations/openclaw/src/exporter.ts
@@ -291,11 +291,19 @@ export function otelSpanToLumin(
   // OpenClaw / Vercel AI / OTel conventions all stash prompt + response
   // text on different attribute keys depending on which provider is
   // in play. Read them all, in priority order.
+  //
+  // The `openclaw.content.*` keys are what real `@openclaw/diagnostics-otel`
+  // emits at runtime (verified against upstream service.ts). The bare
+  // `openclaw.input` / `.output` keys remain as a legacy / convention
+  // fallback for hand-rolled OTel pipelines.
   const input =
     attrs['ai.prompt.messages'] ??
     attrs['ai.toolCall.args'] ??
     attrs['gen_ai.input.messages'] ??
     attrs['gen_ai.prompt'] ??
+    attrs['openclaw.content.input_messages'] ??
+    attrs['openclaw.content.system_prompt'] ??
+    attrs['openclaw.content.tool_input'] ??
     attrs['openclaw.input'] ??
     null;
   const output =
@@ -304,6 +312,8 @@ export function otelSpanToLumin(
     attrs['ai.toolCall.result'] ??
     attrs['gen_ai.output.messages'] ??
     attrs['gen_ai.completion'] ??
+    attrs['openclaw.content.output_messages'] ??
+    attrs['openclaw.content.tool_output'] ??
     attrs['openclaw.output'] ??
     null;
 

--- a/packages/integrations/openclaw/tests/exporter.test.ts
+++ b/packages/integrations/openclaw/tests/exporter.test.ts
@@ -232,7 +232,7 @@ describe('otelSpanToLumin', () => {
     expect(otelSpanToLumin(span).error).toBeNull();
   });
 
-  test('openclaw-style input/output captured', () => {
+  test('openclaw-style input/output captured (legacy bare keys)', () => {
     const span = makeSpan({
       attributes: {
         'openclaw.input': 'What is the weather in Tokyo?',
@@ -242,6 +242,50 @@ describe('otelSpanToLumin', () => {
     const out = otelSpanToLumin(span);
     expect(out.input).toContain('Tokyo');
     expect(out.output).toContain('24°C');
+  });
+
+  test('real openclaw.content.* keys used by @openclaw/diagnostics-otel', () => {
+    // Verified against the upstream package source: real OpenClaw
+    // emits `openclaw.content.input_messages`, `.output_messages`, etc.
+    // The exporter must read those exact keys — without this fallback
+    // every span from a real OpenClaw runtime had null input/output.
+    const span = makeSpan({
+      attributes: {
+        'openclaw.content.input_messages':
+          '[{"role":"user","content":"summarize this PR"}]',
+        'openclaw.content.output_messages':
+          '[{"role":"assistant","content":"It refactors the auth handler."}]',
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.input).toContain('summarize this PR');
+    expect(out.output).toContain('refactors the auth handler');
+  });
+
+  test('openclaw.content.system_prompt is captured as input fallback', () => {
+    const span = makeSpan({
+      attributes: {
+        'openclaw.content.system_prompt': 'You are a careful editor.',
+      },
+    });
+    expect(otelSpanToLumin(span).input).toContain('careful editor');
+  });
+
+  test('openclaw.content.tool_input / tool_output used for tool spans', () => {
+    const span = makeSpan({
+      kind: SpanKind.INTERNAL,
+      attributes: {
+        'openclaw.tool.name': 'web_search',
+        'openclaw.content.tool_input': '{"query":"openclaw vs other agents"}',
+        'openclaw.content.tool_output':
+          '5 results: blog/openclaw-launch, docs/openclaw, comparison/agents-2025, …',
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.type).toBe('tool');
+    expect(out.tool_name).toBe('web_search');
+    expect(out.input).toContain('openclaw vs other agents');
+    expect(out.output).toContain('5 results');
   });
 
   test('Vercel AI SDK ai.prompt.messages and ai.response.text', () => {


### PR DESCRIPTION
## Summary

Pre-publish audit against the actual source of `@openclaw/diagnostics-otel` and `@mastra/core` found two attribute-key mismatches our synthetic tests + live demos couldn't catch. Without this fix, `0.1.0` would have shipped with two visibly broken features:

### 🔴 Bug A — OpenClaw spans show null input / output

Real `@openclaw/diagnostics-otel` emits content under five `openclaw.content.*` keys:

- `openclaw.content.input_messages`
- `openclaw.content.output_messages`
- `openclaw.content.system_prompt`
- `openclaw.content.tool_input`
- `openclaw.content.tool_output`

Our exporter read `openclaw.input` / `openclaw.output` — keys the upstream never emits. Every span from a real OpenClaw runtime would have shown an empty prompt/response panel.

### 🔴 Bug B — Mastra Claude-thinking never lights up the brain emoji

Real `@mastra/core` surfaces extended-thinking text under `ai.response.reasoning` (Vercel AI SDK convention). We were reading `gen_ai.response.thinking` / `anthropic.thinking` — neither is emitted by Mastra.

### 🟡 Three minor parity gaps

- `ai.model.id` / `ai.model.provider` (Mastra alternative attrs)
- `gen_ai.usage.prompt_tokens` / `completion_tokens` (legacy GenAI semconv — older Mastra builds)
- `ai.response.model` (additional Vercel AI SDK key)

## Verification

| package | tests | delta |
|---|---|---|
| sdk-python | 172 | — |
| api | 64 | — |
| sdk-typescript | 59 | — |
| integrations/mastra | **55** | +3 |
| integrations/openclaw | **59** | +3 |
| **total** | **409** | **+6** |

Plus a 27-assertion real-shape replay script that drives both mappers with the EXACT attribute keys grepped from upstream packages' source — **27/27 assertions pass**.

## Test plan

- [x] All 5 unit suites green
- [x] OpenClaw replay (11 assertions) — input, output, tool input/output, model, provider, tokens, cost, classification — all pass
- [x] Mastra replay (16 assertions) — prompt path, response path, thinking detection from `ai.response.reasoning`, ai.model.* fallbacks, legacy token names, tool detection — all pass

## Why this matters for publish

Synthetic unit tests + the live demos used hand-crafted attribute names matching the OTel GenAI semconv documentation. Real frameworks drift from documented conventions in real ways. This PR closes that gap by inspecting the upstream packages' actual source, identifying every attribute key they emit, and adding the right fallbacks.

After this PR merges, both `@lumin-io/openclaw@0.1.0` and `@lumin-io/mastra@0.1.0` are clear to publish.