### PR TITLE
feat(dashboard): light/dark theme toggle in header

### DIFF
--- a/packages/dashboard/app/globals.css
+++ b/packages/dashboard/app/globals.css
@@ -6,7 +6,14 @@
   /* Refined dark palette — softer, more depth than the prior single
      flat slate. Background uses two stops so panels sit slightly
      above the page; subtle radial wash gives the surface depth
-     without going overboard. */
+     without going overboard. Default theme is dark — the
+     [data-theme="light"] block below flips a small set of variables
+     for light-mode users.
+
+     Variables that carry hardcoded color values in component CSS
+     (.app-header background, .wordmark gradient, the body radial
+     washes) are factored into separate vars so the theme switch
+     doesn't require touching every component. */
   --background:        #07090c;
   --background-raised: #0d1117;
   --background-hover:  #11161e;
@@ -26,6 +33,40 @@
   --brand-amber:   #f59e0b;
   --brand-emerald: #10b981;
   --brand-rose:    #f43f5e;
+  /* Themed primitives — read by component CSS that previously
+     hardcoded the dark equivalent inline. */
+  --header-bg:     rgba(7, 9, 12, 0.7);
+  --wash-blue:     rgba(96, 165, 250, 0.06);
+  --wash-violet:   rgba(167, 139, 250, 0.04);
+  --wordmark-from: #e7eaee;
+  --wordmark-to:   #94a3b8;
+  /* Color-scheme tells the browser what tone the page is — affects
+     native form controls, scrollbars on macOS, and image rendering. */
+  color-scheme: dark;
+}
+
+:root[data-theme="light"] {
+  /* Light palette — high contrast on a near-white background, same
+     accent blue so brand recognition holds. Borders are slightly
+     darker than pure greys so cards still read as raised surfaces. */
+  --background:        #f7f8fa;
+  --background-raised: #ffffff;
+  --background-hover:  #eef1f5;
+  --foreground:        #0f172a;
+  --foreground-soft:   #334155;
+  --muted:             #64748b;
+  --muted-soft:        #94a3b8;
+  --border:            #e2e8f0;
+  --border-strong:     #cbd5e1;
+  --border-glow:       rgba(37, 99, 235, 0.18);
+  --accent:            #2563eb;
+  --accent-glow:       rgba(37, 99, 235, 0.10);
+  --header-bg:         rgba(255, 255, 255, 0.75);
+  --wash-blue:         rgba(37, 99, 235, 0.05);
+  --wash-violet:       rgba(139, 92, 246, 0.04);
+  --wordmark-from:     #0f172a;
+  --wordmark-to:       #475569;
+  color-scheme: light;
 }
 
 html,
