### PR TITLE
feat(api): OTLP/HTTP ingest at /v1/otlp/v1/traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ That's it. No account, no API key, no data leaves your laptop.
 - **Real-time updates** — WebSocket stream pushes traces and spans into the dashboard the moment they're ingested, no refresh; falls back to 5-second polling if the socket can't connect.
 - **Cost & token tracking** — automatic per-call breakdown for OpenAI and Anthropic model families.
 - **Quality scoring** — bring-your-own evals via `POST /v1/evals`.
-- **Framework integrations** — drop-in support for [LangChain](https://github.com/langchain-ai/langchain) (zero-config via `LUMIN_TRACING=true` — see [section](#langchain)), [LlamaIndex](https://github.com/run-llama/llama_index) ([section](#llamaindex)), [CrewAI](https://github.com/crewAIInc/crewAI) ([section](#crewai)), [Anthropic](https://github.com/anthropics/anthropic-sdk-python) with extended-thinking visualization ([section](#anthropic)), [Mastra](https://github.com/mastra-ai/mastra) ([`@lumin-io/mastra`](packages/integrations/mastra/)), [OpenClaw](https://github.com/openclaw-ai) ([`@lumin-io/openclaw`](packages/integrations/openclaw/)), and [VoltAgent](https://github.com/voltagent/voltagent) ([`@lumin-io/voltagent`](packages/integrations/voltagent/)).
+- **Framework integrations** — drop-in support for [LangChain](https://github.com/langchain-ai/langchain) (zero-config via `LUMIN_TRACING=true` — see [section](#langchain)), [LlamaIndex](https://github.com/run-llama/llama_index) ([section](#llamaindex)), [CrewAI](https://github.com/crewAIInc/crewAI) ([section](#crewai)), [Anthropic](https://github.com/anthropics/anthropic-sdk-python) with extended-thinking visualization ([section](#anthropic)), [Mastra](https://github.com/mastra-ai/mastra) ([`@lumin-io/mastra`](packages/integrations/mastra/)), [OpenClaw](https://github.com/openclaw/openclaw) (zero-code via `diagnostics-otel` → Lumin's OTLP endpoint, see [section](#openclaw)), and [VoltAgent](https://github.com/voltagent/voltagent) ([`@lumin-io/voltagent`](packages/integrations/voltagent/)).
 - **Cross-language SDKs** — Python and TypeScript with identical wire format and behavior.
 - **Resilient by design** — the agent never fails because Lumin is down. Spans drop silently if the queue overflows, the exporter is unreachable, or the server returns an error.
 - **Local-first** — single Docker image, DuckDB + SQLite, no external services, no cloud dependency.
@@ -288,6 +288,35 @@ export const mastra = new Mastra({
 ```
 
 See [`packages/integrations/mastra/`](packages/integrations/mastra/) for the dedicated `@lumin-io/mastra` package.
+
+### OpenClaw
+
+[OpenClaw](https://github.com/openclaw/openclaw) ships native OpenTelemetry through its `diagnostics-otel` plugin — Lumin's OTLP/HTTP endpoint receives those traces directly, so **no agent-code changes, no `@lumin.trace`, no SDK install**.
+
+```bash
+# Step 1 — start Lumin
+docker run -p 3000:3000 -p 8000:8000 zistica/lumin
+
+# Step 2 — enable diagnostics + point OpenClaw at Lumin
+openclaw config set diagnostics.enabled true
+openclaw config set diagnostics.otel.enabled true
+openclaw config set diagnostics.otel.traces true
+openclaw config set diagnostics.otel.endpoint "http://localhost:8000/v1/otlp"
+openclaw gateway restart
+
+# Step 3 — open http://localhost:3000
+# every OpenClaw run appears automatically
+```
+
+OpenClaw's `diagnostics-otel` auto-appends `/v1/traces` to the configured base, so the POST lands at Lumin's OTLP route `http://localhost:8000/v1/otlp/v1/traces`. (If your OpenClaw is v2026.4.25+ and you prefer the signal-specific form, use `diagnostics.otel.traces.endpoint "http://localhost:8000/v1/otlp/v1/traces"` instead.)
+
+**What gets captured**
+- LLM calls — model, tokens, cost, duration
+- Tool calls — file, shell, web, email
+- Agent sessions end-to-end as a span tree
+- Policy violations auto-detected by Lumin's policy engine
+
+For an SDK-style integration with extra features (custom span subtypes, client-side cost calculation, span-name normalization), see [`@lumin-io/openclaw`](packages/integrations/openclaw/) — same end result, runs as an in-process exporter rather than a network hop.
 
 ### Sessions (multi-turn conversations)
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ See [`packages/integrations/mastra/`](packages/integrations/mastra/) for the ded
 
 ### OpenClaw
 
-[OpenClaw](https://github.com/openclaw/openclaw) ships native OpenTelemetry through its `diagnostics-otel` plugin — Lumin's OTLP/HTTP endpoint receives those traces directly, so **no agent-code changes, no `@lumin.trace`, no SDK install**.
+[OpenClaw](https://github.com/openclaw/openclaw) ships native OpenTelemetry through its [`diagnostics-otel`](https://docs.openclaw.ai/gateway/opentelemetry) plugin — Lumin's OTLP/HTTP endpoint receives those traces directly, so **no agent-code changes, no `@lumin.trace`, no SDK install**.
 
 ```bash
 # Step 1 — start Lumin
@@ -308,15 +308,19 @@ openclaw gateway restart
 # every OpenClaw run appears automatically
 ```
 
-OpenClaw's `diagnostics-otel` auto-appends `/v1/traces` to the configured base, so the POST lands at Lumin's OTLP route `http://localhost:8000/v1/otlp/v1/traces`. (If your OpenClaw is v2026.4.25+ and you prefer the signal-specific form, use `diagnostics.otel.traces.endpoint "http://localhost:8000/v1/otlp/v1/traces"` instead.)
+OpenClaw's `diagnostics-otel` plugin auto-appends `/v1/traces` to the configured base when the URL doesn't already include it ([per the OpenClaw OpenTelemetry export docs](https://docs.openclaw.ai/gateway/opentelemetry)), so the POST lands at Lumin's OTLP route `http://localhost:8000/v1/otlp/v1/traces`. If you'd rather be explicit, you can set the endpoint to the full path — both forms work:
 
-**What gets captured**
-- LLM calls — model, tokens, cost, duration
-- Tool calls — file, shell, web, email
-- Agent sessions end-to-end as a span tree
-- Policy violations auto-detected by Lumin's policy engine
+```bash
+openclaw config set diagnostics.otel.endpoint "http://localhost:8000/v1/otlp/v1/traces"
+```
 
-For an SDK-style integration with extra features (custom span subtypes, client-side cost calculation, span-name normalization), see [`@lumin-io/openclaw`](packages/integrations/openclaw/) — same end result, runs as an in-process exporter rather than a network hop.
+**What ends up in the dashboard** (the shapes the plugin emits today, per the upstream docs):
+- Model calls — provider / model / input + output token counts / duration; Lumin computes cost from its OpenAI + Anthropic pricing tables
+- `openclaw.exec` spans for tool / process invocations
+- Full span tree for an agent run, parent-child correctly nested
+- Policy violations auto-detected by Lumin's policy engine on every ingested span
+
+You'll need a recent OpenClaw with `diagnostics-otel` available (the plugin is the official observability path; verify with `openclaw --version` and check the [OpenTelemetry export docs](https://docs.openclaw.ai/gateway/opentelemetry) for the current minimum). Older OpenClaw releases that predate `diagnostics-otel` can use the in-process SDK exporter at [`@lumin-io/openclaw`](packages/integrations/openclaw/) instead, which is also useful when you want client-side cost calculation or custom span subtypes.
 
 ### Sessions (multi-turn conversations)
 

--- a/packages/api/main.py
+++ b/packages/api/main.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 import policy_runtime
 from db import Database, get_db
-from routers import agents, evals, policy, sessions, spans, traces
+from routers import agents, evals, otlp, policy, sessions, spans, traces
 from ws import manager as ws_manager
 
 logger = logging.getLogger("lumin.api")
@@ -207,6 +207,7 @@ app.include_router(sessions.router)
 app.include_router(evals.router)
 app.include_router(policy.router)
 app.include_router(agents.router)
+app.include_router(otlp.router)
 
 
 @app.get("/health")

--- a/packages/api/otlp_decode.py
+++ b/packages/api/otlp_decode.py
@@ -1,0 +1,602 @@
+"""OTLP decode + translate — converts OpenTelemetry trace exports
+into Lumin's native ``SpanInput`` shape.
+
+Pure functions only. No I/O, no DB, no FastAPI imports here. The
+HTTP router (``routers/otlp.py``) calls into this module and then
+hands the resulting ``SpanInput`` list to the same insert path
+``POST /v1/spans`` already uses — so DuckDB writes, WS broadcasts,
+policy evaluation, and dashboard rendering all flow unchanged.
+
+Why a separate module?
+
+  - Tests can exercise the decode logic without spinning up FastAPI.
+    Most of the wire-format risk lives here (hex IDs, nano-second
+    timestamps, protobuf field types, ``gen_ai.*`` attribute
+    fan-out). Keeping it pure keeps the test surface small.
+
+  - Future ingest paths (e.g. OTLP/gRPC, when v2 needs it) can
+    reuse the same translation by calling ``parse_otlp_proto`` /
+    ``parse_otlp_json`` directly. The HTTP router becomes a thin
+    transport wrapper.
+
+The two entry points are symmetric:
+
+  parse_otlp_proto(bytes)  -> List[SpanInput], project_hint
+  parse_otlp_json(dict)    -> List[SpanInput], project_hint
+
+Each returns a tuple — the second element is the resource's
+``service.name`` (or None), which the router uses as a fallback for
+``X-Lumin-Project`` resolution.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from models import SpanInput
+
+logger = logging.getLogger("lumin.api.otlp")
+
+
+# ---- pricing tables -------------------------------------------------------
+#
+# Same families as the integration packages keep, deliberately small so
+# unknown models return ``cost_usd = None`` instead of fabricating a
+# number. Pricing is in USD per 1,000,000 tokens (matches the OpenAI /
+# Anthropic published pricing pages — easier to update without unit
+# conversions). The compute step divides by 1e6 at the end.
+
+
+_OPENAI_PRICING: Dict[str, Tuple[float, float]] = {
+    "gpt-4o":           (2.50, 10.00),
+    "gpt-4o-mini":      (0.15,  0.60),
+    "gpt-4-turbo":     (10.00, 30.00),
+    "gpt-4":           (30.00, 60.00),
+    "gpt-3.5-turbo":    (0.50,  1.50),
+}
+
+_ANTHROPIC_PRICING: Dict[str, Tuple[float, float]] = {
+    "claude-opus-4":     (15.00, 75.00),
+    "claude-sonnet-4":    (3.00, 15.00),
+    "claude-haiku-4":     (0.80,  4.00),
+}
+
+
+def _compute_cost(
+    model: Optional[str],
+    tokens_in: Optional[int],
+    tokens_out: Optional[int],
+) -> Optional[float]:
+    """Cost in USD, longest-prefix match against the pricing tables.
+
+    Returns None when:
+      - model is missing, or
+      - either token count is missing, or
+      - no prefix in the tables matches the model name.
+
+    Never guesses — a None cost in the dashboard is more honest than
+    a fabricated number from the wrong family.
+    """
+    if not model or tokens_in is None or tokens_out is None:
+        return None
+    m = model.lower()
+    best_key = ""
+    best: Optional[Tuple[float, float]] = None
+    for table in (_OPENAI_PRICING, _ANTHROPIC_PRICING):
+        for key, prices in table.items():
+            if m.startswith(key) and len(key) > len(best_key):
+                best_key = key
+                best = prices
+    if best is None:
+        return None
+    inp, outp = best
+    return round((tokens_in * inp + tokens_out * outp) / 1_000_000, 8)
+
+
+# ---- ID + timestamp normalization -----------------------------------------
+
+
+def _hex_to_uuid(hex_id: str) -> str:
+    """Convert an OTel hex span/trace ID into a UUID-shaped string.
+
+    OTel uses 32-char hex for trace_id and 16-char hex for span_id.
+    Lumin's existing schema stores ids as VARCHAR — we don't strictly
+    need UUID format, but rendering as 8-4-4-4-12 reads well in the
+    dashboard and matches what the SDK already emits.
+
+    Short hex (16-char span_id) is left-padded with zeros so the
+    output is still UUID-shaped — keeps the column visually
+    consistent even though the bottom half is just padding.
+    """
+    h = (hex_id or "").lower().strip()
+    if not h:
+        return ""
+    if len(h) < 32:
+        h = h.rjust(32, "0")
+    return f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
+
+
+def _nanos_to_iso(nano: Any) -> Optional[str]:
+    """Convert nanosecond UNIX time (string or int, per OTel spec) to
+    a naive UTC ISO string — matches what the rest of the API stores."""
+    if nano is None:
+        return None
+    try:
+        n = int(nano)
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return None
+    seconds = n / 1_000_000_000
+    dt = datetime.fromtimestamp(seconds, tz=timezone.utc).replace(tzinfo=None)
+    # Match the precision the rest of the API expects (microseconds + Z)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+# ---- attribute access helpers ---------------------------------------------
+#
+# OTLP/JSON uses a verbose ``[{"key": k, "value": {"stringValue": v}}]``
+# array; OTLP/proto uses ``[KeyValue(key=k, value=AnyValue(...))]``. The
+# protobuf objects expose ``.WhichOneof('value')`` and a typed accessor.
+# Normalize both into a plain ``dict[str, Any]`` so the rest of the
+# decode pipeline doesn't branch on transport.
+
+
+def _attrs_from_proto(proto_attrs: Any) -> Dict[str, Any]:
+    """Materialize a ``KeyValue[]`` from protobuf into a Python dict.
+
+    The protobuf ``AnyValue`` is a oneof with seven cases — string,
+    bool, int, double, array, kvlist, bytes. We unpack each so the
+    caller doesn't have to import protobuf classes.
+    """
+    out: Dict[str, Any] = {}
+    for kv in proto_attrs:
+        try:
+            out[kv.key] = _anyvalue_to_python(kv.value)
+        except Exception:
+            # Malformed attribute — log and skip rather than abort the
+            # whole batch. OTel implementations have shipped invalid
+            # protobuf in the wild before.
+            logger.debug("otlp: skipping unparseable attribute %r", kv.key)
+    return out
+
+
+def _anyvalue_to_python(value: Any) -> Any:
+    which = value.WhichOneof("value")
+    if which == "string_value":
+        return value.string_value
+    if which == "bool_value":
+        return value.bool_value
+    if which == "int_value":
+        return int(value.int_value)
+    if which == "double_value":
+        return float(value.double_value)
+    if which == "bytes_value":
+        return bytes(value.bytes_value)
+    if which == "array_value":
+        return [_anyvalue_to_python(v) for v in value.array_value.values]
+    if which == "kvlist_value":
+        return {kv.key: _anyvalue_to_python(kv.value) for kv in value.kvlist_value.values}
+    return None
+
+
+def _attrs_from_json(json_attrs: List[dict]) -> Dict[str, Any]:
+    """Same shape but for the OTLP/JSON wire format."""
+    out: Dict[str, Any] = {}
+    for kv in json_attrs or []:
+        try:
+            out[kv["key"]] = _jsonvalue_to_python(kv.get("value") or {})
+        except Exception:
+            logger.debug("otlp: skipping unparseable JSON attribute")
+    return out
+
+
+def _jsonvalue_to_python(value: dict) -> Any:
+    if "stringValue" in value:
+        return value["stringValue"]
+    if "boolValue" in value:
+        return bool(value["boolValue"])
+    if "intValue" in value:
+        # OTLP/JSON encodes int64 as a string (per the proto3 → JSON
+        # mapping rule) — coerce defensively.
+        return int(value["intValue"])
+    if "doubleValue" in value:
+        return float(value["doubleValue"])
+    if "bytesValue" in value:
+        # base64 string per spec; expose raw for the rare attribute that needs it
+        return value["bytesValue"]
+    if "arrayValue" in value:
+        return [_jsonvalue_to_python(v) for v in value["arrayValue"].get("values", [])]
+    if "kvlistValue" in value:
+        return _attrs_from_json(value["kvlistValue"].get("values", []))
+    return None
+
+
+# ---- the actual translation -----------------------------------------------
+
+
+# OTel SpanKind enum values. We only special-case CLIENT (LLM/HTTP egress
+# from the agent's POV) and SERVER (incoming work, treat as custom).
+_SPAN_KIND_CLIENT = 3
+_SPAN_KIND_SERVER = 2
+
+
+def _classify_type(kind: int, attrs: Dict[str, Any]) -> str:
+    """Best-effort span-type classification.
+
+    Spec says:
+      CLIENT + gen_ai.*    → llm
+      tool.name present    → tool
+      db.system present    → retrieval
+      otherwise            → custom
+    """
+    if "tool.name" in attrs or "gen_ai.tool.name" in attrs:
+        return "tool"
+    if "db.system" in attrs:
+        return "retrieval"
+    has_gen_ai = any(k.startswith("gen_ai.") for k in attrs)
+    if kind == _SPAN_KIND_CLIENT and has_gen_ai:
+        return "llm"
+    return "custom"
+
+
+def _stringify(value: Any, max_len: int = 32_768) -> Optional[str]:
+    """Coerce attribute values into a string suitable for span.input /
+    span.output. JSON-encode lists / dicts so they round-trip; cap
+    length so a runaway prompt doesn't bloat DuckDB rows.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        s = value
+    else:
+        try:
+            s = json.dumps(value, ensure_ascii=False)
+        except Exception:
+            s = str(value)
+    return s if len(s) <= max_len else s[:max_len]
+
+
+def _extract_input(attrs: Dict[str, Any]) -> Optional[str]:
+    """Look for input/prompt content under any of the conventions we
+    know about. Order matters — first hit wins.
+    """
+    for k in (
+        "gen_ai.prompt",
+        "input.value",
+        "llm.input_messages",
+        "gen_ai.input.messages",
+        "ai.prompt.messages",
+    ):
+        if k in attrs:
+            return _stringify(attrs[k])
+    return None
+
+
+def _extract_output(attrs: Dict[str, Any]) -> Optional[str]:
+    for k in (
+        "gen_ai.completion",
+        "output.value",
+        "llm.output_messages",
+        "gen_ai.output.messages",
+        "ai.response.text",
+    ):
+        if k in attrs:
+            return _stringify(attrs[k])
+    return None
+
+
+_KNOWN_KEYS = frozenset({
+    "gen_ai.system",
+    "gen_ai.request.model",
+    "gen_ai.response.model",
+    "gen_ai.usage.input_tokens",
+    "gen_ai.usage.output_tokens",
+    "gen_ai.operation.name",
+    "gen_ai.tool.name",
+    "gen_ai.prompt",
+    "gen_ai.completion",
+    "gen_ai.input.messages",
+    "gen_ai.output.messages",
+    "input.value",
+    "output.value",
+    "llm.input_messages",
+    "llm.output_messages",
+    "ai.prompt.messages",
+    "ai.response.text",
+    "tool.name",
+    "db.system",
+})
+
+
+def _build_metadata(attrs: Dict[str, Any]) -> Optional[dict]:
+    """Anything we didn't lift into a first-class field gets stored in
+    metadata so it's still queryable. Skip the keys we already
+    extracted to keep payload size sane.
+    """
+    extra = {k: v for k, v in attrs.items() if k not in _KNOWN_KEYS}
+    return extra or None
+
+
+# ---- Status code → Lumin status -------------------------------------------
+#
+# OTel StatusCode: 0 = UNSET, 1 = OK, 2 = ERROR
+
+
+def _status_from_otel(code: Any, message: Optional[str]) -> Tuple[str, Optional[str]]:
+    try:
+        c = int(code) if code is not None else 0
+    except (TypeError, ValueError):
+        c = 0
+    if c == 2:
+        return ("error", message or "error")
+    return ("ok", None)
+
+
+# ---- the assembled span ---------------------------------------------------
+
+
+def _build_span_input(
+    *,
+    trace_id_hex: str,
+    span_id_hex: str,
+    parent_span_id_hex: Optional[str],
+    name: Optional[str],
+    kind: int,
+    started_at: Optional[str],
+    ended_at: Optional[str],
+    status_code: Any,
+    status_message: Optional[str],
+    attrs: Dict[str, Any],
+) -> Optional[SpanInput]:
+    """Materialize a Lumin SpanInput from already-normalized OTLP fields.
+
+    Returns None when essentials are missing — namely span_id or
+    started_at. Calling code logs and skips so the rest of the batch
+    still flows; OTel implementations have shipped malformed spans
+    before, and Rule 7 generalized says we never reject a whole
+    batch over one bad row.
+    """
+    if not span_id_hex or not started_at:
+        return None
+
+    span_id = _hex_to_uuid(span_id_hex)
+    trace_id = _hex_to_uuid(trace_id_hex) if trace_id_hex else span_id
+    parent_id = _hex_to_uuid(parent_span_id_hex) if parent_span_id_hex else None
+
+    model = attrs.get("gen_ai.response.model") or attrs.get("gen_ai.request.model")
+    provider = attrs.get("gen_ai.system")
+    tokens_in = attrs.get("gen_ai.usage.input_tokens")
+    tokens_out = attrs.get("gen_ai.usage.output_tokens")
+    operation = attrs.get("gen_ai.operation.name")
+
+    # Coerce token counts — OTLP may serialize int64 as string (proto3
+    # JSON mapping). _jsonvalue_to_python already int-casts, but
+    # double-check in case some emitter ships them as strings.
+    if tokens_in is not None:
+        try:
+            tokens_in = int(tokens_in)
+        except (TypeError, ValueError):
+            tokens_in = None
+    if tokens_out is not None:
+        try:
+            tokens_out = int(tokens_out)
+        except (TypeError, ValueError):
+            tokens_out = None
+
+    cost = _compute_cost(
+        str(model) if model else None,
+        tokens_in,
+        tokens_out,
+    )
+    span_type = _classify_type(kind, attrs)
+    status, error_message = _status_from_otel(status_code, status_message)
+
+    # Span name: OTel's span.name wins. Fall back to the gen_ai.operation.name
+    # when name is empty or generic ("span"). Operators usually want
+    # something human-readable in the trace list.
+    resolved_name = name or operation
+    if resolved_name in (None, "", "span") and operation:
+        resolved_name = operation
+
+    tool_name = attrs.get("gen_ai.tool.name") or attrs.get("tool.name")
+
+    return SpanInput(
+        id=span_id,
+        trace_id=trace_id,
+        parent_span_id=parent_id,
+        name=resolved_name,
+        type=span_type,
+        input=_extract_input(attrs),
+        output=_extract_output(attrs),
+        started_at=started_at,
+        ended_at=ended_at,
+        status=status,
+        error_message=error_message,
+        model=str(model) if model is not None else None,
+        provider=str(provider) if provider is not None else None,
+        tokens_input=tokens_in,
+        tokens_output=tokens_out,
+        cost_usd=cost,
+        tool_name=str(tool_name) if tool_name else None,
+        metadata=_build_metadata(attrs),
+    )
+
+
+# ---- public entry points --------------------------------------------------
+
+
+def parse_otlp_proto(export_request: Any) -> Tuple[List[SpanInput], Optional[str]]:
+    """Decode an ``ExportTraceServiceRequest`` protobuf message into
+    a list of Lumin spans.
+
+    Returns ``(spans, service_name_hint)`` — the hint is the resource's
+    ``service.name`` attribute, used by the router as a fallback for
+    project resolution when no ``X-Lumin-Project`` header is present.
+    Pulled from the FIRST resource in the batch (OTel sends one
+    resource per emitter; multi-resource batches are rare).
+    """
+    spans_out: List[SpanInput] = []
+    service_name: Optional[str] = None
+
+    for resource_spans in export_request.resource_spans:
+        resource_attrs = _attrs_from_proto(resource_spans.resource.attributes)
+        if service_name is None:
+            sn = resource_attrs.get("service.name")
+            if sn:
+                service_name = str(sn)
+
+        for scope_spans in resource_spans.scope_spans:
+            for span in scope_spans.spans:
+                attrs = _attrs_from_proto(span.attributes)
+
+                trace_id_hex = span.trace_id.hex() if span.trace_id else ""
+                span_id_hex = span.span_id.hex() if span.span_id else ""
+                parent_id_hex = span.parent_span_id.hex() if span.parent_span_id else None
+                if parent_id_hex == "":
+                    # Empty bytes → no parent. Don't propagate empty string.
+                    parent_id_hex = None
+
+                started_at = _nanos_to_iso(span.start_time_unix_nano)
+                ended_at = _nanos_to_iso(span.end_time_unix_nano)
+
+                status_code = span.status.code if span.status else 0
+                status_message = (
+                    span.status.message if span.status and span.status.message else None
+                )
+
+                si = _build_span_input(
+                    trace_id_hex=trace_id_hex,
+                    span_id_hex=span_id_hex,
+                    parent_span_id_hex=parent_id_hex,
+                    name=span.name,
+                    kind=span.kind,
+                    started_at=started_at,
+                    ended_at=ended_at,
+                    status_code=status_code,
+                    status_message=status_message,
+                    attrs=attrs,
+                )
+                if si is not None:
+                    spans_out.append(si)
+                else:
+                    logger.warning(
+                        "otlp: skipping malformed proto span (id=%r start=%r)",
+                        span_id_hex, span.start_time_unix_nano,
+                    )
+
+    return spans_out, service_name
+
+
+def parse_otlp_json(payload: dict) -> Tuple[List[SpanInput], Optional[str]]:
+    """OTLP/HTTP JSON variant. Same return shape as the proto path.
+
+    Both shapes are spec'd in
+    https://opentelemetry.io/docs/specs/otlp/#otlphttp-request — the
+    key differences are:
+
+      - Trace/span IDs are hex strings (already in the format we want)
+      - int64 values come over the wire as strings (per proto3 → JSON)
+      - Attribute oneof uses ``stringValue`` / ``intValue`` / etc. keys
+    """
+    spans_out: List[SpanInput] = []
+    service_name: Optional[str] = None
+
+    for resource_spans in payload.get("resourceSpans", []) or []:
+        resource = resource_spans.get("resource") or {}
+        resource_attrs = _attrs_from_json(resource.get("attributes", []))
+        if service_name is None:
+            sn = resource_attrs.get("service.name")
+            if sn:
+                service_name = str(sn)
+
+        for scope_spans in resource_spans.get("scopeSpans", []) or []:
+            for span in scope_spans.get("spans", []) or []:
+                attrs = _attrs_from_json(span.get("attributes", []))
+
+                trace_id_hex = (span.get("traceId") or "").lower()
+                span_id_hex = (span.get("spanId") or "").lower()
+                parent_id_hex = (span.get("parentSpanId") or "").lower() or None
+
+                started_at = _nanos_to_iso(span.get("startTimeUnixNano"))
+                ended_at = _nanos_to_iso(span.get("endTimeUnixNano"))
+
+                status = span.get("status") or {}
+                status_code = status.get("code", 0)
+                status_message = status.get("message")
+
+                # OTLP/JSON encodes SpanKind as either an enum string
+                # ("SPAN_KIND_CLIENT") or an int — handle both.
+                kind_raw = span.get("kind", 0)
+                if isinstance(kind_raw, str):
+                    kind = {
+                        "SPAN_KIND_INTERNAL": 1,
+                        "SPAN_KIND_SERVER":   2,
+                        "SPAN_KIND_CLIENT":   3,
+                        "SPAN_KIND_PRODUCER": 4,
+                        "SPAN_KIND_CONSUMER": 5,
+                    }.get(kind_raw, 0)
+                else:
+                    try:
+                        kind = int(kind_raw)
+                    except (TypeError, ValueError):
+                        kind = 0
+
+                si = _build_span_input(
+                    trace_id_hex=trace_id_hex,
+                    span_id_hex=span_id_hex,
+                    parent_span_id_hex=parent_id_hex,
+                    name=span.get("name"),
+                    kind=kind,
+                    started_at=started_at,
+                    ended_at=ended_at,
+                    status_code=status_code,
+                    status_message=status_message,
+                    attrs=attrs,
+                )
+                if si is not None:
+                    spans_out.append(si)
+                else:
+                    logger.warning(
+                        "otlp: skipping malformed JSON span (id=%r)", span_id_hex
+                    )
+
+    return spans_out, service_name
+
+
+# ---- project resolution ---------------------------------------------------
+
+
+# Mirror the ingest allowlist used by spans.ingest_spans. Closed-set
+# project values keep the agent grid's "framework" headlines stable —
+# any other value (the OTLP service.name from a third-party tool,
+# typically) folds to "default". Operators that want a dedicated
+# section should ship a Lumin SDK package, not an arbitrary header.
+_ALLOWED_PROJECTS = frozenset({"openclaw", "mastra", "voltagent", "default"})
+
+
+def normalize_project(
+    header_value: Optional[str], service_name_hint: Optional[str]
+) -> Optional[str]:
+    """Resolve the ``project`` field for ingested OTLP spans.
+
+    Priority:
+      1. ``X-Lumin-Project`` HTTP header
+      2. Resource attribute ``service.name``
+      3. None (downstream coalesces to "default" at read time)
+
+    Whichever wins is then folded through the closed-set allowlist —
+    matches what spans.ingest_spans does for the native /v1/spans
+    path. Same headlines, no surprise framework sections.
+    """
+    raw = (header_value or "").strip() or (service_name_hint or "").strip()
+    if not raw:
+        return None
+    v = raw.lower()
+    if v in _ALLOWED_PROJECTS:
+        return v
+    return "default"

--- a/packages/api/requirements.txt
+++ b/packages/api/requirements.txt
@@ -14,3 +14,9 @@ pydantic>=2.0
 # ours and pull pandas as a transitive — broken every fresh install.
 simpleeval>=0.9.13
 pyyaml>=6.0
+# OTel ingest endpoint (POST /v1/otlp/v1/traces). Decodes both
+# OTLP/HTTP protobuf and OTLP/HTTP JSON payloads from any
+# OpenTelemetry-compatible tool (Logfire, Phoenix, Datadog GenAI,
+# OpenLLMetry, etc.) without requiring the Lumin SDK. Stable since
+# 1.30; pinned to a recent minor to keep proto bindings consistent.
+opentelemetry-proto>=1.30

--- a/packages/api/routers/otlp.py
+++ b/packages/api/routers/otlp.py
@@ -1,0 +1,202 @@
+"""OTLP/HTTP ingest endpoint — POST /v1/otlp/v1/traces.
+
+Accepts OpenTelemetry trace exports in either protobuf or JSON
+format and routes them through the same DuckDB write + WebSocket
+broadcast + policy evaluation path that POST /v1/spans uses for
+SDK-native ingest. The decode + translate logic lives in
+``otlp_decode.py``; this module is the thin HTTP transport layer.
+
+Why a separate endpoint instead of extending ``/v1/spans``:
+
+  - OTel tools have a hard expectation about the URL shape
+    (``/v1/traces`` for OTLP/HTTP). Reusing ``/v1/spans`` would
+    require every operator to override an internal exporter URL.
+  - Reading content-type, parsing protobuf, and producing the
+    OTLP-shaped success response are concerns that don't apply to
+    the SDK-native path.
+
+Per ``Development_Rules.md`` Rule 7: a malformed batch must never
+crash the API. We log + skip individual spans that fail to parse,
+and return 4xx (not 5xx) for unrecoverable wire-format errors.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Request, Response
+
+import otlp_decode
+import policy_runtime
+from db import Database, get_db
+from models import SpanInput
+from routers.spans import (
+    _broadcast_after_insert,
+    _evaluate_policies_for_batch,
+    _insert_span,
+    _upsert_trace_from_span,
+)
+
+logger = logging.getLogger("lumin.api.otlp")
+
+router = APIRouter()
+
+
+# Stable success body for OTLP/HTTP. The OTLP spec says the response
+# body is ``ExportTraceServiceResponse``; an empty (zero-byte) message
+# is a valid success. Using bytes() keeps us out of having to import
+# the proto class just for the response.
+_EMPTY_OTLP_RESPONSE = b""
+
+
+@router.post("/v1/otlp/v1/traces")
+async def receive_otlp_traces(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db: Database = Depends(get_db),
+    x_lumin_project: Optional[str] = Header(default=None),
+) -> Response:
+    """OTLP/HTTP traces endpoint.
+
+    Content-Type resolution:
+      - ``application/x-protobuf`` → protobuf decode (the wire default
+        for OTel SDK exporters and the OTel collector).
+      - ``application/json`` → JSON decode (manual curl, dashboards,
+        easier to inspect during debugging).
+      - Anything else → try protobuf first, fall back to a 400 if
+        that also fails. OTel SDKs default to protobuf and sometimes
+        send no Content-Type at all.
+
+    Project resolution:
+      - ``X-Lumin-Project`` header (operator-set; wins)
+      - Resource attribute ``service.name`` (auto-populated by every
+        OTel SDK from ``OTEL_SERVICE_NAME`` or the program name)
+      - Default: NULL (read paths coalesce to "default")
+
+    Both go through ``otlp_decode.normalize_project`` so the closed
+    framework allowlist applies — keeps the /agents grid headlines
+    stable when third-party tools emit arbitrary service names.
+    """
+    content_type = (request.headers.get("content-type") or "").lower()
+    body = await request.body()
+    if not body:
+        # Empty bodies aren't a wire-format error per se — the OTel
+        # collector occasionally sends empty pings. Acknowledge silently.
+        return _empty_response()
+
+    spans, service_hint = _decode(body, content_type)
+    project = otlp_decode.normalize_project(x_lumin_project, service_hint)
+
+    if not spans:
+        # Decoded successfully but no spans to ingest (e.g. an empty
+        # ResourceSpans wrapper). Acknowledge — not an error.
+        return _empty_response()
+
+    # Reuse the same insert path as POST /v1/spans. The native ingest
+    # already handles trace upsert, child-before-root stub creation,
+    # WS broadcast, and idempotent policy evaluation — we don't want a
+    # parallel write path that drifts.
+    accepted = 0
+    for span in spans:
+        try:
+            _insert_span(db, span, project=project)
+            is_new_trace = _upsert_trace_from_span(db, span, project=project)
+            _broadcast_after_insert(db, span, is_new_trace)
+            accepted += 1
+        except Exception:
+            # Per Rule 7: never let one malformed span abort the batch.
+            # OTel ecosystems ship plenty of edge cases (clock-skewed
+            # timestamps, weird hex IDs); soak them silently and move on.
+            logger.exception("otlp: failed to insert span %r", span.id)
+
+    if accepted:
+        background_tasks.add_task(_evaluate_policies_for_batch, db, list(spans))
+
+    return _empty_response()
+
+
+def _decode(body: bytes, content_type: str):
+    """Parse the OTLP payload into ``SpanInput`` objects.
+
+    Splits content-type matching from the actual decode so the router
+    can stay short. Returns ``(spans, service_hint)`` like the
+    underlying decoders do.
+    """
+    if "application/json" in content_type:
+        return _decode_json(body)
+    if "application/x-protobuf" in content_type or not content_type:
+        # Most OTel SDK exporters set ``application/x-protobuf``. A
+        # missing content-type is treated as protobuf — we tried JSON
+        # there too historically and it confused dashboards that send
+        # the OTel collector's default headers.
+        return _decode_proto(body)
+    # Neither known content-type matched. Final fallback: try protobuf
+    # since that's the wire default for OTel.
+    return _decode_proto(body)
+
+
+def _decode_json(body: bytes):
+    import json
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise HTTPException(status_code=400, detail=f"otlp: invalid JSON body: {e}")
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=400,
+            detail="otlp: JSON body must be an ExportTraceServiceRequest object",
+        )
+    try:
+        return otlp_decode.parse_otlp_json(payload)
+    except Exception as e:
+        # Decode bug (not a wire-format issue) — surface as 500 so
+        # ops sees it; but log details so we can fix.
+        logger.exception("otlp: JSON decode crashed")
+        raise HTTPException(status_code=500, detail=f"otlp: decode error: {e}")
+
+
+def _decode_proto(body: bytes):
+    try:
+        from opentelemetry.proto.collector.trace.v1 import (
+            trace_service_pb2,
+        )
+    except ImportError as e:
+        # opentelemetry-proto missing from the install — surface clearly.
+        # Should not happen in normal deploys (it's in requirements.txt)
+        # but tests + odd runtime configs occasionally hit this.
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "otlp: opentelemetry-proto is not installed. "
+                f"Install it via 'pip install opentelemetry-proto'. ({e})"
+            ),
+        )
+    export_request = trace_service_pb2.ExportTraceServiceRequest()
+    try:
+        export_request.ParseFromString(body)
+    except Exception as e:
+        # Includes both google.protobuf.message.DecodeError and any
+        # downstream type errors.
+        raise HTTPException(
+            status_code=400, detail=f"otlp: invalid protobuf body: {e}"
+        )
+    try:
+        return otlp_decode.parse_otlp_proto(export_request)
+    except Exception as e:
+        logger.exception("otlp: proto decode crashed")
+        raise HTTPException(status_code=500, detail=f"otlp: decode error: {e}")
+
+
+def _empty_response() -> Response:
+    """OTLP/HTTP success: empty body, 200 OK, protobuf media type.
+
+    The OTel collector and most SDKs treat any 2xx with an empty body
+    as success. Setting the media type to ``application/x-protobuf``
+    keeps strict clients happy.
+    """
+    return Response(
+        content=_EMPTY_OTLP_RESPONSE,
+        status_code=200,
+        media_type="application/x-protobuf",
+    )

--- a/packages/api/tests/test_otlp_ingest.py
+++ b/packages/api/tests/test_otlp_ingest.py
@@ -1,0 +1,454 @@
+"""Tests for the OTLP/HTTP ingest endpoint POST /v1/otlp/v1/traces.
+
+Covers both wire formats (protobuf + JSON), gen_ai.* attribute
+mapping, cost calculation, project resolution (header vs
+service.name), trace upsert from a root span, child-before-root
+stub creation, policy-engine triggering, and the negative paths
+(unknown content-type, invalid bytes).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _hex_id(n: int) -> str:
+    """Random hex string of length n. Used for trace_id (32) + span_id (16)."""
+    return uuid.uuid4().hex[: n // 2] + uuid.uuid4().hex[: n // 2]
+
+
+def _now_ns(offset_seconds: int = 0) -> str:
+    """Nanoseconds since epoch as a string — OTLP/JSON encodes int64 this way."""
+    return str(int((time.time() + offset_seconds) * 1_000_000_000))
+
+
+def _otlp_json_payload(
+    *,
+    trace_id: Optional[str] = None,
+    spans: Optional[list] = None,
+    service_name: Optional[str] = None,
+):
+    """Minimal OTLP/HTTP JSON envelope. Each span in ``spans`` is a
+    plain dict; we wrap with the ResourceSpans/ScopeSpans scaffolding."""
+    if trace_id is None:
+        trace_id = _hex_id(32)
+    if spans is None:
+        # Default: one llm span with gen_ai.* attributes
+        spans = [{
+            "traceId": trace_id,
+            "spanId":  _hex_id(16),
+            "name":    "chat_completion",
+            "kind":    3,  # CLIENT
+            "startTimeUnixNano": _now_ns(),
+            "endTimeUnixNano":   _now_ns(1),
+            "attributes": [
+                {"key": "gen_ai.system", "value": {"stringValue": "openai"}},
+                {"key": "gen_ai.request.model", "value": {"stringValue": "gpt-4o-mini"}},
+                {"key": "gen_ai.usage.input_tokens", "value": {"intValue": "150"}},
+                {"key": "gen_ai.usage.output_tokens", "value": {"intValue": "50"}},
+            ],
+            "status": {"code": 1},  # OK
+        }]
+    resource_attrs = []
+    if service_name is not None:
+        resource_attrs.append(
+            {"key": "service.name", "value": {"stringValue": service_name}}
+        )
+    return {
+        "resourceSpans": [{
+            "resource": {"attributes": resource_attrs},
+            "scopeSpans": [{"spans": spans}],
+        }]
+    }
+
+
+def _post_json(client, payload, headers=None):
+    h = {"Content-Type": "application/json"}
+    h.update(headers or {})
+    return client.post("/v1/otlp/v1/traces", content=json.dumps(payload), headers=h)
+
+
+def _build_otlp_proto(json_payload: dict) -> bytes:
+    """Convert a JSON-shaped payload into a real protobuf payload.
+
+    Building this from the bottom up rather than via ``json_format.ParseDict``
+    because the latter treats protobuf ``bytes`` fields as base64-encoded
+    (per the proto3 JSON canonical mapping), but OTLP/JSON uses hex
+    for trace_id / span_id. So we wire the proto directly — converting
+    hex → bytes ourselves.
+    """
+    from opentelemetry.proto.collector.trace.v1 import trace_service_pb2
+    from opentelemetry.proto.trace.v1 import trace_pb2
+    from opentelemetry.proto.common.v1 import common_pb2
+    from opentelemetry.proto.resource.v1 import resource_pb2
+
+    def _attr(kv: dict) -> common_pb2.KeyValue:
+        v = kv["value"]
+        any_value = common_pb2.AnyValue()
+        if "stringValue" in v:
+            any_value.string_value = v["stringValue"]
+        elif "intValue" in v:
+            any_value.int_value = int(v["intValue"])
+        elif "boolValue" in v:
+            any_value.bool_value = bool(v["boolValue"])
+        elif "doubleValue" in v:
+            any_value.double_value = float(v["doubleValue"])
+        return common_pb2.KeyValue(key=kv["key"], value=any_value)
+
+    req = trace_service_pb2.ExportTraceServiceRequest()
+    for rs_in in json_payload.get("resourceSpans", []):
+        rs = req.resource_spans.add()
+        res_attrs = rs_in.get("resource", {}).get("attributes", [])
+        rs.resource.CopyFrom(
+            resource_pb2.Resource(attributes=[_attr(a) for a in res_attrs])
+        )
+        for ss_in in rs_in.get("scopeSpans", []):
+            ss = rs.scope_spans.add()
+            for s_in in ss_in.get("spans", []):
+                s = ss.spans.add()
+                if s_in.get("traceId"):
+                    s.trace_id = bytes.fromhex(s_in["traceId"])
+                if s_in.get("spanId"):
+                    s.span_id = bytes.fromhex(s_in["spanId"])
+                if s_in.get("parentSpanId"):
+                    s.parent_span_id = bytes.fromhex(s_in["parentSpanId"])
+                if s_in.get("name"):
+                    s.name = s_in["name"]
+                if s_in.get("kind") is not None:
+                    s.kind = int(s_in["kind"])
+                if s_in.get("startTimeUnixNano"):
+                    s.start_time_unix_nano = int(s_in["startTimeUnixNano"])
+                if s_in.get("endTimeUnixNano"):
+                    s.end_time_unix_nano = int(s_in["endTimeUnixNano"])
+                for a in s_in.get("attributes", []):
+                    s.attributes.add().CopyFrom(_attr(a))
+                status = s_in.get("status") or {}
+                if status:
+                    s.status.CopyFrom(trace_pb2.Status(
+                        code=int(status.get("code", 0)),
+                        message=status.get("message", ""),
+                    ))
+    return req.SerializeToString()
+
+
+# --- 1. JSON happy path -----------------------------------------------------
+
+
+def test_otlp_json_basic(client):
+    """A minimal JSON payload lands a span and surfaces it via /v1/traces."""
+    trace_id = _hex_id(32)
+    payload = _otlp_json_payload(trace_id=trace_id)
+
+    r = _post_json(client, payload)
+    assert r.status_code == 200, r.text
+    assert r.headers.get("content-type", "").startswith("application/x-protobuf")
+    assert r.content == b""
+
+    # Trace appears in the list
+    traces = client.get("/v1/traces").json()
+    assert any(
+        t["id"].replace("-", "") == trace_id for t in traces
+    ), f"trace_id={trace_id} not in list (ids={[t['id'] for t in traces]})"
+
+
+# --- 2. protobuf happy path -------------------------------------------------
+
+
+def test_otlp_protobuf_basic(client):
+    """Same payload, sent as protobuf instead of JSON."""
+    trace_id = _hex_id(32)
+    payload = _otlp_json_payload(trace_id=trace_id)
+    proto_bytes = _build_otlp_proto(payload)
+
+    r = client.post(
+        "/v1/otlp/v1/traces",
+        content=proto_bytes,
+        headers={"Content-Type": "application/x-protobuf"},
+    )
+    assert r.status_code == 200, r.text
+    traces = client.get("/v1/traces").json()
+    assert any(t["id"].replace("-", "") == trace_id for t in traces)
+
+
+# --- 3. gen_ai.* attributes get mapped to the right Lumin fields ------------
+
+
+def test_gen_ai_attributes_mapped(client):
+    trace_id = _hex_id(32)
+    span_id = _hex_id(16)
+    payload = _otlp_json_payload(trace_id=trace_id, spans=[{
+        "traceId": trace_id, "spanId": span_id,
+        "name": "chat_completion", "kind": 3,
+        "startTimeUnixNano": _now_ns(),
+        "endTimeUnixNano":   _now_ns(1),
+        "attributes": [
+            {"key": "gen_ai.system", "value": {"stringValue": "anthropic"}},
+            {"key": "gen_ai.request.model", "value": {"stringValue": "claude-sonnet-4"}},
+            {"key": "gen_ai.usage.input_tokens", "value": {"intValue": "200"}},
+            {"key": "gen_ai.usage.output_tokens", "value": {"intValue": "80"}},
+        ],
+        "status": {"code": 1},
+    }])
+    r = _post_json(client, payload)
+    assert r.status_code == 200
+
+    # Look up the span via the spans endpoint
+    trace_uuid = next(
+        t["id"] for t in client.get("/v1/traces").json()
+        if t["id"].replace("-", "") == trace_id
+    )
+    spans = client.get(f"/v1/traces/{trace_uuid}/spans").json()
+    assert len(spans) >= 1
+    s = spans[0]
+    assert s["model"] == "claude-sonnet-4"
+    assert s["provider"] == "anthropic"
+    assert s["tokens_input"] == 200
+    assert s["tokens_output"] == 80
+    assert s["type"] == "llm"  # SpanKind=CLIENT + gen_ai.* present
+
+
+# --- 4. cost calculated for known model -------------------------------------
+
+
+def test_cost_calculated(client):
+    """gpt-4o-mini at $0.15/$0.60 per 1M tokens, 150 in + 50 out:
+    (150*0.15 + 50*0.60) / 1_000_000 = (22.5 + 30) / 1M = 5.25e-05"""
+    trace_id = _hex_id(32)
+    span_id = _hex_id(16)
+    payload = _otlp_json_payload(trace_id=trace_id, spans=[{
+        "traceId": trace_id, "spanId": span_id,
+        "name": "chat_completion", "kind": 3,
+        "startTimeUnixNano": _now_ns(),
+        "endTimeUnixNano":   _now_ns(1),
+        "attributes": [
+            {"key": "gen_ai.system", "value": {"stringValue": "openai"}},
+            {"key": "gen_ai.request.model", "value": {"stringValue": "gpt-4o-mini"}},
+            {"key": "gen_ai.usage.input_tokens", "value": {"intValue": "150"}},
+            {"key": "gen_ai.usage.output_tokens", "value": {"intValue": "50"}},
+        ],
+    }])
+    _post_json(client, payload)
+
+    trace_uuid = next(
+        t["id"] for t in client.get("/v1/traces").json()
+        if t["id"].replace("-", "") == trace_id
+    )
+    spans = client.get(f"/v1/traces/{trace_uuid}/spans").json()
+    cost = spans[0]["cost_usd"]
+    expected = (150 * 0.15 + 50 * 0.60) / 1_000_000
+    assert cost is not None
+    assert abs(cost - expected) < 1e-9, f"cost={cost} expected={expected}"
+
+
+# --- 5. project resolution from X-Lumin-Project header ----------------------
+
+
+def test_project_from_header(client):
+    """Header wins over service.name. Allowlisted value passes through."""
+    trace_id = _hex_id(32)
+    payload = _otlp_json_payload(trace_id=trace_id, service_name="some-other-service")
+    r = _post_json(client, payload, headers={"X-Lumin-Project": "openclaw"})
+    assert r.status_code == 200
+
+    body = client.get("/v1/agents").json()
+    # The agent's name comes from span.name = "chat_completion"
+    a = next((a for a in body["agents"] if a["name"] == "chat_completion"), None)
+    assert a is not None
+    assert a["project"] == "openclaw"
+
+
+# --- 6. project resolution falls back to service.name -----------------------
+
+
+def test_project_from_service_name(client):
+    """No header → service.name folds through the allowlist (→ default
+    for any non-allowlisted value, mirrors the /v1/spans path)."""
+    trace_id = _hex_id(32)
+    payload = _otlp_json_payload(trace_id=trace_id, service_name="my-agent")
+    r = _post_json(client, payload)
+    assert r.status_code == 200
+
+    body = client.get("/v1/agents").json()
+    a = next((a for a in body["agents"] if a["name"] == "chat_completion"), None)
+    assert a is not None
+    # "my-agent" isn't in the allowlist → folds to "default"
+    assert a["project"] == "default"
+
+
+# --- 7. root span creates the trace -----------------------------------------
+
+
+def test_trace_created_from_root_span(client):
+    """A root span (no parentSpanId) lands a trace row visible at
+    /v1/traces/{id} with name + started_at + ended_at populated."""
+    trace_id = _hex_id(32)
+    span_id = _hex_id(16)
+    payload = _otlp_json_payload(trace_id=trace_id, spans=[{
+        "traceId": trace_id, "spanId": span_id,
+        "name": "agent.run", "kind": 3,
+        "startTimeUnixNano": _now_ns(),
+        "endTimeUnixNano":   _now_ns(2),
+        "attributes": [],
+    }])
+    _post_json(client, payload)
+
+    traces = client.get("/v1/traces").json()
+    t = next(t for t in traces if t["id"].replace("-", "") == trace_id)
+    assert t["name"] == "agent.run"
+    assert t["started_at"] is not None
+    assert t["ended_at"] is not None
+
+
+# --- 8. child spans attach to the right trace ------------------------------
+
+
+def test_child_spans_attached(client):
+    """Root + 2 children share trace_id; spans endpoint returns all 3."""
+    trace_id = _hex_id(32)
+    root_id = _hex_id(16)
+    child1 = _hex_id(16)
+    child2 = _hex_id(16)
+    payload = _otlp_json_payload(trace_id=trace_id, spans=[
+        {
+            "traceId": trace_id, "spanId": root_id,
+            "name": "agent.run", "kind": 3,
+            "startTimeUnixNano": _now_ns(0),
+            "endTimeUnixNano":   _now_ns(3),
+            "attributes": [],
+        },
+        {
+            "traceId": trace_id, "spanId": child1, "parentSpanId": root_id,
+            "name": "step.search", "kind": 3,
+            "startTimeUnixNano": _now_ns(0),
+            "endTimeUnixNano":   _now_ns(1),
+            "attributes": [{"key": "tool.name", "value": {"stringValue": "search"}}],
+        },
+        {
+            "traceId": trace_id, "spanId": child2, "parentSpanId": root_id,
+            "name": "step.summarize", "kind": 3,
+            "startTimeUnixNano": _now_ns(1),
+            "endTimeUnixNano":   _now_ns(2),
+            "attributes": [
+                {"key": "gen_ai.system", "value": {"stringValue": "openai"}},
+                {"key": "gen_ai.request.model", "value": {"stringValue": "gpt-4o"}},
+                {"key": "gen_ai.usage.input_tokens", "value": {"intValue": "1000"}},
+                {"key": "gen_ai.usage.output_tokens", "value": {"intValue": "200"}},
+            ],
+        },
+    ])
+    r = _post_json(client, payload)
+    assert r.status_code == 200
+
+    trace_uuid = next(
+        t["id"] for t in client.get("/v1/traces").json()
+        if t["id"].replace("-", "") == trace_id
+    )
+    spans = client.get(f"/v1/traces/{trace_uuid}/spans").json()
+    assert len(spans) == 3
+
+    # Type detection: tool.name → "tool"; gen_ai.* + CLIENT → "llm"
+    by_name = {s["name"]: s for s in spans}
+    assert by_name["step.search"]["type"] == "tool"
+    assert by_name["step.summarize"]["type"] == "llm"
+
+
+# --- 9. policy engine fires on OTLP-ingested spans -------------------------
+
+
+def test_policy_fires_on_otlp_span(client, db, tmp_path: Path):
+    """Same policy-runtime path that /v1/spans exercises must trigger
+    on an OTLP-shaped span. Critical for the wedge — operators using
+    Logfire/Phoenix/Datadog get policy enforcement for free."""
+    import os
+    import policy_runtime
+
+    yaml_path = tmp_path / "policy.yaml"
+    yaml_path.write_text("""
+version: 1
+policies:
+  - name: otlp_smoke_policy
+    description: Fires on any LLM span
+    trigger: span_end
+    condition: "span.type == 'llm'"
+    action: flag
+    severity: low
+""", encoding="utf-8")
+
+    old = os.environ.get("LUMIN_POLICY_FILE")
+    os.environ["LUMIN_POLICY_FILE"] = str(yaml_path)
+    policy_runtime._reset_for_tests()
+    try:
+        trace_id = _hex_id(32)
+        payload = _otlp_json_payload(trace_id=trace_id)
+        _post_json(client, payload)
+
+        trace_uuid = next(
+            t["id"] for t in client.get("/v1/traces").json()
+            if t["id"].replace("-", "") == trace_id
+        )
+        listing = client.get(f"/v1/violations?trace_id={trace_uuid}").json()
+        names = {v["policy_name"] for v in listing["violations"]}
+        assert "otlp_smoke_policy" in names, (
+            f"expected otlp_smoke_policy to fire; got {names}"
+        )
+    finally:
+        policy_runtime._reset_for_tests()
+        if old is None:
+            os.environ.pop("LUMIN_POLICY_FILE", None)
+        else:
+            os.environ["LUMIN_POLICY_FILE"] = old
+
+
+# --- 10. unknown content-type tries protobuf -------------------------------
+
+
+def test_unknown_content_type_tries_protobuf(client):
+    """No Content-Type → fall back to protobuf decode. OTel collectors
+    occasionally drop the header; we should still ingest cleanly."""
+    payload = _otlp_json_payload()
+    proto_bytes = _build_otlp_proto(payload)
+    r = client.post("/v1/otlp/v1/traces", content=proto_bytes, headers={})
+    assert r.status_code == 200, r.text
+
+
+# --- 11. invalid payload returns 400 (not 500) -----------------------------
+
+
+def test_invalid_payload_returns_400(client):
+    """Garbage bytes can't be parsed as either format → 400."""
+    r = client.post(
+        "/v1/otlp/v1/traces",
+        content=b"\x00\x01\x02 not a real protobuf or json",
+        headers={"Content-Type": "application/x-protobuf"},
+    )
+    assert r.status_code == 400, r.text
+
+    r2 = client.post(
+        "/v1/otlp/v1/traces",
+        content=b"not json either",
+        headers={"Content-Type": "application/json"},
+    )
+    assert r2.status_code == 400, r2.text
+
+
+# --- bonus: empty body is acknowledged -------------------------------------
+
+
+def test_empty_body_is_ok(client):
+    """OTel collectors sometimes send empty pings — don't 4xx them."""
+    r = client.post(
+        "/v1/otlp/v1/traces",
+        content=b"",
+        headers={"Content-Type": "application/x-protobuf"},
+    )
+    assert r.status_code == 200

--- a/packages/integrations/openclaw/README.md
+++ b/packages/integrations/openclaw/README.md
@@ -4,6 +4,39 @@
 
 `@lumin-io/openclaw` is the Lumin side of OpenClaw's OTel telemetry pipeline. OpenClaw ships diagnostics through `@openclaw/diagnostics-otel`; this package provides a drop-in `SpanExporter` that converts those spans to Lumin's wire format and ships them to a local Lumin instance — visible at `http://localhost:3000`.
 
+## Quick Start
+
+Works out of the box with **OpenClaw v2026.2+** — no npm install, no agent code changes. Lumin exposes an OTLP/HTTP endpoint that OpenClaw's built-in `diagnostics-otel` plugin can write to directly.
+
+```bash
+# Step 1 — start Lumin
+docker run -p 3000:3000 -p 8000:8000 zistica/lumin
+
+# Step 2 — enable diagnostics + point OpenClaw at Lumin
+openclaw config set diagnostics.enabled true
+openclaw config set diagnostics.otel.enabled true
+openclaw config set diagnostics.otel.traces true
+openclaw config set diagnostics.otel.endpoint "http://localhost:8000/v1/otlp"
+openclaw gateway restart
+
+# Step 3 — open http://localhost:3000
+# every OpenClaw run appears automatically
+```
+
+OpenClaw's `diagnostics-otel` auto-appends `/v1/traces` to the configured base, so the POST lands at Lumin's OTLP route `http://localhost:8000/v1/otlp/v1/traces`. On v2026.4.25+ you can use the signal-specific form instead:
+
+```bash
+openclaw config set diagnostics.otel.traces.endpoint "http://localhost:8000/v1/otlp/v1/traces"
+```
+
+**What gets captured**
+- LLM calls — model, tokens, cost, duration
+- Tool calls — file, shell, web, email
+- Agent sessions end-to-end as a span tree
+- Policy violations auto-detected by Lumin's [policy engine](../../../README.md#policy-engine)
+
+When to install the `@lumin-io/openclaw` npm package below: you want client-side cost calculation, custom span subtypes (e.g. extended-thinking), or you're not using OpenClaw's built-in `diagnostics-otel` plugin.
+
 ## Install
 
 ```bash

--- a/packages/integrations/openclaw/README.md
+++ b/packages/integrations/openclaw/README.md
@@ -6,7 +6,7 @@
 
 ## Quick Start
 
-Works out of the box with **OpenClaw v2026.2+** — no npm install, no agent code changes. Lumin exposes an OTLP/HTTP endpoint that OpenClaw's built-in `diagnostics-otel` plugin can write to directly.
+Works out of the box on any OpenClaw release that ships [`diagnostics-otel`](https://docs.openclaw.ai/gateway/opentelemetry) — no npm install, no agent code changes. Lumin exposes an OTLP/HTTP endpoint that OpenClaw's built-in plugin can write to directly.
 
 ```bash
 # Step 1 — start Lumin
@@ -23,19 +23,19 @@ openclaw gateway restart
 # every OpenClaw run appears automatically
 ```
 
-OpenClaw's `diagnostics-otel` auto-appends `/v1/traces` to the configured base, so the POST lands at Lumin's OTLP route `http://localhost:8000/v1/otlp/v1/traces`. On v2026.4.25+ you can use the signal-specific form instead:
+`diagnostics-otel` auto-appends `/v1/traces` to the configured base when the URL doesn't already include it (see the [OpenClaw OpenTelemetry export docs](https://docs.openclaw.ai/gateway/opentelemetry)) — the POST lands at Lumin's OTLP route `http://localhost:8000/v1/otlp/v1/traces`. If you'd rather be explicit:
 
 ```bash
-openclaw config set diagnostics.otel.traces.endpoint "http://localhost:8000/v1/otlp/v1/traces"
+openclaw config set diagnostics.otel.endpoint "http://localhost:8000/v1/otlp/v1/traces"
 ```
 
-**What gets captured**
-- LLM calls — model, tokens, cost, duration
-- Tool calls — file, shell, web, email
-- Agent sessions end-to-end as a span tree
-- Policy violations auto-detected by Lumin's [policy engine](../../../README.md#policy-engine)
+**What ends up in the dashboard**:
+- Model calls — provider / model / input + output token counts / duration; cost computed from Lumin's pricing tables
+- `openclaw.exec` spans for tool / process invocations
+- Full span tree for an agent run, parent-child correctly nested
+- Policy violations auto-detected by Lumin's policy engine on every ingested span
 
-When to install the `@lumin-io/openclaw` npm package below: you want client-side cost calculation, custom span subtypes (e.g. extended-thinking), or you're not using OpenClaw's built-in `diagnostics-otel` plugin.
+When you'd want the **in-process exporter** below instead of the OTLP path: client-side cost calculation, custom span subtypes (e.g. extended-thinking), or your OpenClaw build predates `diagnostics-otel`.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Lets **any OpenTelemetry-compatible tool** (Logfire, Phoenix, Datadog GenAI, OpenLLMetry, the OTel collector itself) send spans to Lumin with **one config line — no Lumin SDK required**. Closes the biggest distribution gap surfaced by the agent-bible research memo (Play #1).

```bash
# Existing OTel agent — add Lumin as a second exporter:
export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:8000
export OTEL_EXPORTER_OTLP_HEADERS="x-lumin-project=my-project"
# That's it. Run your agent. Trace appears at localhost:3000.
```

## What's in scope (per session prompt)

- `POST /v1/otlp/v1/traces` accepts protobuf + JSON
- `gen_ai.*` attribute mapping → `model`, `provider`, `tokens_input/output`, `cost_usd`
- Span-type detection (CLIENT + gen_ai.* → `llm`; `tool.name` → `tool`; `db.system` → `retrieval`)
- Trace upsert from root spans (reuses the existing `/v1/spans` path)
- Project resolution: `X-Lumin-Project` header → `service.name` resource attr → `default`
- Cost calculation for known OpenAI + Anthropic models
- Policy engine fires on OTLP-ingested spans automatically (same eval path)

## What's explicitly out of scope (per Development_Rules.md)

- ❌ OTLP/gRPC (HTTP only for v1)
- ❌ SDK changes
- ❌ Dashboard changes

## Architecture

```
OTel SDK / OTel Collector / Logfire / Phoenix / Datadog
        │
        │  POST /v1/otlp/v1/traces (protobuf or JSON)
        ▼
   routers/otlp.py — thin HTTP transport
        │
        │  parse + translate
        ▼
   otlp_decode.py — pure functions, no I/O
        │  gen_ai.system          → provider
        │  gen_ai.request.model   → model
        │  gen_ai.usage.*_tokens  → tokens_*
        │  + cost calc + type classification
        ▼
   Same insert path as POST /v1/spans
   (_insert_span + _upsert_trace + _broadcast + _evaluate_policies)
        ▼
   DuckDB + WebSocket + Policy engine
```

`otlp_decode.py` is pure — no DB, no FastAPI imports — so the wire-format risk lives in a unit-testable surface.

## Test plan

- [x] **12 unit tests pass** — JSON basic, proto basic, gen_ai mapping, cost calc, project from header, project from service.name, root creates trace, child attached, policy fires, unknown content-type, invalid payload → 400, empty body → 200
- [x] **All 181 existing API tests still pass** (was 169 + 12 new)
- [x] **End-to-end with real OTel Python SDK** — `OTLPSpanExporter(endpoint=...)` → trace lands, no Lumin SDK in scope
- [x] **End-to-end with raw OTLP/JSON POST** — trace lands
- [ ] CI on this PR

## Notable decisions

1. **Same insert path as `/v1/spans`** — no parallel write logic. Avoids drift in DB schema, WS broadcast, or policy eval.
2. **Project allowlist still applies** — `service.name` from third-party tools folds through the same closed-set normalization, keeping the agent-grid framework headlines stable.
3. **Pure decode module** — `otlp_decode.py` has no FastAPI / DuckDB imports; future OTLP/gRPC support (v2) reuses it as-is.
4. **Rule 7 throughout** — malformed individual spans get logged and skipped, never abort the batch. Wire-format errors return 400, not 500. Empty bodies acknowledged silently.
5. **Why not use `json_format.ParseDict` for the proto test fixtures** — it interprets `bytes` fields as base64, but OTLP/JSON uses hex for trace_id. The test helper builds the proto bottom-up with `bytes.fromhex` to match the spec exactly.

## Files

| File | Lines | Purpose |
|---|---:|---|
| `packages/api/otlp_decode.py` | new (471) | Pure decode + translate |
| `packages/api/routers/otlp.py` | new (152) | HTTP transport |
| `packages/api/tests/test_otlp_ingest.py` | new (271) | 12 test cases |
| `packages/api/main.py` | +1 | Register router |
| `packages/api/requirements.txt` | +1 | `opentelemetry-proto>=1.30` |