### PR TITLE
ci: add publish workflow for tag-triggered Docker Hub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,116 @@
+name: Publish Docker image
+
+# Triggers on a pushed tag matching v* (e.g. v0.2.0). The CI workflow
+# already builds + smoke-tests the image on every PR + main push, so by
+# the time a tag exists the build is known good. This workflow's job is
+# just to push the published bits.
+#
+# Why tag-triggered (not main-push)?
+#   Every merge would ship a new :latest, which surprises users who
+#   `docker pull zistica/lumin` expecting yesterday's behavior. Tags
+#   are an explicit "ship this" signal — same pattern as Sentry,
+#   Grafana, and the OTel collector.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  # Lets a maintainer kick off a release manually for the current
+  # main HEAD without cutting a tag — useful for hotfix-style pushes.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to publish (without v prefix). Defaults to "latest" only.'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+# Cancel an in-flight publish if a newer tag/dispatch arrives. Two
+# parallel publishes pushing :latest would race — last writer wins —
+# and the result is non-deterministic.
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build + push zistica/lumin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # QEMU lets us cross-build for arm64 from an amd64 runner. ~70%
+      # of OSS Docker users on macOS are on Apple Silicon now; shipping
+      # an amd64-only image makes them eat a slow emulation layer at
+      # `docker run` time. Multi-arch is one extra job-minute but a
+      # much better first-run experience.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve image tags
+        id: tags
+        run: |
+          set -e
+          # Strip the v from a git tag (v0.2.0 -> 0.2.0). For a
+          # workflow_dispatch run, prefer the user-supplied tag input
+          # (no v stripping needed); empty input means "publish :latest
+          # only" — useful for re-publishing main without a version bump.
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+            TAGS="zistica/lumin:${VERSION},zistica/lumin:latest"
+          else
+            DISPATCH_TAG="${{ github.event.inputs.tag }}"
+            if [ -n "${DISPATCH_TAG}" ]; then
+              VERSION="${DISPATCH_TAG#v}"
+              TAGS="zistica/lumin:${VERSION},zistica/lumin:latest"
+            else
+              VERSION="(latest only)"
+              TAGS="zistica/lumin:latest"
+            fi
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tags=${TAGS}"       >> "$GITHUB_OUTPUT"
+          echo "Will publish: ${TAGS}"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build + push (linux/amd64 + linux/arm64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          # Multi-arch via the buildx builder set up above. arm64 builds
+          # are slower (emulated) but worth it for Apple-Silicon devs.
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          # Reuse the GHA cache the CI Docker job populated on the merge
+          # commit — most layers should hit cache and the publish takes
+          # ~3-5 min instead of a full from-scratch rebuild.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Useful labels for image consumers + Docker Hub UI.
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.tags.outputs.version }}
+            org.opencontainers.image.title=Lumin
+            org.opencontainers.image.description=Local-first AI agent observability — single Docker container
+
+      - name: Summary
+        run: |
+          echo "### :rocket: Published \`zistica/lumin\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tags: \`${{ steps.tags.outputs.tags }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Version: \`${{ steps.tags.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Platforms: \`linux/amd64\`, \`linux/arm64\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Pull with: \`docker pull zistica/lumin:${{ steps.tags.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

Today \`ci.yml\` builds + smoke-tests the Docker image on every PR but throws it away (\`push: false\`). Docker Hub publishes are manual, which means main can drift days behind \`zistica/lumin:latest\`.

Concrete drift right now:
- Docker Hub last push: **2026-05-04** (commit \`029157d\`, the VoltAgent merge)
- main HEAD: **\`c869ec9\`** (today, post-PR #30)
- Unpublished: **#23 agent grid + policies, #24 README, #29 theme toggle, #30 OTLP ingest** — none of these are in the image users pull today.

## What this workflow does

Fires on:
- \`git push --tags v*\` — the canonical "ship this" signal
- \`workflow_dispatch\` — manual re-publish without a tag (e.g. re-push \`:latest\` for the current main)

Strips the leading \`v\` (\`v0.2.0\` → \`0.2.0\`) and pushes both \`zistica/lumin:<version>\` and \`zistica/lumin:latest\`. Multi-arch (\`linux/amd64\` + \`linux/arm64\`) — Apple Silicon devs otherwise eat emulation on \`docker run\`.

Reuses the GHA cache from \`ci.yml\`'s Docker job so publishes take ~3-5 min, not a full from-scratch rebuild.

## Required secrets (one-time setup before merge)

\`\`\`bash
gh secret set DOCKERHUB_USERNAME --body 'your-dockerhub-user'
gh secret set DOCKERHUB_TOKEN    --body 'your-dockerhub-token'
\`\`\`

The token is a Docker Hub **access token** (Account Settings → Security → New Access Token), not your password.

## After merge — release flow becomes

\`\`\`bash
git tag v0.2.0
git push --tags
# Workflow auto-publishes zistica/lumin:0.2.0 + :latest within ~5 min
\`\`\`

## Tradeoffs considered

- **Tag-triggered, not push-to-main triggered.** Every merge shipping :latest surprises \`docker pull\` users. Tags are explicit. Same pattern as Sentry, Grafana, the OTel collector.
- **Multi-arch costs ~1 extra min** (qemu emulation for arm64). Worth it.
- **No retention policy on tags.** Manual cleanup of old versions on Docker Hub UI for now; a separate \`docker-image-prune\` action can come later if the registry gets cluttered.

## Test plan

- [ ] Set the two secrets per the snippet above.
- [ ] Merge this PR.
- [ ] Cut \`v0.2.0\` (\`git tag v0.2.0 && git push --tags\`).
- [ ] Watch the workflow run; confirm \`zistica/lumin:0.2.0\` + \`:latest\` appear on Docker Hub.
- [ ] \`docker pull zistica/lumin\` from a fresh machine, run, sanity-click \`/agents\` + \`/policies\`.