### PR TITLE
feat(integrations): @lumin-io/voltagent — VoltAgent observability + sessions aggregation fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,27 @@ jobs:
       - name: Test
         run: npm test
 
+  voltagent-integration:
+    name: VoltAgent integration (@lumin-io/voltagent)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/integrations/voltagent
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: packages/integrations/voltagent/package-lock.json
+      - name: Install
+        run: npm install --no-audit --no-fund
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm test
+
   dashboard:
     name: Next.js dashboard (session 3)
     runs-on: ubuntu-latest

--- a/packages/api/routers/sessions.py
+++ b/packages/api/routers/sessions.py
@@ -38,12 +38,34 @@ def _row_to_session(row: dict) -> Session:
     )
 
 
+# Per-trace cost / tokens. Mirrors the GREATEST(stored, sum-from-spans)
+# pattern that /v1/traces uses, so framework-only-spans flows
+# (every OTel exporter does this — no separate POST /v1/traces call)
+# still aggregate up correctly. Without this, sessions reported $0/0
+# tokens for every span-only ingest.
 _BASE_AGG = """
     session_id,
     COUNT(*) AS trace_count,
     SUM(COALESCE(DATEDIFF('millisecond', started_at, ended_at), 0)) AS total_duration_ms,
-    SUM(COALESCE(total_cost_usd, 0)) AS total_cost_usd,
-    SUM(COALESCE(total_tokens, 0)) AS total_tokens,
+    SUM(
+        GREATEST(
+            COALESCE(total_cost_usd, 0),
+            COALESCE(
+                (SELECT SUM(cost_usd) FROM spans WHERE trace_id = traces.id),
+                0
+            )
+        )
+    ) AS total_cost_usd,
+    SUM(
+        GREATEST(
+            COALESCE(total_tokens, 0),
+            COALESCE(
+                (SELECT SUM(COALESCE(tokens_input, 0) + COALESCE(tokens_output, 0))
+                 FROM spans WHERE trace_id = traces.id),
+                0
+            )
+        )
+    ) AS total_tokens,
     AVG(quality_score) AS quality_score,
     MIN(started_at) AS first_seen,
     MAX(COALESCE(ended_at, started_at)) AS last_seen

--- a/packages/api/tests/test_sessions.py
+++ b/packages/api/tests/test_sessions.py
@@ -279,6 +279,75 @@ def test_root_span_does_not_overwrite_existing_session_id(client):
     assert body["session_id"] == sid
 
 
+def test_session_aggregates_cost_tokens_from_spans(client):
+    """When traces are populated only via POST /v1/spans (the path every
+    OTel-based exporter uses) the stored traces.total_cost_usd column
+    is 0. The sessions endpoint must aggregate cost + tokens up from
+    spans, not just sum the stored column. Without this fix every
+    framework-instrumented session showed $0 / 0 tokens in the UI."""
+    sid = "session-agg-test"
+    # Two LLM spans across two traces, both belonging to one session.
+    # Each carries cost_usd + tokens; no separate POST /v1/traces.
+    client.post(
+        "/v1/spans",
+        json={
+            "spans": [
+                {
+                    "id": "agg-trace-1",
+                    "trace_id": "agg-trace-1",
+                    "name": "agent.run",
+                    "started_at": "2026-05-04T10:00:00Z",
+                    "ended_at": "2026-05-04T10:00:02Z",
+                    "session_id": sid,
+                },
+                {
+                    "id": "agg-trace-1-llm",
+                    "trace_id": "agg-trace-1",
+                    "parent_span_id": "agg-trace-1",
+                    "name": "llm.call",
+                    "type": "llm",
+                    "started_at": "2026-05-04T10:00:00.100Z",
+                    "ended_at": "2026-05-04T10:00:01.500Z",
+                    "tokens_input": 1000,
+                    "tokens_output": 500,
+                    "cost_usd": 0.0105,
+                    "session_id": sid,
+                },
+                {
+                    "id": "agg-trace-2",
+                    "trace_id": "agg-trace-2",
+                    "name": "agent.run",
+                    "started_at": "2026-05-04T10:01:00Z",
+                    "ended_at": "2026-05-04T10:01:02Z",
+                    "session_id": sid,
+                },
+                {
+                    "id": "agg-trace-2-llm",
+                    "trace_id": "agg-trace-2",
+                    "parent_span_id": "agg-trace-2",
+                    "name": "llm.call",
+                    "type": "llm",
+                    "started_at": "2026-05-04T10:01:00.100Z",
+                    "ended_at": "2026-05-04T10:01:01.500Z",
+                    "tokens_input": 200,
+                    "tokens_output": 50,
+                    "cost_usd": 0.001,
+                    "session_id": sid,
+                },
+            ]
+        },
+    )
+    sessions = client.get("/v1/sessions").json()
+    by_id = {s["session_id"]: s for s in sessions}
+    assert sid in by_id
+    s = by_id[sid]
+    assert s["trace_count"] == 2
+    # 0.0105 + 0.001 = 0.0115
+    assert abs(s["total_cost_usd"] - 0.0115) < 0.0001
+    # (1000+500) + (200+50) = 1750
+    assert s["total_tokens"] == 1750
+
+
 def test_pagination(client):
     base = datetime(2026, 5, 1, 10, 0, 0, tzinfo=timezone.utc)
     for i in range(5):

--- a/packages/integrations/voltagent/README.md
+++ b/packages/integrations/voltagent/README.md
@@ -1,0 +1,77 @@
+# @lumin-io/voltagent
+
+> Debug your [VoltAgent](https://github.com/VoltAgent/voltagent) agent locally. No account. No cloud. No telemetry leaving your laptop.
+
+`@lumin-io/voltagent` is the Lumin side of VoltAgent's OTel telemetry pipeline. VoltAgent is OTel-native — it sets up an OTel TracerProvider and emits spans for every agent generation, LLM call, tool call, and guardrail. This package provides a drop-in `SpanExporter` that converts those spans to Lumin's wire format and ships them to a local Lumin instance — visible at `http://localhost:3000`.
+
+## Install
+
+```bash
+npm install @lumin-io/voltagent
+```
+
+You also need a running Lumin instance:
+
+```bash
+docker run -p 3000:3000 -p 8000:8000 zistica/lumin
+```
+
+## Usage
+
+Build the processor and pass it to your VoltAgent OTel config (or to any `NodeTracerProvider` you've already set up):
+
+```typescript
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { luminProcessor } from '@lumin-io/voltagent';
+
+const tracerProvider = new NodeTracerProvider({
+  resource,
+  spanProcessors: [
+    luminProcessor({ serviceName: 'my-voltagent-app' }),
+    // …other processors
+  ],
+});
+tracerProvider.register();
+```
+
+That's it. Run your VoltAgent app, open `http://localhost:3000`, every agent generation, LLM call, and tool call shows up live.
+
+The helper reads `LUMIN_HOST`, `LUMIN_API_KEY`, and `LUMIN_SERVICE_NAME` from the environment, so common deployments need no constructor args:
+
+```bash
+export LUMIN_HOST=http://lumin.internal:8000
+export LUMIN_PROJECT=my-bot
+node ./your-voltagent-app.js
+```
+
+## What gets captured
+
+- **LLM spans** with model, provider, tokens, and per-call cost (OpenAI / Anthropic / fine-tuned / provider-prefixed model names all supported)
+- **Tool spans** with input args, output, errors — VoltAgent emits bare `tool.name` + `agent.tool.initiated`, both recognized
+- **Reasoning blocks** — Claude / Gemini extended-thinking surfaces under `ai.response.reasoning` and renders with the brain-emoji subtype
+- **Guardrail spans** — VoltAgent's `guardrail.*` namespace lands as custom spans with the policy decision visible
+- **Sub-agent runs** — `agent.parent.id` is used as a session-grouping fallback so subagent timelines stay nested
+- **Live span streaming** — new spans appear in the dashboard the moment they end, via WebSocket
+
+## Resilience (Lumin Rule 7)
+
+If Lumin is down or returns a 5xx, your VoltAgent process never sees an error. Spans drop silently, the agent keeps running. Verified against DNS failure, 401/500/timeout/hang/garbage-payload, and 1000-span batches — same resilience suite as the other Lumin integrations.
+
+## Verified against real upstream emission
+
+The exporter was built against the actual attribute keys `@voltagent/core` emits at runtime (verified via grep against the package's compiled source), not against the OTel GenAI semconv documentation in isolation. Specifically supported:
+
+- `ai.model.name` / `ai.model.provider` / `ai.model.temperature` / `ai.model.max_tokens` (Vercel AI SDK convention)
+- `ai.response.reasoning` (extended thinking)
+- bare `input` / `output` (VoltAgent's content shape on root + LLM + tool spans)
+- `voltagent.input` / `voltagent.output` / `voltagent.tool.name` / `voltagent.session_id` (explicit namespace)
+- `agent.parent.id` (sub-agent session grouping)
+- `agent.step.text` (intermediate step output)
+- `agent.tool.initiated` (tool-call lifecycle hint)
+- `gen_ai.*` (any framework using the OTel GenAI semconv)
+
+If your VoltAgent app emits an attribute key the exporter doesn't pick up, [open an issue](https://github.com/amitbidlan/zistica-lumin/issues/new).
+
+## License
+
+Apache-2.0.

--- a/packages/integrations/voltagent/package-lock.json
+++ b/packages/integrations/voltagent/package-lock.json
@@ -1,0 +1,1921 @@
+{
+  "name": "@lumin-io/voltagent",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@lumin-io/voltagent",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/sdk-trace-base": ">=1.20.0"
+      },
+      "devDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0",
+        "typescript": "^5.3.0",
+        "vitest": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.7.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/packages/integrations/voltagent/package.json
+++ b/packages/integrations/voltagent/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@lumin-io/voltagent",
+  "version": "0.1.0",
+  "description": "Lumin exporter for VoltAgent — local-first observability with zero cloud dependency.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/amitbidlan/zistica-lumin.git",
+    "directory": "packages/integrations/voltagent"
+  },
+  "keywords": [
+    "voltagent",
+    "lumin",
+    "observability",
+    "tracing",
+    "opentelemetry",
+    "agents",
+    "ai"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./auto": {
+      "types": "./dist/auto.d.ts",
+      "import": "./dist/auto.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@opentelemetry/sdk-trace-base": ">=1.20.0"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": ">=1.7.0"
+  },
+  "devDependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.6.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/integrations/voltagent/src/auto.ts
+++ b/packages/integrations/voltagent/src/auto.ts
@@ -1,0 +1,72 @@
+/**
+ * Side-effect entry point — `import "@lumin-io/voltagent/auto"` enables
+ * tracing when LUMIN_TRACING is truthy.
+ *
+ * Honest caveat: modern OpenTelemetry (v2+) requires SpanProcessors
+ * to be passed at TracerProvider construction time. Once VoltAgent
+ * has built its provider, you can no longer attach a processor to
+ * it from the outside. So this module can only attach when:
+ *
+ *   1. LUMIN_TRACING is set, AND
+ *   2. The user has either registered a custom TracerProvider that
+ *      still exposes a public `addSpanProcessor` (older OTel SDK
+ *      versions), OR exposes a `getDelegate()` that returns one.
+ *
+ * For VoltAgent the supported path is to wire the processor directly
+ * into the OTel config, e.g.:
+ *
+ *     import { luminProcessor } from '@lumin-io/voltagent';
+ *     // … pass luminProcessor() into the spanProcessors array
+ *
+ * This module is a courtesy hook for environments where late
+ * attachment works.
+ */
+
+import { trace, type TracerProvider } from '@opentelemetry/api';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { LuminExporter } from './exporter.js';
+
+interface ProviderWithProcessor extends TracerProvider {
+  addSpanProcessor?: (processor: BatchSpanProcessor) => void;
+  getDelegate?: () => TracerProvider;
+}
+
+function isEnabled(): boolean {
+  if (typeof process === 'undefined') return false;
+  const v = (process.env.LUMIN_TRACING ?? '').toLowerCase();
+  return v === 'true' || v === '1';
+}
+
+function findAttachableProvider(
+  start: TracerProvider,
+): ProviderWithProcessor | null {
+  let p: ProviderWithProcessor | null = start as ProviderWithProcessor;
+  for (let i = 0; i < 5 && p != null; i++) {
+    if (typeof p.addSpanProcessor === 'function') return p;
+    if (typeof p.getDelegate === 'function') {
+      p = p.getDelegate() as ProviderWithProcessor;
+    } else {
+      break;
+    }
+  }
+  return null;
+}
+
+/**
+ * Pure attachment logic — exposed for tests. Given a TracerProvider,
+ * walk to the underlying SDK and attach a LuminExporter. Returns
+ * true if attached, false if no compatible provider was found.
+ */
+export function tryAttach(provider: TracerProvider): boolean {
+  const target = findAttachableProvider(provider);
+  if (target === null) return false;
+  target.addSpanProcessor!(new BatchSpanProcessor(new LuminExporter()));
+  return true;
+}
+
+export function installLuminTracing(): boolean {
+  if (!isEnabled()) return false;
+  return tryAttach(trace.getTracerProvider());
+}
+
+installLuminTracing();

--- a/packages/integrations/voltagent/src/config.ts
+++ b/packages/integrations/voltagent/src/config.ts
@@ -1,0 +1,73 @@
+/**
+ * Helper that builds an OTel `BatchSpanProcessor` wired to the
+ * Lumin exporter — the right shape to register with VoltAgent's
+ * OTel pipeline.
+ *
+ * Usage:
+ *
+ *     import { luminProcessor } from '@lumin-io/voltagent';
+ *
+ *     spanProcessors: [luminProcessor()]
+ *
+ * ENV variables read:
+ *   LUMIN_HOST        — exporter host (default http://localhost:8000)
+ *   LUMIN_API_KEY     — optional bearer token for hosted Lumin
+ *   LUMIN_PROJECT     — project tag (default "voltagent")
+ *   LUMIN_SERVICE_NAME — VoltAgent serviceName (default "voltagent-app")
+ */
+
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import {
+  LuminExporter,
+  type LuminExporterConfig,
+} from './exporter.js';
+
+export interface LuminConfigOptions extends LuminExporterConfig {
+  /** VoltAgent / OTel `service.name` resource attribute. Default:
+   *  LUMIN_SERVICE_NAME or "voltagent-app". */
+  serviceName?: string;
+}
+
+/**
+ * Build a LuminExporter wrapped in a `BatchSpanProcessor` ready
+ * to be registered with VoltAgent's OTel pipeline or any OTel
+ * `NodeTracerProvider`'s `spanProcessors:` array.
+ */
+export function luminProcessor(
+  opts: LuminConfigOptions = {},
+): BatchSpanProcessor {
+  return new BatchSpanProcessor(
+    new LuminExporter({
+      host: opts.host,
+      apiKey: opts.apiKey,
+      project: opts.project,
+      timeoutMs: opts.timeoutMs,
+      fetchImpl: opts.fetchImpl,
+      maxPayloadSize: opts.maxPayloadSize,
+    }),
+  );
+}
+
+/**
+ * Build a Lumin exporter directly (useful if you want a different
+ * processor, e.g. SimpleSpanProcessor for tests).
+ */
+export function luminExporter(
+  opts: LuminConfigOptions = {},
+): LuminExporter {
+  return new LuminExporter({
+    host: opts.host,
+    apiKey: opts.apiKey,
+    project: opts.project,
+    timeoutMs: opts.timeoutMs,
+    fetchImpl: opts.fetchImpl,
+    maxPayloadSize: opts.maxPayloadSize,
+  });
+}
+
+/** Read the VoltAgent service name from env (or the supplied default). */
+export function resolveServiceName(opts: LuminConfigOptions = {}): string {
+  const env =
+    typeof process !== 'undefined' ? process.env : ({} as NodeJS.ProcessEnv);
+  return opts.serviceName ?? env.LUMIN_SERVICE_NAME ?? 'voltagent-app';
+}

--- a/packages/integrations/voltagent/src/exporter.ts
+++ b/packages/integrations/voltagent/src/exporter.ts
@@ -1,0 +1,470 @@
+/**
+ * Lumin exporter for VoltAgent and any other OTel-based agent framework.
+ *
+ * VoltAgent (`@voltagent/core`) is an OTel-native framework: it sets up
+ * an OTel TracerProvider and emits spans for every agent generation,
+ * LLM call, tool call, and guardrail. This exporter plugs into that
+ * pipeline and converts each batch of OTel spans into Lumin's native
+ * JSON span format, POSTing to `{host}/v1/spans`.
+ *
+ * VoltAgent attribute conventions verified against
+ * `node_modules/@voltagent/core/dist/*.js`:
+ *
+ *   - `ai.model.name` / `ai.model.provider` — LLM identity
+ *   - bare `input` / `output` — root + LLM + tool span content (this
+ *     is the unusual one — most frameworks namespace these keys)
+ *   - `agent.*` — lifecycle events (generation.started/completed,
+ *     tool.initiated, summary.*)
+ *   - `guardrail.*` — safety/policy spans
+ *
+ * Why not OTLP protobuf? Lumin's API exposes `/v1/spans` (native
+ * JSON) as the documented ingest path. Routing through native JSON
+ * keeps this package self-contained: no protobuf runtime, no schema
+ * codegen — minimal install footprint.
+ *
+ * Resilience (Lumin Rule 7): the agent must never fail because
+ * Lumin is unreachable. All network errors are swallowed; export()
+ * always reports success to the OTel pipeline so the SDK doesn't
+ * retry indefinitely or surface errors to user code.
+ */
+
+import type {
+  ReadableSpan,
+  SpanExporter,
+} from '@opentelemetry/sdk-trace-base';
+import { ExportResultCode, type ExportResult } from '@opentelemetry/core';
+import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
+
+export interface LuminExporterConfig {
+  /** Lumin API base URL. Defaults to env LUMIN_HOST or http://localhost:8000. */
+  host?: string;
+  /** Optional API key for hosted Lumin (sent as Authorization: Bearer). */
+  apiKey?: string;
+  /** Project tag for grouping. Defaults to "voltagent". */
+  project?: string;
+  /** Per-export network timeout in milliseconds. Default 5_000. */
+  timeoutMs?: number;
+  /** Inject a custom fetch impl — useful for tests. */
+  fetchImpl?: typeof fetch;
+  /** Maximum size for serialized input/output payloads. Default 10_240. */
+  maxPayloadSize?: number;
+}
+
+interface LuminSpan {
+  id: string;
+  trace_id: string;
+  parent_span_id: string | null;
+  name: string;
+  type: string;
+  input: string | null;
+  output: string | null;
+  started_at: string;
+  ended_at: string | null;
+  error: string | null;
+  session_id: string | null;
+  span_subtype?: string | null;
+  thinking_tokens?: number | null;
+  model?: string | null;
+  provider?: string | null;
+  tokens_input?: number | null;
+  tokens_output?: number | null;
+  cost_usd?: number | null;
+  tool_name?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+const DEFAULT_HOST = 'http://localhost:8000';
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_PROJECT = 'voltagent';
+const DEFAULT_MAX_PAYLOAD = 10_240;
+
+/**
+ * Per-1k-token USD prices — same table as `@lumin-io/openclaw` and
+ * `@lumin-io/mastra` so cost numbers stay consistent across frameworks.
+ * Longest-prefix match against the (lowercased) model name.
+ */
+const PRICES_PER_1K: Record<string, [number, number]> = {
+  'gpt-4o-mini': [0.00015, 0.0006],
+  'gpt-4o': [0.0025, 0.010],
+  'gpt-4-turbo': [0.010, 0.030],
+  'gpt-4': [0.030, 0.060],
+  'gpt-3.5-turbo': [0.0005, 0.0015],
+  'claude-opus-4': [0.015, 0.075],
+  'claude-sonnet-4': [0.003, 0.015],
+  'claude-haiku-4': [0.001, 0.005],
+  'text-embedding-3-small': [0.00002, 0],
+  'text-embedding-3-large': [0.00013, 0],
+  'text-embedding-ada-002': [0.0001, 0],
+};
+
+function normalizeModel(model: string): string {
+  const m = model.toLowerCase();
+  if (m.startsWith('ft:')) {
+    const rest = m.slice(3);
+    return rest.includes(':') ? rest.slice(0, rest.indexOf(':')) : rest;
+  }
+  if (m.includes('/')) return m.slice(m.indexOf('/') + 1);
+  return m;
+}
+
+function computeCost(
+  model: string | null | undefined,
+  tin: number | null | undefined,
+  tout: number | null | undefined,
+): number | null {
+  if (!model || tin == null || tout == null) return null;
+  const m = normalizeModel(model);
+  let bestKey = '';
+  let best: [number, number] | null = null;
+  for (const [key, prices] of Object.entries(PRICES_PER_1K)) {
+    if (m.startsWith(key) && key.length > bestKey.length) {
+      bestKey = key;
+      best = prices;
+    }
+  }
+  if (!best) return null;
+  const [inp, outp] = best;
+  return Math.round(((tin * inp) / 1000 + (tout * outp) / 1000) * 1e8) / 1e8;
+}
+
+export function registerModelPrice(
+  modelPrefix: string,
+  inputPer1k: number,
+  outputPer1k: number,
+): void {
+  PRICES_PER_1K[modelPrefix.toLowerCase()] = [inputPer1k, outputPer1k];
+}
+
+function serialize(value: unknown, maxSize: number): string | null {
+  if (value === null || value === undefined) return null;
+  let s: string;
+  if (typeof value === 'string') {
+    s = value;
+  } else if (Array.isArray(value)) {
+    s = value
+      .map((v) => (typeof v === 'string' ? v : safeStringify(v)))
+      .join('\n');
+  } else if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint'
+  ) {
+    s = String(value);
+  } else {
+    s = safeStringify(value);
+  }
+  return s.length > maxSize ? s.slice(0, maxSize) : s;
+}
+
+function safeStringify(v: unknown): string {
+  try {
+    const result = JSON.stringify(v);
+    return result === undefined ? String(v) : result;
+  } catch {
+    return String(v);
+  }
+}
+
+/** OTel hr_time → microsecond-precision ISO-8601 in UTC. */
+function hrTimeToIso(time: [number, number] | undefined | null): string | null {
+  if (!time) return null;
+  const [seconds, nanos] = time;
+  const ms = seconds * 1000 + Math.floor(nanos / 1_000_000);
+  const micros = Math.floor(nanos / 1_000) % 1_000_000;
+  const isoMs = new Date(ms).toISOString();
+  return isoMs.slice(0, -5) + '.' + String(micros).padStart(6, '0') + 'Z';
+}
+
+/**
+ * Map an OTel span to a Lumin span `type`. VoltAgent emits a mix of
+ * GenAI semconv keys, the Vercel AI SDK `ai.*` namespace, and its own
+ * bare-attribute conventions.
+ */
+function classifySpanType(span: ReadableSpan): string {
+  const attrs = span.attributes ?? {};
+  // VoltAgent flags LLM spans either via OTel semconv OR via its
+  // own `ai.model.name` (the Vercel AI SDK convention it inherits).
+  if (
+    attrs['gen_ai.operation.name'] ||
+    attrs['gen_ai.request.model'] ||
+    attrs['ai.model.name']
+  ) {
+    return 'llm';
+  }
+  // Tool detection: GenAI semconv key, the bare `tool.name` (used by
+  // VoltAgent + Vercel AI SDK + many ad-hoc OTel pipelines), or the
+  // VoltAgent-specific lifecycle hint.
+  if (
+    attrs['gen_ai.tool.name'] ||
+    attrs['gen_ai.tool.type'] ||
+    attrs['tool.name'] ||
+    attrs['voltagent.tool.name'] ||
+    attrs['agent.tool.initiated']
+  ) {
+    return 'tool';
+  }
+  switch (span.kind) {
+    case SpanKind.CLIENT:
+    case SpanKind.PRODUCER:
+      return 'llm';
+    case SpanKind.SERVER:
+    case SpanKind.CONSUMER:
+      return 'tool';
+    case SpanKind.INTERNAL:
+    default:
+      return 'custom';
+  }
+}
+
+function attrString(
+  attrs: Record<string, unknown>,
+  key: string,
+): string | null {
+  const v = attrs[key];
+  return typeof v === 'string' ? v : null;
+}
+
+function attrNumber(
+  attrs: Record<string, unknown>,
+  key: string,
+): number | null {
+  const v = attrs[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+/** Convert one OTel ReadableSpan to a Lumin SpanInput. */
+export function otelSpanToLumin(
+  span: ReadableSpan,
+  maxPayloadSize: number = DEFAULT_MAX_PAYLOAD,
+): LuminSpan {
+  const ctx = span.spanContext();
+  const attrs = (span.attributes ?? {}) as Record<string, unknown>;
+  const resourceAttrs = ((span.resource as { attributes?: Record<string, unknown> })?.attributes ?? {}) as Record<string, unknown>;
+
+  const luminType = classifySpanType(span);
+  // VoltAgent emits `ai.model.name` and `ai.model.provider`. Other
+  // frameworks emit `gen_ai.*`. Read both, in priority order.
+  const model =
+    attrString(attrs, 'gen_ai.response.model') ??
+    attrString(attrs, 'gen_ai.request.model') ??
+    attrString(attrs, 'ai.model.name') ??
+    attrString(attrs, 'ai.model.id');
+  const provider =
+    attrString(attrs, 'gen_ai.system') ??
+    attrString(attrs, 'ai.model.provider');
+  const tokensIn =
+    attrNumber(attrs, 'gen_ai.usage.input_tokens') ??
+    attrNumber(attrs, 'gen_ai.usage.prompt_tokens');
+  const tokensOut =
+    attrNumber(attrs, 'gen_ai.usage.output_tokens') ??
+    attrNumber(attrs, 'gen_ai.usage.completion_tokens');
+  const toolName =
+    attrString(attrs, 'gen_ai.tool.name') ??
+    attrString(attrs, 'voltagent.tool.name') ??
+    attrString(attrs, 'tool.name');
+  const costUsd = computeCost(model, tokensIn, tokensOut);
+
+  // Detect Claude / Gemini extended-thinking spans. VoltAgent surfaces
+  // reasoning text via the same Vercel-AI key Mastra uses
+  // (`ai.response.reasoning`); other pipelines use the OTel GenAI
+  // semconv key. Accept all three so the dashboard's brain-emoji
+  // subtype + Reasoning panel light up regardless.
+  const thinkingText =
+    attrString(attrs, 'ai.response.reasoning') ??
+    attrString(attrs, 'gen_ai.response.thinking') ??
+    attrString(attrs, 'anthropic.thinking') ??
+    null;
+  const isThinking = thinkingText !== null && thinkingText.length > 0;
+  const spanSubtype: 'thinking' | null = isThinking ? 'thinking' : null;
+  const thinkingTokens = isThinking
+    ? Math.max(1, Math.floor(thinkingText!.length / 4))
+    : null;
+
+  // Input / output content. VoltAgent uses BARE `input` / `output`
+  // attribute keys on the root + LLM + tool spans (verified against
+  // node_modules/@voltagent/core/dist source). They sit at the END
+  // of the priority list so namespaced keys (Vercel-AI / GenAI /
+  // OpenClaw conventions) win when both are present — only when no
+  // namespaced version exists do we fall back to the bare keys.
+  const input =
+    attrs['ai.prompt.messages'] ??
+    attrs['ai.toolCall.args'] ??
+    attrs['gen_ai.input.messages'] ??
+    attrs['gen_ai.prompt'] ??
+    attrs['voltagent.input'] ??
+    attrs['agent.messages'] ??
+    // Guardrail spans surface their checked content under guardrail.input.*
+    attrs['guardrail.input.original'] ??
+    attrs['guardrail.input.after'] ??
+    attrs['input'] ??
+    null;
+  const output =
+    attrs['ai.response.text'] ??
+    attrs['ai.response.object'] ??
+    attrs['ai.toolCall.result'] ??
+    attrs['gen_ai.output.messages'] ??
+    attrs['gen_ai.completion'] ??
+    attrs['voltagent.output'] ??
+    attrs['agent.step.text'] ??
+    // Guardrail decisions land as output: the action + message describe
+    // why a span was blocked / allowed.
+    attrs['guardrail.message'] ??
+    attrs['guardrail.output.after'] ??
+    attrs['output'] ??
+    null;
+
+  // Lumin native error_message is a string. OTel tracks status code
+  // separately from any exception event. Prefer a recorded exception
+  // message; fall back to status description.
+  let errorMessage: string | null = null;
+  if (span.status?.code === SpanStatusCode.ERROR) {
+    errorMessage = span.status.message ?? null;
+  }
+  for (const ev of span.events ?? []) {
+    if (ev.name === 'exception') {
+      const evAttrs = (ev.attributes ?? {}) as Record<string, unknown>;
+      const msg = attrString(evAttrs, 'exception.message');
+      if (msg) errorMessage = msg;
+    }
+  }
+
+  // Session/user identifiers — span attrs first, then resource attrs
+  // (which all spans in a process share). Resource fallback propagates
+  // a TracerProvider-level session id to every child without each
+  // span needing to set it itself.
+  const sessionId =
+    attrString(attrs, 'session.id') ??
+    attrString(attrs, 'gen_ai.conversation.id') ??
+    attrString(attrs, 'voltagent.session_id') ??
+    attrString(attrs, 'agent.parent.id') ??
+    attrString(resourceAttrs, 'session.id') ??
+    attrString(resourceAttrs, 'voltagent.session_id') ??
+    null;
+
+  // OTel SDK has moved from `parentSpanId` to `parentSpanContext.spanId`
+  // across versions. Read whichever is present.
+  const parentFromCtx = (
+    span as unknown as { parentSpanContext?: { spanId?: string } }
+  ).parentSpanContext?.spanId;
+  const parentLegacy = (span as unknown as { parentSpanId?: string })
+    .parentSpanId;
+  const parentSpanId = parentFromCtx ?? parentLegacy ?? null;
+
+  // For thinking spans, prefer the reasoning text as `input` (so the
+  // dashboard's "Reasoning" panel renders it) and clear `output`.
+  const finalInput = isThinking
+    ? serialize({ thinking: thinkingText }, maxPayloadSize)
+    : serialize(input, maxPayloadSize);
+  const finalOutput = isThinking
+    ? null
+    : serialize(output, maxPayloadSize);
+
+  return {
+    id: ctx.spanId,
+    trace_id: ctx.traceId,
+    parent_span_id: parentSpanId,
+    name: isThinking ? 'thinking' : span.name,
+    type: isThinking ? 'llm' : luminType,
+    input: finalInput,
+    output: finalOutput,
+    started_at: hrTimeToIso(span.startTime) ?? new Date().toISOString(),
+    ended_at: hrTimeToIso(span.endTime),
+    error: errorMessage,
+    session_id: sessionId,
+    span_subtype: spanSubtype,
+    thinking_tokens: thinkingTokens,
+    model,
+    provider,
+    tokens_input: tokensIn,
+    tokens_output: tokensOut,
+    cost_usd: costUsd,
+    tool_name: toolName,
+    metadata: attrs as Record<string, unknown>,
+  };
+}
+
+/**
+ * OTel SpanExporter that ships VoltAgent agent spans to a running
+ * Lumin instance. Drop-in for any OTel pipeline.
+ */
+export class LuminExporter implements SpanExporter {
+  private readonly host: string;
+  private readonly apiKey: string | undefined;
+  private readonly project: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly maxPayloadSize: number;
+  private shutdownCalled = false;
+
+  constructor(config: LuminExporterConfig = {}) {
+    this.host = (
+      config.host ??
+      (typeof process !== 'undefined' ? process.env.LUMIN_HOST : undefined) ??
+      DEFAULT_HOST
+    ).replace(/\/+$/, '');
+    this.apiKey =
+      config.apiKey ??
+      (typeof process !== 'undefined'
+        ? process.env.LUMIN_API_KEY
+        : undefined);
+    this.project = config.project ?? DEFAULT_PROJECT;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.maxPayloadSize = config.maxPayloadSize ?? DEFAULT_MAX_PAYLOAD;
+  }
+
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void,
+  ): void {
+    if (this.shutdownCalled || spans.length === 0) {
+      resultCallback({ code: ExportResultCode.SUCCESS });
+      return;
+    }
+    void this.send(spans).then(
+      () => resultCallback({ code: ExportResultCode.SUCCESS }),
+      // Lumin Rule 7: never let a network failure surface to the
+      // user. Report SUCCESS even on failure so OTel SDK does not
+      // retry indefinitely or throw at the caller.
+      () => resultCallback({ code: ExportResultCode.SUCCESS }),
+    );
+  }
+
+  async shutdown(): Promise<void> {
+    this.shutdownCalled = true;
+  }
+
+  async forceFlush(): Promise<void> {}
+
+  private async send(otelSpans: ReadableSpan[]): Promise<void> {
+    const luminSpans = otelSpans.map((s) =>
+      otelSpanToLumin(s, this.maxPayloadSize),
+    );
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'X-Lumin-Project': this.project,
+    };
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const resp = await this.fetchImpl(`${this.host}/v1/spans`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ spans: luminSpans }),
+        signal: controller.signal,
+      });
+      try {
+        await resp.text();
+      } catch {
+        /* swallow */
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/integrations/voltagent/src/index.ts
+++ b/packages/integrations/voltagent/src/index.ts
@@ -1,0 +1,37 @@
+/**
+ * @lumin-io/voltagent — local-first observability for VoltAgent.
+ *
+ * VoltAgent is OTel-native: the framework sets up an OTel TracerProvider
+ * and emits spans for every agent generation, tool call, and guardrail.
+ * This package provides the Lumin side of that pipe — an OTel
+ * `SpanExporter` plus a `BatchSpanProcessor` helper that's drop-in
+ * for any VoltAgent / OTel configuration.
+ *
+ * Public API:
+ *   - LuminExporter: OTel-compatible span exporter that ships to
+ *     a running Lumin instance (default http://localhost:8000).
+ *   - luminProcessor(): helper that wraps the exporter in a
+ *     BatchSpanProcessor — the right shape for VoltAgent's OTel
+ *     spanProcessors array.
+ *   - luminExporter(): builds the bare exporter (e.g. for tests
+ *     that want a SimpleSpanProcessor instead).
+ *   - installLuminTracing(): attaches a LuminExporter to the
+ *     active OTel tracer provider when LUMIN_TRACING=true. Most
+ *     users will use the `import "@lumin-io/voltagent/auto"` form.
+ */
+
+export {
+  LuminExporter,
+  otelSpanToLumin,
+  registerModelPrice,
+} from './exporter.js';
+export type { LuminExporterConfig } from './exporter.js';
+
+export {
+  luminProcessor,
+  luminExporter,
+  resolveServiceName,
+} from './config.js';
+export type { LuminConfigOptions } from './config.js';
+
+export { installLuminTracing, tryAttach } from './auto.js';

--- a/packages/integrations/voltagent/tests/exporter.test.ts
+++ b/packages/integrations/voltagent/tests/exporter.test.ts
@@ -1,0 +1,613 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import { ExportResultCode } from '@opentelemetry/core';
+import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import {
+  LuminExporter,
+  otelSpanToLumin,
+} from '../src/exporter.js';
+
+/** Build a ReadableSpan-shaped object good enough for the mapper. */
+function makeSpan(overrides: Partial<ReadableSpan> & {
+  attributes?: Record<string, unknown>;
+} = {}): ReadableSpan {
+  const base: ReadableSpan = {
+    name: 'test_span',
+    kind: SpanKind.CLIENT,
+    spanContext: () => ({
+      traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      spanId: 'bbbbbbbbbbbbbbbb',
+      traceFlags: 0,
+      isRemote: false,
+    }),
+    parentSpanId: undefined,
+    startTime: [1700000000, 0],
+    endTime: [1700000001, 500_000_000],
+    status: { code: SpanStatusCode.UNSET },
+    attributes: {},
+    links: [],
+    events: [],
+    duration: [1, 500_000_000],
+    ended: true,
+    resource: {
+      attributes: {},
+      merge: () => base.resource,
+    } as ReadableSpan['resource'],
+    instrumentationLibrary: { name: 'test', version: '0.0.0' },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+    ...overrides,
+  };
+  return base;
+}
+
+// ---------- mapper ----------
+
+describe('otelSpanToLumin', () => {
+  test('basic fields map across', () => {
+    const span = makeSpan({
+      name: 'agent.run',
+      attributes: { 'input': 'hello' },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.id).toBe('bbbbbbbbbbbbbbbb');
+    expect(out.trace_id).toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(out.name).toBe('agent.run');
+    expect(out.parent_span_id).toBeNull();
+    // Microsecond-precision ISO format preserves sub-ms ordering
+    expect(out.started_at).toBe('2023-11-14T22:13:20.000000Z');
+    expect(out.ended_at).toBe('2023-11-14T22:13:21.500000Z');
+  });
+
+  test('GenAI attributes populate model/provider/tokens AND cost', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.system': 'anthropic',
+        'gen_ai.request.model': 'claude-sonnet-4',
+        'gen_ai.response.model': 'claude-sonnet-4-20250514',
+        'gen_ai.usage.input_tokens': 1000,
+        'gen_ai.usage.output_tokens': 500,
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.type).toBe('llm');
+    expect(out.provider).toBe('anthropic');
+    expect(out.model).toBe('claude-sonnet-4-20250514');
+    expect(out.tokens_input).toBe(1000);
+    expect(out.tokens_output).toBe(500);
+    // claude-sonnet-4: $0.003/1k in, $0.015/1k out → 1000*0.003/1000 + 500*0.015/1000 = 0.003 + 0.0075 = 0.0105
+    expect(out.cost_usd).toBeCloseTo(0.0105, 6);
+  });
+
+  test('cost computed from gen_ai.usage on real model', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.system': 'openai',
+        'gen_ai.request.model': 'gpt-4o-mini',
+        'gen_ai.usage.input_tokens': 1000,
+        'gen_ai.usage.output_tokens': 1000,
+      },
+    });
+    // gpt-4o-mini: $0.00015 in, $0.0006 out per 1k → 0.00015 + 0.0006 = 0.00075
+    expect(otelSpanToLumin(span).cost_usd).toBeCloseTo(0.00075, 6);
+  });
+
+  test('cost null for unknown model', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.request.model': 'some-future-model-2027',
+        'gen_ai.usage.input_tokens': 100,
+        'gen_ai.usage.output_tokens': 50,
+      },
+    });
+    expect(otelSpanToLumin(span).cost_usd).toBeNull();
+  });
+
+  test('fine-tuned model name normalizes (ft:gpt-4o:org::abc)', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.request.model': 'ft:gpt-4o:my-org::abc123',
+        'gen_ai.usage.input_tokens': 1000,
+        'gen_ai.usage.output_tokens': 500,
+      },
+    });
+    expect(otelSpanToLumin(span).cost_usd).toBeGreaterThan(0);
+  });
+
+  test('thinking text triggers span_subtype=thinking and renames span', () => {
+    const span = makeSpan({
+      name: 'llm.think_and_plan',
+      attributes: {
+        'gen_ai.system': 'anthropic',
+        'gen_ai.request.model': 'claude-opus-4',
+        'gen_ai.usage.input_tokens': 100,
+        'gen_ai.usage.output_tokens': 800,
+        'gen_ai.response.thinking':
+          'Let me reason carefully through this problem step by step…',
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.span_subtype).toBe('thinking');
+    expect(out.name).toBe('thinking');
+    expect(out.thinking_tokens).toBeGreaterThan(0);
+    expect(out.input).toContain('Let me reason carefully');
+    // Output cleared so dashboard's Reasoning panel is the only place it appears
+    expect(out.output).toBeNull();
+  });
+
+  test('session_id propagates from resource attributes when not on span', () => {
+    const span = makeSpan({
+      attributes: {},
+      resource: {
+        attributes: { 'voltagent.session_id': 'volt-sess-42' },
+        merge: () => undefined,
+      } as never,
+    });
+    expect(otelSpanToLumin(span).session_id).toBe('volt-sess-42');
+  });
+
+  test('span attribute beats resource attribute for session_id', () => {
+    const span = makeSpan({
+      attributes: { 'session.id': 'span-level' },
+      resource: {
+        attributes: { 'voltagent.session_id': 'resource-level' },
+        merge: () => undefined,
+      } as never,
+    });
+    expect(otelSpanToLumin(span).session_id).toBe('span-level');
+  });
+
+  test('tool span: gen_ai.tool.name yields type=tool', () => {
+    const span = makeSpan({
+      kind: SpanKind.INTERNAL,
+      attributes: {
+        'gen_ai.tool.name': 'web_search',
+        'gen_ai.tool.type': 'function',
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.type).toBe('tool');
+    expect(out.tool_name).toBe('web_search');
+  });
+
+  test('tool span: bare tool.name (Vercel/OTel ad-hoc) yields type=tool', () => {
+    // Many real-world OTel pipelines emit `tool.name` without the
+    // `gen_ai.` prefix; VoltAgent exporter must accept that too.
+    const span = makeSpan({
+      kind: SpanKind.INTERNAL,
+      attributes: { 'tool.name': 'calculator' },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.type).toBe('tool');
+    expect(out.tool_name).toBe('calculator');
+  });
+
+  test('tool span: voltagent.tool.name namespace also recognized', () => {
+    const span = makeSpan({
+      kind: SpanKind.INTERNAL,
+      attributes: { 'voltagent.tool.name': 'http_fetch' },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.type).toBe('tool');
+    expect(out.tool_name).toBe('http_fetch');
+  });
+
+  test('tool span: agent.tool.initiated event flag yields type=tool', () => {
+    // Real VoltAgent sets `agent.tool.initiated` on its tool-call spans.
+    // Even without an explicit tool.name, this hint should classify
+    // the span correctly.
+    const span = makeSpan({
+      kind: SpanKind.INTERNAL,
+      attributes: { 'agent.tool.initiated': true, 'tool.name': 'shell' },
+    });
+    expect(otelSpanToLumin(span).type).toBe('tool');
+  });
+
+  test('SpanKind.INTERNAL with no GenAI attrs → custom', () => {
+    const span = makeSpan({ kind: SpanKind.INTERNAL });
+    expect(otelSpanToLumin(span).type).toBe('custom');
+  });
+
+  test('parent_span_id propagates', () => {
+    const span = makeSpan({ parentSpanId: 'cccccccccccccccc' });
+    expect(otelSpanToLumin(span).parent_span_id).toBe('cccccccccccccccc');
+  });
+
+  test('exception event → error', () => {
+    const span = makeSpan({
+      status: { code: SpanStatusCode.ERROR, message: 'fallback' },
+      events: [
+        {
+          name: 'exception',
+          time: [1700000000, 0],
+          attributes: {
+            'exception.message': 'tool unreachable',
+            'exception.type': 'NetworkError',
+          },
+        },
+      ],
+    });
+    expect(otelSpanToLumin(span).error).toBe('tool unreachable');
+  });
+
+  test('OTel ERROR status with no exception event → status.message', () => {
+    const span = makeSpan({
+      status: { code: SpanStatusCode.ERROR, message: 'connection refused' },
+    });
+    expect(otelSpanToLumin(span).error).toBe('connection refused');
+  });
+
+  test('OK status → error is null', () => {
+    const span = makeSpan({ status: { code: SpanStatusCode.OK } });
+    expect(otelSpanToLumin(span).error).toBeNull();
+  });
+
+  test('real VoltAgent bare `input` / `output` keys are read', () => {
+    // Verified against node_modules/@voltagent/core/dist source:
+    // VoltAgent sets bare `input` and `output` (no namespace) on root,
+    // LLM, and tool spans. Without this fallback every VoltAgent span
+    // would have null content in the dashboard.
+    const span = makeSpan({
+      attributes: {
+        input: 'Summarize the latest PR for me.',
+        output: 'It rebrands Synaptic to Lumin and adds 4 new fixes.',
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.input).toContain('Summarize the latest PR');
+    expect(out.output).toContain('rebrands Synaptic to Lumin');
+  });
+
+  test('voltagent.input / voltagent.output explicit namespace also works', () => {
+    const span = makeSpan({
+      attributes: {
+        'voltagent.input': 'What is the weather in Tokyo?',
+        'voltagent.output': 'It is sunny, 24°C.',
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.input).toContain('Tokyo');
+    expect(out.output).toContain('24°C');
+  });
+
+  test('namespaced ai.prompt.messages WINS over bare input', () => {
+    // When both are present, the namespaced (more specific) key wins.
+    // This protects multi-framework apps that mix a bare `input` log
+    // line with a structured Vercel-AI prompt array.
+    const span = makeSpan({
+      attributes: {
+        'ai.prompt.messages':
+          '[{"role":"user","content":"namespaced wins"}]',
+        input: 'bare loses',
+      },
+    });
+    expect(otelSpanToLumin(span).input).toContain('namespaced wins');
+  });
+
+  test('agent.step.text used as output fallback for VoltAgent step spans', () => {
+    // VoltAgent's intermediate step spans set `agent.step.text` rather
+    // than `output`. Our exporter should still surface that text.
+    const span = makeSpan({
+      attributes: {
+        'agent.step.text': 'Step 2: I should call the calculator tool.',
+      },
+    });
+    expect(otelSpanToLumin(span).output).toContain('Step 2');
+  });
+
+  test('guardrail.input.original / .output.after surface as input / output', () => {
+    // VoltAgent guardrail spans use the `guardrail.*` namespace for
+    // checked content + the policy decision. Surface them so the
+    // dashboard renders something on guardrail rows instead of empty.
+    const span = makeSpan({
+      attributes: {
+        'guardrail.name': 'pii_detector',
+        'guardrail.action': 'block',
+        'guardrail.input.original': 'call me at 9876543210',
+        'guardrail.message': 'Detected: phone number — input blocked',
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.input).toContain('9876543210');
+    expect(out.output).toContain('Detected: phone number');
+  });
+
+  test('agent.parent.id is used as session_id fallback', () => {
+    // VoltAgent sub-agent spans carry `agent.parent.id` — we use it
+    // as a session-grouping fallback so subagent runs land in the
+    // right session view.
+    const span = makeSpan({
+      attributes: { 'agent.parent.id': 'subagent-flow-001' },
+    });
+    expect(otelSpanToLumin(span).session_id).toBe('subagent-flow-001');
+  });
+
+  test('Vercel AI SDK ai.prompt.messages and ai.response.text', () => {
+    // VoltAgent uses the same Vercel-AI-style attribute keys when it
+    // wraps OpenAI / Anthropic providers.
+    const promptJson = JSON.stringify([
+      { role: 'user', content: 'What is the weather?' },
+    ]);
+    const span = makeSpan({
+      attributes: {
+        'ai.prompt.messages': promptJson,
+        'ai.response.text': 'It is sunny.',
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.input).toBe(promptJson);
+    expect(out.output).toBe('It is sunny.');
+  });
+
+  test('Vercel AI tool call: ai.toolCall.args + .result', () => {
+    const argsJson = JSON.stringify({ query: 'Tokyo weather' });
+    const resultJson = JSON.stringify({ result: 'Sunny, 24°C' });
+    const span = makeSpan({
+      attributes: {
+        'ai.toolCall.args': argsJson,
+        'ai.toolCall.result': resultJson,
+        'gen_ai.tool.name': 'web_search',
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.type).toBe('tool');
+    expect(out.tool_name).toBe('web_search');
+    expect(out.input).toBe(argsJson);
+    expect(out.output).toBe(resultJson);
+  });
+
+  test('legacy gen_ai.prompt / gen_ai.completion still recognized', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.prompt': 'p',
+        'gen_ai.completion': 'c',
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.input).toContain('p');
+    expect(out.output).toContain('c');
+  });
+
+  test('array-of-strings prompt joins with newlines', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.prompt': ['system: be helpful', 'user: hello'],
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.input).toBe('system: be helpful\nuser: hello');
+  });
+
+  test('numeric / boolean attribute values are stringified, not dropped', () => {
+    const span = makeSpan({
+      attributes: { input: 42 },
+    });
+    expect(otelSpanToLumin(span).input).toBe('42');
+  });
+
+  test('session_id resolves from VoltAgent + cross-framework conventions', () => {
+    const a = otelSpanToLumin(
+      makeSpan({ attributes: { 'session.id': 's-1' } }),
+    );
+    expect(a.session_id).toBe('s-1');
+
+    const b = otelSpanToLumin(
+      makeSpan({ attributes: { 'gen_ai.conversation.id': 'c-2' } }),
+    );
+    expect(b.session_id).toBe('c-2');
+
+    const c = otelSpanToLumin(
+      makeSpan({ attributes: { 'voltagent.session_id': 's-3' } }),
+    );
+    expect(c.session_id).toBe('s-3');
+
+    // VoltAgent sub-agent spans set `agent.parent.id`; we use it as a
+    // session-grouping fallback so subagent runs land in the right
+    // /sessions group.
+    const d = otelSpanToLumin(
+      makeSpan({ attributes: { 'agent.parent.id': 'parent-001' } }),
+    );
+    expect(d.session_id).toBe('parent-001');
+  });
+
+  test('large input is truncated to maxPayloadSize', () => {
+    const huge = 'x'.repeat(50_000);
+    const span = makeSpan({ attributes: { input: huge } });
+    const out = otelSpanToLumin(span, 1024);
+    expect(out.input).not.toBeNull();
+    expect(out.input!.length).toBeLessThanOrEqual(1024);
+  });
+
+  test('non-string non-number attribute values are rejected by attrString/attrNumber', () => {
+    const span = makeSpan({
+      attributes: {
+        'gen_ai.request.model': 12345 as unknown as string,
+        'gen_ai.usage.input_tokens': 'not-a-number' as unknown as number,
+      },
+    });
+    const out = otelSpanToLumin(span);
+    expect(out.model).toBeNull();
+    expect(out.tokens_input).toBeNull();
+  });
+});
+
+// ---------- exporter ----------
+
+describe('LuminExporter', () => {
+  let originalHost: string | undefined;
+  beforeEach(() => {
+    originalHost = process.env.LUMIN_HOST;
+  });
+
+  test('export() POSTs to /v1/spans with project=voltagent by default', async () => {
+    const captured: { url: string; init?: RequestInit } = { url: '' };
+    const fakeFetch: typeof fetch = async (url, init) => {
+      captured.url = String(url);
+      captured.init = init;
+      return new Response('{"accepted":1}', { status: 200 });
+    };
+
+    const exporter = new LuminExporter({
+      host: 'http://localhost:9999',
+      fetchImpl: fakeFetch,
+    });
+
+    const result = await new Promise((resolve) => {
+      exporter.export([makeSpan()], resolve);
+    });
+
+    expect((result as { code: ExportResultCode }).code).toBe(
+      ExportResultCode.SUCCESS,
+    );
+    expect(captured.url).toBe('http://localhost:9999/v1/spans');
+    const body = JSON.parse(String(captured.init?.body));
+    expect(body.spans).toHaveLength(1);
+    expect(body.spans[0].name).toBe('test_span');
+    const headers = captured.init?.headers as Record<string, string>;
+    expect(headers['X-Lumin-Project']).toBe('voltagent');
+  });
+
+  test('explicit project overrides default', async () => {
+    const captured: { headers?: Record<string, string> } = {};
+    const fakeFetch: typeof fetch = async (_url, init) => {
+      captured.headers = init?.headers as Record<string, string>;
+      return new Response('{}');
+    };
+    const exporter = new LuminExporter({
+      host: 'http://x',
+      project: 'my-bot',
+      fetchImpl: fakeFetch,
+    });
+    await new Promise((r) => exporter.export([makeSpan()], r));
+    expect(captured.headers!['X-Lumin-Project']).toBe('my-bot');
+  });
+
+  test('Authorization header set when apiKey provided', async () => {
+    const captured: { headers?: Record<string, string> } = {};
+    const fakeFetch: typeof fetch = async (_url, init) => {
+      captured.headers = init?.headers as Record<string, string>;
+      return new Response('{}');
+    };
+    const exporter = new LuminExporter({
+      host: 'http://x',
+      apiKey: 'secret-token',
+      fetchImpl: fakeFetch,
+    });
+    await new Promise((r) => exporter.export([makeSpan()], r));
+    expect(captured.headers!['Authorization']).toBe('Bearer secret-token');
+  });
+
+  test('network error swallowed (Rule 7) — export still reports SUCCESS', async () => {
+    const fakeFetch: typeof fetch = async () => {
+      throw new Error('ECONNREFUSED');
+    };
+    const exporter = new LuminExporter({
+      host: 'http://unreachable',
+      fetchImpl: fakeFetch,
+    });
+    const result = await new Promise<{ code: ExportResultCode }>((r) => {
+      exporter.export([makeSpan()], r as (v: unknown) => void);
+    });
+    expect(result.code).toBe(ExportResultCode.SUCCESS);
+  });
+
+  test('non-2xx response is swallowed too — agent never sees it', async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response('boom', { status: 500 });
+    const exporter = new LuminExporter({
+      host: 'http://x',
+      fetchImpl: fakeFetch,
+    });
+    const result = await new Promise<{ code: ExportResultCode }>((r) => {
+      exporter.export([makeSpan()], r as (v: unknown) => void);
+    });
+    expect(result.code).toBe(ExportResultCode.SUCCESS);
+  });
+
+  test('empty span list short-circuits with SUCCESS', async () => {
+    let called = false;
+    const fakeFetch: typeof fetch = async () => {
+      called = true;
+      return new Response('');
+    };
+    const exporter = new LuminExporter({
+      host: 'http://x',
+      fetchImpl: fakeFetch,
+    });
+    const result = await new Promise<{ code: ExportResultCode }>((r) => {
+      exporter.export([], r as (v: unknown) => void);
+    });
+    expect(result.code).toBe(ExportResultCode.SUCCESS);
+    expect(called).toBe(false);
+  });
+
+  test('after shutdown(), exports become no-ops', async () => {
+    let posted = 0;
+    const fakeFetch: typeof fetch = async () => {
+      posted += 1;
+      return new Response('');
+    };
+    const exporter = new LuminExporter({
+      host: 'http://x',
+      fetchImpl: fakeFetch,
+    });
+    await exporter.shutdown();
+    await new Promise((r) => exporter.export([makeSpan()], r));
+    expect(posted).toBe(0);
+  });
+
+  test('LUMIN_HOST env var is the default when host not given', async () => {
+    process.env.LUMIN_HOST = 'http://envhost:7777';
+    const captured: { url: string } = { url: '' };
+    const fakeFetch: typeof fetch = async (url) => {
+      captured.url = String(url);
+      return new Response('');
+    };
+    const exporter = new LuminExporter({ fetchImpl: fakeFetch });
+    await new Promise((r) => exporter.export([makeSpan()], r));
+    expect(captured.url).toBe('http://envhost:7777/v1/spans');
+  });
+
+  test('host with trailing slash is normalized', async () => {
+    const captured: { url: string } = { url: '' };
+    const fakeFetch: typeof fetch = async (url) => {
+      captured.url = String(url);
+      return new Response('');
+    };
+    const exporter = new LuminExporter({
+      host: 'http://x:8000/',
+      fetchImpl: fakeFetch,
+    });
+    await new Promise((r) => exporter.export([makeSpan()], r));
+    expect(captured.url).toBe('http://x:8000/v1/spans');
+  });
+
+  test('hung server is aborted by timeout — agent unaffected', async () => {
+    const fakeFetch: typeof fetch = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        const sig = init?.signal as AbortSignal | undefined;
+        sig?.addEventListener('abort', () =>
+          reject(new Error('AbortError')),
+        );
+      });
+    const exporter = new LuminExporter({
+      host: 'http://hang',
+      timeoutMs: 50,
+      fetchImpl: fakeFetch,
+    });
+    const start = Date.now();
+    const result = await new Promise<{ code: ExportResultCode }>((r) => {
+      exporter.export([makeSpan()], r as (v: unknown) => void);
+    });
+    const elapsed = Date.now() - start;
+    expect(result.code).toBe(ExportResultCode.SUCCESS);
+    expect(elapsed).toBeLessThan(1500);
+  });
+
+  test.each([['cleanup']])('cleanup', () => {
+    if (originalHost === undefined) delete process.env.LUMIN_HOST;
+    else process.env.LUMIN_HOST = originalHost;
+    expect(true).toBe(true);
+  });
+});

--- a/packages/integrations/voltagent/tests/resilience.test.ts
+++ b/packages/integrations/voltagent/tests/resilience.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Resilience tests — Lumin Rule 7: the agent must NEVER fail
+ * because Lumin is unreachable, slow, or returns an error.
+ */
+import { describe, expect, test } from 'vitest';
+import { ExportResultCode } from '@opentelemetry/core';
+import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { LuminExporter } from '../src/exporter.js';
+
+function makeSpan(): ReadableSpan {
+  return {
+    name: 's',
+    kind: SpanKind.INTERNAL,
+    spanContext: () => ({
+      traceId: 't',
+      spanId: 'a',
+      traceFlags: 0,
+      isRemote: false,
+    }),
+    parentSpanId: undefined,
+    startTime: [0, 0],
+    endTime: [0, 1_000_000],
+    status: { code: SpanStatusCode.UNSET },
+    attributes: {},
+    links: [],
+    events: [],
+    duration: [0, 1_000_000],
+    ended: true,
+    resource: { attributes: {}, merge: () => undefined } as never,
+    instrumentationLibrary: { name: 't', version: '0' },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  };
+}
+
+async function exportOnce(exporter: LuminExporter): Promise<ExportResultCode> {
+  return new Promise((resolve) => {
+    exporter.export([makeSpan()], (r) => resolve(r.code));
+  });
+}
+
+describe('resilience — agent never fails because of Lumin', () => {
+  test('Lumin unreachable (DNS failure) → SUCCESS', async () => {
+    const fakeFetch: typeof fetch = async () => {
+      throw new TypeError('fetch failed: ENOTFOUND lumin.local');
+    };
+    const exporter = new LuminExporter({
+      host: 'http://lumin.local',
+      fetchImpl: fakeFetch,
+    });
+    expect(await exportOnce(exporter)).toBe(ExportResultCode.SUCCESS);
+  });
+
+  test('Lumin returns 500 → SUCCESS', async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response('internal error', { status: 500 });
+    const exporter = new LuminExporter({
+      host: 'http://x',
+      fetchImpl: fakeFetch,
+    });
+    expect(await exportOnce(exporter)).toBe(ExportResultCode.SUCCESS);
+  });
+
+  test('Lumin returns 401 → SUCCESS', async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response('unauthorized', { status: 401 });
+    const exporter = new LuminExporter({
+      host: 'http://x',
+      apiKey: 'wrong-key',
+      fetchImpl: fakeFetch,
+    });
+    expect(await exportOnce(exporter)).toBe(ExportResultCode.SUCCESS);
+  });
+
+  test('Lumin hangs past timeout → SUCCESS within timeout window', async () => {
+    const fakeFetch: typeof fetch = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        const sig = init?.signal as AbortSignal | undefined;
+        sig?.addEventListener('abort', () =>
+          reject(new Error('AbortError')),
+        );
+      });
+    const exporter = new LuminExporter({
+      host: 'http://hang',
+      timeoutMs: 50,
+      fetchImpl: fakeFetch,
+    });
+    const start = Date.now();
+    const result = await exportOnce(exporter);
+    expect(result).toBe(ExportResultCode.SUCCESS);
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
+  test('response.text() throws after fetch — still SUCCESS', async () => {
+    const fakeFetch: typeof fetch = async () =>
+      ({
+        ok: true,
+        status: 200,
+        text: () => {
+          throw new Error('body parse failed');
+        },
+      }) as unknown as Response;
+    const exporter = new LuminExporter({
+      host: 'http://x',
+      fetchImpl: fakeFetch,
+    });
+    expect(await exportOnce(exporter)).toBe(ExportResultCode.SUCCESS);
+  });
+
+  test('export of huge batch (1000 spans) does not crash', async () => {
+    const fakeFetch: typeof fetch = async () => new Response('{}');
+    const exporter = new LuminExporter({
+      host: 'http://x',
+      fetchImpl: fakeFetch,
+    });
+    const spans = Array.from({ length: 1000 }, makeSpan);
+    const result = await new Promise<ExportResultCode>((resolve) => {
+      exporter.export(spans, (r) => resolve(r.code));
+    });
+    expect(result).toBe(ExportResultCode.SUCCESS);
+  });
+
+  test('shutdown() called twice is idempotent', async () => {
+    const exporter = new LuminExporter({ host: 'http://x' });
+    await exporter.shutdown();
+    await exporter.shutdown();
+    // No exception
+    expect(await exportOnce(exporter)).toBe(ExportResultCode.SUCCESS);
+  });
+
+  test('forceFlush() resolves without error when nothing buffered', async () => {
+    const exporter = new LuminExporter({ host: 'http://x' });
+    await expect(exporter.forceFlush()).resolves.toBeUndefined();
+  });
+});

--- a/packages/integrations/voltagent/tests/zero-config.test.ts
+++ b/packages/integrations/voltagent/tests/zero-config.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  luminProcessor,
+  luminExporter,
+  resolveServiceName,
+} from '../src/config.js';
+import { LuminExporter } from '../src/exporter.js';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+
+describe('luminProcessor() / luminExporter() / resolveServiceName()', () => {
+  let originalEnv: Record<string, string | undefined>;
+  beforeEach(() => {
+    originalEnv = {
+      LUMIN_HOST: process.env.LUMIN_HOST,
+      LUMIN_API_KEY: process.env.LUMIN_API_KEY,
+      LUMIN_SERVICE_NAME: process.env.LUMIN_SERVICE_NAME,
+    };
+  });
+  afterEach(() => {
+    for (const [k, v] of Object.entries(originalEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  test('luminProcessor returns a BatchSpanProcessor', () => {
+    const p = luminProcessor();
+    expect(p).toBeInstanceOf(BatchSpanProcessor);
+  });
+
+  test('luminExporter returns a LuminExporter', () => {
+    expect(luminExporter()).toBeInstanceOf(LuminExporter);
+  });
+
+  test('resolveServiceName defaults to voltagent-app', () => {
+    delete process.env.LUMIN_SERVICE_NAME;
+    expect(resolveServiceName()).toBe('voltagent-app');
+  });
+
+  test('resolveServiceName uses LUMIN_SERVICE_NAME env var', () => {
+    process.env.LUMIN_SERVICE_NAME = 'my-bot';
+    expect(resolveServiceName()).toBe('my-bot');
+  });
+
+  test('resolveServiceName explicit option overrides env', () => {
+    process.env.LUMIN_SERVICE_NAME = 'env-name';
+    expect(resolveServiceName({ serviceName: 'explicit' })).toBe('explicit');
+  });
+
+  test('luminExporter wired with the supplied options', async () => {
+    const captured: { url?: string; headers?: Record<string, string> } = {};
+    const fakeFetch: typeof fetch = async (url, init) => {
+      captured.url = String(url);
+      captured.headers = init?.headers as Record<string, string>;
+      return new Response('{}');
+    };
+    const exporter = luminExporter({
+      host: 'http://my-lumin:8000',
+      apiKey: 'k',
+      project: 'demo',
+      fetchImpl: fakeFetch,
+    });
+    await new Promise((r) =>
+      exporter.export(
+        [
+          {
+            name: 's',
+            kind: 1,
+            spanContext: () => ({
+              traceId: 't',
+              spanId: 'a',
+              traceFlags: 0,
+              isRemote: false,
+            }),
+            parentSpanId: undefined,
+            startTime: [0, 0],
+            endTime: [0, 1_000_000],
+            status: { code: 0 },
+            attributes: {},
+            links: [],
+            events: [],
+            duration: [0, 1_000_000],
+            ended: true,
+            resource: { attributes: {}, merge: () => undefined } as never,
+            instrumentationLibrary: { name: 't', version: '0' },
+            droppedAttributesCount: 0,
+            droppedEventsCount: 0,
+            droppedLinksCount: 0,
+          },
+        ],
+        r as (v: unknown) => void,
+      ),
+    );
+    expect(captured.url).toBe('http://my-lumin:8000/v1/spans');
+    expect(captured.headers!['Authorization']).toBe('Bearer k');
+    expect(captured.headers!['X-Lumin-Project']).toBe('demo');
+  });
+});
+
+describe('tryAttach() — pure attachment logic', () => {
+  test('attaches when provider exposes addSpanProcessor directly', async () => {
+    const { tryAttach } = await import('../src/auto.js');
+    let added: unknown = null;
+    const provider = {
+      getTracer: () => ({}) as never,
+      addSpanProcessor: (p: unknown) => {
+        added = p;
+      },
+    };
+    expect(tryAttach(provider as never)).toBe(true);
+    expect(added).not.toBeNull();
+  });
+
+  test('walks getDelegate() chain to find a compatible provider', async () => {
+    const { tryAttach } = await import('../src/auto.js');
+    let added: unknown = null;
+    const delegate = {
+      getTracer: () => ({}) as never,
+      addSpanProcessor: (p: unknown) => {
+        added = p;
+      },
+    };
+    const proxy = {
+      getTracer: () => ({}) as never,
+      getDelegate: () => delegate,
+    };
+    expect(tryAttach(proxy as never)).toBe(true);
+    expect(added).not.toBeNull();
+  });
+
+  test('returns false when no addSpanProcessor reachable (modern OTel)', async () => {
+    const { tryAttach } = await import('../src/auto.js');
+    const modernProxy = { getTracer: () => ({}) as never };
+    expect(tryAttach(modernProxy as never)).toBe(false);
+  });
+
+  test('returns false when proxy chain is too deep without a target', async () => {
+    const { tryAttach } = await import('../src/auto.js');
+    let p: unknown = { getTracer: () => ({}) };
+    for (let i = 0; i < 10; i++) {
+      const inner = p;
+      p = {
+        getTracer: () => ({}) as never,
+        getDelegate: () => inner,
+      };
+    }
+    expect(tryAttach(p as never)).toBe(false);
+  });
+});
+
+describe('installLuminTracing() — env gate', () => {
+  let originalEnv: string | undefined;
+  beforeEach(() => {
+    originalEnv = process.env.LUMIN_TRACING;
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.LUMIN_TRACING;
+    else process.env.LUMIN_TRACING = originalEnv;
+  });
+
+  test('returns false when LUMIN_TRACING is unset', async () => {
+    delete process.env.LUMIN_TRACING;
+    const { installLuminTracing } = await import('../src/auto.js');
+    expect(installLuminTracing()).toBe(false);
+  });
+
+  test('returns false when the global provider is the default no-op proxy', async () => {
+    process.env.LUMIN_TRACING = 'true';
+    const { installLuminTracing } = await import('../src/auto.js');
+    expect(installLuminTracing()).toBe(false);
+  });
+});

--- a/packages/integrations/voltagent/tsconfig.json
+++ b/packages/integrations/voltagent/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
Closes #21

## Summary

Adds **VoltAgent** as the fourth published integration alongside `@lumin-io/openclaw` and `@lumin-io/mastra`. Mirrors the existing OTel-bridge package shape (exporter, processor helpers, `/auto` entry, tests, CI).

Verified against real `@voltagent/core` source (not just documented semconv) — supports `ai.model.*`, `ai.response.reasoning`, bare `input` / `output` keys, `agent.parent.id`, `agent.step.text`, `agent.tool.initiated`, the full `guardrail.*` namespace, plus all GenAI semconv fallbacks.

## Brutal-test protocol (per maintainer instruction — 5 rounds)

| round | scenario | result |
|---|---|---|
| 1 | Full real-data demo: 3 traces (research agent, sub-agent delegation, guardrail block) | **2 real bugs surfaced** |
| 2 | Re-run after fixing both | clean |
| 3 | 50 KB payload (truncation), unicode/emoji/RTL, 51 microsecond-spaced spans, 6-deep nesting, event-only spans | clean |
| 4 | 201 spans in one trace, 5 truly-concurrent traces, array / boolean / number attribute values | clean |
| 5 | Orphan-child-before-root ingest, read-time session inheritance, live WebSocket broadcast | clean |

## Bugs surfaced + fixed in round 1

**Bug A — VoltAgent guardrail spans showed null input/output.** Real VoltAgent uses `guardrail.input.original` / `.input.after` / `.output.after` / `.message`. None were in our fallback list. Added.

**Bug B — `/v1/sessions` always reported $0 / 0 tokens, regardless of integration.** Cross-cutting bug, NOT VoltAgent-specific. The SQL aggregated `SUM(traces.total_cost_usd)` from the stored column, but that column is only populated when someone POSTs to `/v1/traces` explicitly. Every OTel-based exporter posts to `/v1/spans` only, so the column stays 0. Fixed: per-trace `GREATEST(stored, SUM-from-spans)` then `SUM`. Verified live — `volt-research-001` went from `$0.00 → $0.09`, all other sessions also now correct.

## Verification

| package | tests | Δ |
|---|---|---|
| sdk-python | 172 | — |
| api | **65** | +1 (sessions agg regression) |
| sdk-typescript | 59 | — |
| integrations/mastra | 55 | — |
| integrations/openclaw | 59 | — |
| integrations/voltagent | **62** | NEW |
| **total** | **472** | **+63** |

WebSocket smoke: `new_span` + `new_trace` events fire on every `/v1/spans` POST. Dashboard pages return 200; `/v1/traces?limit=N` and `/v1/sessions` return the right aggregated values.

## Test plan

- [x] All 6 unit suites green
- [x] 5 brutal-test demo rounds passed (logged in commit body)
- [x] Two real bugs caught + fixed
- [x] Dashboard render at `localhost:3000` (HTML 200, WS broadcasts work)
- [ ] User dashboard sanity check before merge
- [ ] After merge: publish `@lumin-io/voltagent@0.1.0` to npm