@@ -34,9 +75,11 @@ body {
   color: var(--foreground);
   /* Subtle radial wash from top — gives the page depth without noise. */
   background-image:
-    radial-gradient(ellipse 800px 600px at 50% -200px, rgba(96, 165, 250, 0.06), transparent 60%),
-    radial-gradient(ellipse 600px 500px at 90% 20%, rgba(167, 139, 250, 0.04), transparent 60%);
+    radial-gradient(ellipse 800px 600px at 50% -200px, var(--wash-blue), transparent 60%),
+    radial-gradient(ellipse 600px 500px at 90% 20%, var(--wash-violet), transparent 60%);
   background-attachment: fixed;
+  /* Smooth the visual transition when the user flips themes. */
+  transition: background-color 200ms ease, color 200ms ease;
 }
 
 body {
@@ -240,15 +283,16 @@ textarea.form-input {
   position: sticky;
   top: 0;
   z-index: 50;
-  background: rgba(7, 9, 12, 0.7);
+  background: var(--header-bg);
   backdrop-filter: saturate(180%) blur(8px);
   -webkit-backdrop-filter: saturate(180%) blur(8px);
   border-bottom: 1px solid var(--border);
 }
 
-/* Subtle text gradient for the wordmark */
+/* Subtle text gradient for the wordmark — light/dark palette swaps
+   the two stops via --wordmark-from / --wordmark-to. */
 .wordmark {
-  background: linear-gradient(135deg, #e7eaee 0%, #94a3b8 100%);
+  background: linear-gradient(135deg, var(--wordmark-from) 0%, var(--wordmark-to) 100%);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -4,6 +4,14 @@ import Link from 'next/link';
 import Logo from '@/components/Logo';
 import ViolationsNavLink from '@/components/ViolationsNavLink';
 import NavLink from '@/components/NavLink';
+import ThemeToggle from '@/components/ThemeToggle';
+
+// Pre-hydration script — sets data-theme on <html> BEFORE React
+// hydrates so light-mode users don't see a dark flash on first paint.
+// Resolution: localStorage > prefers-color-scheme > default 'dark'.
+// Wrapped in a try/catch so a Safari-private-mode localStorage
+// throw doesn't blank the page.
+const THEME_INIT_SCRIPT = `(function(){try{var s=localStorage.getItem('lumin.theme');var p=window.matchMedia('(prefers-color-scheme: light)').matches;var t=s||(p?'light':'dark');if(t==='light'){document.documentElement.setAttribute('data-theme','light');}}catch(e){}})();`;
 
 export const metadata: Metadata = {
   title: {
@@ -34,7 +42,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Inline theme bootstrap — must run before <body> renders to
+            avoid a dark→light flash on first paint. dangerouslySetInnerHTML
+            is the documented Next.js pattern for this; the script string
+            is a constant, no user input goes through it. */}
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
+      </head>
       <body>
         <div className="min-h-screen flex flex-col">
           <header className="app-header px-6 py-3 flex items-center justify-between gap-4">
@@ -74,6 +89,7 @@ export default function RootLayout({
               >
                 GitHub
               </a>
+              <ThemeToggle />
               <span
                 className="ml-1 font-mono text-[10px] uppercase tracking-wider px-1.5 py-0.5 border border-[var(--border)] rounded text-[var(--muted)]"
                 title={`Lumin ${VERSION}`}

--- a/packages/dashboard/components/ThemeToggle.tsx
+++ b/packages/dashboard/components/ThemeToggle.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Header theme toggle.
+ *
+ * Resolution priority on first render:
+ *   1. data-theme attribute on <html> (set by the inline script in
+ *      layout.tsx before React hydrates — avoids FOUC)
+ *   2. localStorage 'lumin.theme'
+ *   3. prefers-color-scheme media query
+ *   4. Default: dark
+ *
+ * The inline script in layout.tsx covers cases 1-3 server-side
+ * already; this component just mirrors the current value into React
+ * state and lets the user flip it. Click writes to localStorage AND
+ * mirrors via data-theme so future page loads (and other tabs, on
+ * the next render) pick up the change.
+ *
+ * The icon shows the *target* state (sun = "click to go to light",
+ * moon = "click to go to dark") — most apps converge on this so
+ * users don't have to guess what the current state is.
+ */
+type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'lumin.theme';
+
+
+function readCurrentTheme(): Theme {
+  if (typeof document === 'undefined') return 'dark';
+  return document.documentElement.getAttribute('data-theme') === 'light'
+    ? 'light'
+    : 'dark';
+}
+
+
+export default function ThemeToggle() {
+  // Start with `null` to avoid a hydration mismatch — the server
+  // doesn't know the user's theme. After mount we sync from the
+  // already-applied DOM attribute.
+  const [theme, setTheme] = useState<Theme | null>(null);
+
+  useEffect(() => {
+    setTheme(readCurrentTheme());
+  }, []);
+
+  const toggle = () => {
+    const next: Theme = theme === 'light' ? 'dark' : 'light';
+    setTheme(next);
+    document.documentElement.setAttribute('data-theme', next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      /* Safari private mode etc. — non-critical */
+    }
+  };
+
+  // Until the effect runs, render a placeholder of identical size to
+  // avoid layout shift. aria-hidden so screen readers don't announce
+  // "button button" if React hydrates the real one immediately after.
+  if (theme === null) {
+    return (
+      <span
+        aria-hidden
+        className="inline-block px-2 py-1"
+        style={{ width: 28, height: 28 }}
+      />
+    );
+  }
+
+  const isDark = theme === 'dark';
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      title={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      className="px-2 py-1 rounded text-[var(--muted)] hover:text-[var(--foreground)] hover:bg-[var(--background-hover)] transition-colors"
+    >
+      {isDark ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+}
+
+
+/**
+ * Inline SVGs — keeps the dashboard free of an icon library dep
+ * (lucide-react isn't installed; see issue #27 for the broader icon
+ * conversation). 14×14 to match the header text size.
+ */
+function SunIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
+  );
+}
+
+
+function MoonIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a sun/moon toggle in the header next to the GitHub link. Persists the user's choice and respects `prefers-color-scheme` on first visit.

## How it works

- **`:root[data-theme=\"light\"]`** in `globals.css` overrides the dark CSS variables. Every component already reads its colors from those variables (`--background`, `--foreground`, `--muted`, etc.), so the swap is one attribute flip. A few hardcoded values in `.app-header` and `.wordmark` were factored into new vars (`--header-bg`, `--wordmark-from/-to`, `--wash-blue/-violet`) so themes don't need component-level changes.
- **Pre-hydration `<head>` script** sets `data-theme` before React mounts. Without it, light-mode users would see a dark flash on first paint. The script is a small inline IIFE — wrapped in try/catch for Safari private mode.
- **`ThemeToggle.tsx`** mirrors the DOM attribute into React state on mount, flips on click, persists to `localStorage['lumin.theme']`. Inline SVG icons (no `lucide-react` dep — defer to issue #27 for the broader icon conversation).
- **`color-scheme`** declared per theme so native scrollbars + form controls match.
- **`200ms ease`** transition on background + color — visible but not jarring.

## Resolution priority on first paint

1. `localStorage['lumin.theme']`
2. `prefers-color-scheme: light` media query
3. Default: dark

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean — 14 routes built, no new errors
- [x] Bootstrap script renders in served HTML (`grep data-theme | lumin.theme | prefers-color-scheme` all hit)
- [x] User confirmed visually that both themes look correct
- [ ] CI on this PR