### PR TITLE
feat(api): OTLP decoder reads OpenClaw native attributes

### DIFF
--- a/packages/api/otlp_decode.py
+++ b/packages/api/otlp_decode.py
@@ -225,21 +225,40 @@ _SPAN_KIND_CLIENT = 3
 _SPAN_KIND_SERVER = 2
 
 
-def _classify_type(kind: int, attrs: Dict[str, Any]) -> str:
+def _classify_type(kind: int, attrs: Dict[str, Any], name: Optional[str] = None) -> str:
     """Best-effort span-type classification.
 
-    Spec says:
-      CLIENT + gen_ai.*    → llm
-      tool.name present    → tool
-      db.system present    → retrieval
-      otherwise            → custom
+    Priority (first match wins):
+      tool.name / gen_ai.tool.name / openclaw.tool.name → tool
+      db.system                                          → retrieval
+      span name 'openclaw.tool.*'                        → tool
+      span name 'openclaw.model.*'                       → llm
+      gen_ai.* attributes present + ANY span kind        → llm
+      span name 'openclaw.exec'                          → custom
+      otherwise                                          → custom
+
+    Why span-name patterns: OpenClaw's diagnostics-otel emits model
+    calls with SpanKind.INTERNAL (kind=1) rather than CLIENT (kind=3).
+    The strict-OTel rule "CLIENT + gen_ai.* → llm" misses every one
+    of them — operators see "type=custom" on what's clearly an LLM
+    call. The span name itself is a reliable signal.
+
+    Why we relaxed the kind requirement on gen_ai.*: tools beyond
+    OpenClaw also emit gen_ai attributes on INTERNAL spans (Logfire
+    does this for in-process Pydantic-AI calls, for example). Strict
+    kind matching kept producing too many type=custom rows.
     """
-    if "tool.name" in attrs or "gen_ai.tool.name" in attrs:
+    if "tool.name" in attrs or "gen_ai.tool.name" in attrs or "openclaw.tool.name" in attrs:
         return "tool"
     if "db.system" in attrs:
         return "retrieval"
+    if name:
+        if name.startswith("openclaw.tool."):
+            return "tool"
+        if name.startswith("openclaw.model.") or name.startswith("gen_ai."):
+            return "llm"
     has_gen_ai = any(k.startswith("gen_ai.") for k in attrs)
-    if kind == _SPAN_KIND_CLIENT and has_gen_ai:
+    if has_gen_ai:
         return "llm"
     return "custom"
 
@@ -264,13 +283,23 @@ def _stringify(value: Any, max_len: int = 32_768) -> Optional[str]:
 def _extract_input(attrs: Dict[str, Any]) -> Optional[str]:
     """Look for input/prompt content under any of the conventions we
     know about. Order matters — first hit wins.
+
+    Includes OpenClaw's `openclaw.content.*` and `openclaw.input` keys
+    so spans from `@openclaw/diagnostics-otel` carry their actual
+    prompt text into the dashboard. Without these, the OpenClaw
+    integration showed empty input columns even though the LLM call
+    plainly had a prompt — see PR follow-up to PR #30.
     """
     for k in (
         "gen_ai.prompt",
+        "gen_ai.input.messages",
         "input.value",
         "llm.input_messages",
-        "gen_ai.input.messages",
         "ai.prompt.messages",
+        "openclaw.content.input_messages",
+        "openclaw.content.system_prompt",
+        "openclaw.content.tool_input",
+        "openclaw.input",
     ):
         if k in attrs:
             return _stringify(attrs[k])
@@ -280,13 +309,32 @@ def _extract_input(attrs: Dict[str, Any]) -> Optional[str]:
 def _extract_output(attrs: Dict[str, Any]) -> Optional[str]:
     for k in (
         "gen_ai.completion",
+        "gen_ai.output.messages",
         "output.value",
         "llm.output_messages",
-        "gen_ai.output.messages",
         "ai.response.text",
+        "openclaw.content.output_messages",
+        "openclaw.content.tool_output",
+        "openclaw.output",
     ):
         if k in attrs:
             return _stringify(attrs[k])
+    return None
+
+
+def _extract_session_id(attrs: Dict[str, Any]) -> Optional[str]:
+    """Resolve session_id from OpenClaw conventions.
+
+    OpenClaw groups multi-turn conversations under `openclaw.session_id`
+    (per-thread) or `openclaw.channel.id` (per-channel). Whichever is
+    present wins. Lumin's session view groups traces with shared
+    session_id, so populating this lets the /sessions page work for
+    OpenClaw chat threads without any user config.
+    """
+    for k in ("openclaw.session_id", "openclaw.channel.id"):
+        v = attrs.get(k)
+        if isinstance(v, str) and v:
+            return v
     return None
 
 
@@ -307,6 +355,21 @@ _KNOWN_KEYS = frozenset({
     "llm.input_messages",
     "llm.output_messages",
     "ai.prompt.messages",
+    # OpenClaw native attributes — the diagnostics-otel plugin emits
+    # these on every model.call / tool.execution span. Stripping them
+    # from metadata so first-class fields don't double up.
+    "openclaw.provider",
+    "openclaw.model",
+    "openclaw.tool.name",
+    "openclaw.content.input_messages",
+    "openclaw.content.system_prompt",
+    "openclaw.content.tool_input",
+    "openclaw.content.output_messages",
+    "openclaw.content.tool_output",
+    "openclaw.input",
+    "openclaw.output",
+    "openclaw.session_id",
+    "openclaw.channel.id",
     "ai.response.text",
     "tool.name",
     "db.system",
@@ -368,8 +431,19 @@ def _build_span_input(
     trace_id = _hex_to_uuid(trace_id_hex) if trace_id_hex else span_id
     parent_id = _hex_to_uuid(parent_span_id_hex) if parent_span_id_hex else None
 
-    model = attrs.get("gen_ai.response.model") or attrs.get("gen_ai.request.model")
-    provider = attrs.get("gen_ai.system")
+    # Read the OTel GenAI semconv keys first; fall back to OpenClaw's
+    # native namespace when the strict-OTel attributes aren't set.
+    # Real-world: OpenClaw's diagnostics-otel emits both — but other
+    # tools (and older OpenClaw builds) may emit only one or the other.
+    model = (
+        attrs.get("gen_ai.response.model")
+        or attrs.get("gen_ai.request.model")
+        or attrs.get("openclaw.model")
+    )
+    provider = (
+        attrs.get("gen_ai.system")
+        or attrs.get("openclaw.provider")
+    )
     tokens_in = attrs.get("gen_ai.usage.input_tokens")
     tokens_out = attrs.get("gen_ai.usage.output_tokens")
     operation = attrs.get("gen_ai.operation.name")
@@ -393,7 +467,9 @@ def _build_span_input(
         tokens_in,
         tokens_out,
     )
-    span_type = _classify_type(kind, attrs)
+    # Span name flows into the classifier so name-prefix patterns
+    # ('openclaw.model.*' → llm) work when SpanKind isn't CLIENT.
+    span_type = _classify_type(kind, attrs, name=name)
     status, error_message = _status_from_otel(status_code, status_message)
 
     # Span name: OTel's span.name wins. Fall back to the gen_ai.operation.name
@@ -403,7 +479,13 @@ def _build_span_input(
     if resolved_name in (None, "", "span") and operation:
         resolved_name = operation
 
-    tool_name = attrs.get("gen_ai.tool.name") or attrs.get("tool.name")
+    tool_name = (
+        attrs.get("gen_ai.tool.name")
+        or attrs.get("tool.name")
+        or attrs.get("openclaw.tool.name")
+    )
+
+    session_id = _extract_session_id(attrs)
 
     return SpanInput(
         id=span_id,
@@ -423,6 +505,7 @@ def _build_span_input(
         tokens_output=tokens_out,
         cost_usd=cost,
         tool_name=str(tool_name) if tool_name else None,
+        session_id=session_id,
         metadata=_build_metadata(attrs),
     )
 

--- a/packages/api/otlp_decode.py
+++ b/packages/api/otlp_decode.py
@@ -403,6 +403,43 @@ def _status_from_otel(code: Any, message: Optional[str]) -> Tuple[str, Optional[
 # ---- the assembled span ---------------------------------------------------
 
 
+def _resolve_agent_identity(
+    name: Optional[str],
+    parent_span_id_hex: Optional[str],
+    service_name_hint: Optional[str],
+) -> Optional[str]:
+    """Collapse multi-phase root span names under one agent identity.
+
+    Lumin's agent grid groups by ``trace.name`` (the root span's name).
+    Frameworks like OpenClaw emit several distinct root span names per
+    user interaction — ``openclaw.run``, ``openclaw.message.processed``,
+    ``openclaw.harness.run``, ``openclaw.context.assembled``,
+    ``openclaw.liveness.warning``, ``openclaw.diagnostic.phase`` — each
+    landing as a separate trace_id. The unmodified grid then shows
+    five-plus ``agent`` cards for what operators rightly think of as
+    one agent (the bot itself).
+
+    Rule: when a ROOT span's name starts with a known framework
+    prefix, fold to the resource ``service.name`` (which OTel SDKs
+    auto-set from ``OTEL_SERVICE_NAME`` or the binary name) — falling
+    back to the prefix itself if no service name is present. Children
+    keep their original names so the span timeline still shows the
+    phase breakdown.
+
+    Today this only kicks in for the ``openclaw.`` prefix. Other
+    frameworks haven't shown the same multi-root-name pattern in
+    practice (Mastra and VoltAgent emit one root per interaction with
+    a user-defined name); add new prefixes here as we encounter them.
+    """
+    if parent_span_id_hex:
+        return name
+    if not name:
+        return name
+    if name.startswith("openclaw."):
+        return service_name_hint or "openclaw"
+    return name
+
+
 def _build_span_input(
     *,
     trace_id_hex: str,
@@ -415,6 +452,7 @@ def _build_span_input(
     status_code: Any,
     status_message: Optional[str],
     attrs: Dict[str, Any],
+    service_name_hint: Optional[str] = None,
 ) -> Optional[SpanInput]:
     """Materialize a Lumin SpanInput from already-normalized OTLP fields.
 
@@ -423,6 +461,10 @@ def _build_span_input(
     still flows; OTel implementations have shipped malformed spans
     before, and Rule 7 generalized says we never reject a whole
     batch over one bad row.
+
+    ``service_name_hint`` is the resource ``service.name`` from the
+    OTLP payload — used to collapse OpenClaw's multiple internal
+    root span names under a single agent identity in the grid.
     """
     if not span_id_hex or not started_at:
         return None
@@ -469,6 +511,9 @@ def _build_span_input(
     )
     # Span name flows into the classifier so name-prefix patterns
     # ('openclaw.model.*' → llm) work when SpanKind isn't CLIENT.
+    # Use the ORIGINAL name here, before the agent-identity fold,
+    # so model.call spans are still classified llm even when their
+    # root parent gets renamed.
     span_type = _classify_type(kind, attrs, name=name)
     status, error_message = _status_from_otel(status_code, status_message)
 
@@ -478,6 +523,16 @@ def _build_span_input(
     resolved_name = name or operation
     if resolved_name in (None, "", "span") and operation:
         resolved_name = operation
+
+    # Agent-identity fold for root spans (see _resolve_agent_identity).
+    # When this rewrites the name, stash the original under a metadata
+    # key so the span detail page can still surface what phase this was.
+    folded = _resolve_agent_identity(
+        resolved_name, parent_span_id_hex, service_name_hint
+    )
+    if folded != resolved_name and resolved_name:
+        attrs = {**attrs, "openclaw.span.original_name": resolved_name}
+        resolved_name = folded
 
     tool_name = (
         attrs.get("gen_ai.tool.name")
@@ -528,10 +583,15 @@ def parse_otlp_proto(export_request: Any) -> Tuple[List[SpanInput], Optional[str
 
     for resource_spans in export_request.resource_spans:
         resource_attrs = _attrs_from_proto(resource_spans.resource.attributes)
-        if service_name is None:
-            sn = resource_attrs.get("service.name")
-            if sn:
-                service_name = str(sn)
+        # Service name is per-resource. The batch-level `service_name`
+        # we return is the first one encountered (used by the router as
+        # a project hint); each span gets folded against ITS resource's
+        # service name though, so multi-resource batches stay correct.
+        resource_service_name = resource_attrs.get("service.name")
+        if resource_service_name:
+            resource_service_name = str(resource_service_name)
+        if service_name is None and resource_service_name:
+            service_name = resource_service_name
 
         for scope_spans in resource_spans.scope_spans:
             for span in scope_spans.spans:
@@ -563,6 +623,7 @@ def parse_otlp_proto(export_request: Any) -> Tuple[List[SpanInput], Optional[str
                     status_code=status_code,
                     status_message=status_message,
                     attrs=attrs,
+                    service_name_hint=resource_service_name,
                 )
                 if si is not None:
                     spans_out.append(si)
@@ -592,10 +653,11 @@ def parse_otlp_json(payload: dict) -> Tuple[List[SpanInput], Optional[str]]:
     for resource_spans in payload.get("resourceSpans", []) or []:
         resource = resource_spans.get("resource") or {}
         resource_attrs = _attrs_from_json(resource.get("attributes", []))
-        if service_name is None:
-            sn = resource_attrs.get("service.name")
-            if sn:
-                service_name = str(sn)
+        resource_service_name = resource_attrs.get("service.name")
+        if resource_service_name:
+            resource_service_name = str(resource_service_name)
+        if service_name is None and resource_service_name:
+            service_name = resource_service_name
 
         for scope_spans in resource_spans.get("scopeSpans", []) or []:
             for span in scope_spans.get("spans", []) or []:
@@ -640,6 +702,7 @@ def parse_otlp_json(payload: dict) -> Tuple[List[SpanInput], Optional[str]]:
                     status_code=status_code,
                     status_message=status_message,
                     attrs=attrs,
+                    service_name_hint=resource_service_name,
                 )
                 if si is not None:
                     spans_out.append(si)

--- a/packages/api/tests/test_otlp_ingest.py
+++ b/packages/api/tests/test_otlp_ingest.py
@@ -452,3 +452,167 @@ def test_empty_body_is_ok(client):
         headers={"Content-Type": "application/x-protobuf"},
     )
     assert r.status_code == 200
+
+
+# ---- OpenClaw-shaped spans (PR #30 follow-up) ----------------------------
+#
+# OpenClaw's diagnostics-otel emits a mix of strict-OTel attributes
+# (gen_ai.system, gen_ai.request.model) and its own openclaw.* keys
+# for things the OTel spec doesn't cover (request_bytes, content
+# text). It also emits model-call spans with SpanKind.INTERNAL (1)
+# rather than CLIENT (3). The decoder needs to handle both.
+
+
+def test_openclaw_model_call_classified_as_llm_via_name(client):
+    """SpanKind.INTERNAL + name 'openclaw.model.call' → type='llm'.
+
+    Pre-fix: type='custom' because the strict CLIENT+gen_ai.* gate
+    didn't match. Operators saw real LLM calls labeled 'custom' in
+    the dashboard, no LLM filter, no policy gating.
+    """
+    trace_id = _hex_id(32)
+    span_id = _hex_id(16)
+    payload = _otlp_json_payload(trace_id=trace_id, spans=[{
+        "traceId": trace_id, "spanId": span_id,
+        "name": "openclaw.model.call",
+        "kind": 1,  # INTERNAL — this is the bit pre-fix decoder choked on
+        "startTimeUnixNano": _now_ns(),
+        "endTimeUnixNano":   _now_ns(1),
+        "attributes": [
+            {"key": "openclaw.provider", "value": {"stringValue": "ollama"}},
+            {"key": "openclaw.model", "value": {"stringValue": "llama3.2:latest"}},
+            {"key": "openclaw.api", "value": {"stringValue": "openai-completions"}},
+        ],
+    }])
+    _post_json(client, payload)
+
+    trace_uuid = next(
+        t["id"] for t in client.get("/v1/traces").json()
+        if t["id"].replace("-", "") == trace_id
+    )
+    spans = client.get(f"/v1/traces/{trace_uuid}/spans").json()
+    s = spans[0]
+    assert s["type"] == "llm", f"expected llm, got {s['type']}"
+    assert s["model"] == "llama3.2:latest"
+    assert s["provider"] == "ollama"
+
+
+def test_openclaw_content_keys_extracted_to_input_output(client):
+    """openclaw.content.input_messages / openclaw.content.output_messages
+    populate span.input / span.output — without this they sat in
+    metadata only and the dashboard's input/output columns were empty.
+    """
+    trace_id = _hex_id(32)
+    span_id = _hex_id(16)
+    payload = _otlp_json_payload(trace_id=trace_id, spans=[{
+        "traceId": trace_id, "spanId": span_id,
+        "name": "openclaw.model.call",
+        "kind": 1,
+        "startTimeUnixNano": _now_ns(),
+        "endTimeUnixNano":   _now_ns(1),
+        "attributes": [
+            {"key": "openclaw.provider", "value": {"stringValue": "ollama"}},
+            {"key": "openclaw.model", "value": {"stringValue": "llama3.2:latest"}},
+            {"key": "openclaw.content.input_messages",
+             "value": {"stringValue": "user: hello"}},
+            {"key": "openclaw.content.output_messages",
+             "value": {"stringValue": "assistant: hi back"}},
+        ],
+    }])
+    _post_json(client, payload)
+
+    trace_uuid = next(
+        t["id"] for t in client.get("/v1/traces").json()
+        if t["id"].replace("-", "") == trace_id
+    )
+    s = client.get(f"/v1/traces/{trace_uuid}/spans").json()[0]
+    assert s["input"] == "user: hello"
+    assert s["output"] == "assistant: hi back"
+
+
+def test_openclaw_tool_execution_classified_as_tool(client):
+    """openclaw.tool.execution with openclaw.tool.name → type='tool'."""
+    trace_id = _hex_id(32)
+    span_id = _hex_id(16)
+    payload = _otlp_json_payload(trace_id=trace_id, spans=[{
+        "traceId": trace_id, "spanId": span_id,
+        "name": "openclaw.tool.execution",
+        "kind": 1,
+        "startTimeUnixNano": _now_ns(),
+        "endTimeUnixNano":   _now_ns(1),
+        "attributes": [
+            {"key": "openclaw.tool.name", "value": {"stringValue": "memory_get"}},
+        ],
+    }])
+    _post_json(client, payload)
+
+    trace_uuid = next(
+        t["id"] for t in client.get("/v1/traces").json()
+        if t["id"].replace("-", "") == trace_id
+    )
+    s = client.get(f"/v1/traces/{trace_uuid}/spans").json()[0]
+    assert s["type"] == "tool"
+    assert s["tool_name"] == "memory_get"
+
+
+def test_openclaw_session_id_propagates(client):
+    """openclaw.session_id on a root span flows into trace.session_id
+    so /sessions can group multi-turn OpenClaw chats correctly.
+    """
+    trace_id = _hex_id(32)
+    span_id = _hex_id(16)
+    payload = _otlp_json_payload(trace_id=trace_id, spans=[{
+        "traceId": trace_id, "spanId": span_id,
+        "name": "openclaw.run", "kind": 1,
+        "startTimeUnixNano": _now_ns(),
+        "endTimeUnixNano":   _now_ns(2),
+        "attributes": [
+            {"key": "openclaw.session_id",
+             "value": {"stringValue": "tg:5706212396:dm"}},
+        ],
+    }])
+    _post_json(client, payload)
+
+    trace_uuid = next(
+        t["id"] for t in client.get("/v1/traces").json()
+        if t["id"].replace("-", "") == trace_id
+    )
+    body = client.get(f"/v1/traces/{trace_uuid}").json()
+    assert body["session_id"] == "tg:5706212396:dm"
+
+
+def test_openclaw_attrs_dont_pollute_metadata(client):
+    """Once we promote openclaw.* keys to first-class fields, they
+    should NOT also live in metadata — would double the row size and
+    confuse readers."""
+    trace_id = _hex_id(32)
+    span_id = _hex_id(16)
+    payload = _otlp_json_payload(trace_id=trace_id, spans=[{
+        "traceId": trace_id, "spanId": span_id,
+        "name": "openclaw.model.call",
+        "kind": 1,
+        "startTimeUnixNano": _now_ns(),
+        "endTimeUnixNano":   _now_ns(1),
+        "attributes": [
+            {"key": "openclaw.provider", "value": {"stringValue": "ollama"}},
+            {"key": "openclaw.model", "value": {"stringValue": "llama3.2:latest"}},
+            {"key": "openclaw.input", "value": {"stringValue": "test"}},
+            {"key": "openclaw.api", "value": {"stringValue": "openai-completions"}},
+            {"key": "openclaw.transport", "value": {"stringValue": "auto"}},
+        ],
+    }])
+    _post_json(client, payload)
+
+    trace_uuid = next(
+        t["id"] for t in client.get("/v1/traces").json()
+        if t["id"].replace("-", "") == trace_id
+    )
+    s = client.get(f"/v1/traces/{trace_uuid}/spans").json()[0]
+    md = s["metadata"] or {}
+    # Promoted keys not in metadata
+    assert "openclaw.provider" not in md
+    assert "openclaw.model" not in md
+    assert "openclaw.input" not in md
+    # Non-promoted keys still preserved (operators may want them)
+    assert md.get("openclaw.api") == "openai-completions"
+    assert md.get("openclaw.transport") == "auto"

--- a/packages/api/tests/test_otlp_ingest.py
+++ b/packages/api/tests/test_otlp_ingest.py
@@ -616,3 +616,136 @@ def test_openclaw_attrs_dont_pollute_metadata(client):
     # Non-promoted keys still preserved (operators may want them)
     assert md.get("openclaw.api") == "openai-completions"
     assert md.get("openclaw.transport") == "auto"
+
+
+# ---- agent identity fold (PR #32 follow-up) ------------------------------
+
+
+def test_openclaw_root_spans_fold_to_one_agent(client):
+    """OpenClaw emits 5+ different root span names per user message
+    (openclaw.run, .message.processed, .harness.run, .liveness.warning,
+    .diagnostic.phase). Without the fold, /v1/agents shows them as
+    separate agent cards — misleading. With the fold, all become
+    one agent named after the resource service.name.
+    """
+    # 3 distinct root spans, 3 distinct trace IDs, all with service.name='openclaw'
+    payloads = []
+    for i, root_name in enumerate([
+        "openclaw.run",
+        "openclaw.harness.run",
+        "openclaw.liveness.warning",
+    ]):
+        trace_id = _hex_id(32)
+        payloads.append({
+            "resourceSpans": [{
+                "resource": {"attributes": [
+                    {"key": "service.name", "value": {"stringValue": "openclaw"}},
+                ]},
+                "scopeSpans": [{"spans": [{
+                    "traceId": trace_id, "spanId": _hex_id(16),
+                    "name": root_name, "kind": 1,
+                    "startTimeUnixNano": _now_ns(),
+                    "endTimeUnixNano":   _now_ns(1),
+                    "attributes": [],
+                }]}],
+            }]
+        })
+    for p in payloads:
+        _post_json(client, p)
+
+    # All three should land under ONE agent named "openclaw"
+    body = client.get("/v1/agents?window_hours=1").json()
+    openclaw_agents = [a for a in body["agents"] if a["name"] == "openclaw"]
+    assert len(openclaw_agents) == 1
+    assert openclaw_agents[0]["trace_count"] == 3
+
+    # And no agent card for the original phase names
+    other_phase_names = {a["name"] for a in body["agents"]} & {
+        "openclaw.run", "openclaw.harness.run", "openclaw.liveness.warning"
+    }
+    assert other_phase_names == set(), (
+        f"phase names should have folded; still see {other_phase_names}"
+    )
+
+
+def test_openclaw_fold_falls_back_when_service_name_missing(client):
+    """If the resource has no service.name, the fold uses the literal
+    'openclaw' prefix as the identity. Don't drop the rename just
+    because the service name wasn't set."""
+    trace_id = _hex_id(32)
+    payload = {
+        "resourceSpans": [{
+            "resource": {"attributes": []},  # no service.name
+            "scopeSpans": [{"spans": [{
+                "traceId": trace_id, "spanId": _hex_id(16),
+                "name": "openclaw.run", "kind": 1,
+                "startTimeUnixNano": _now_ns(),
+                "endTimeUnixNano":   _now_ns(1),
+                "attributes": [],
+            }]}],
+        }]
+    }
+    _post_json(client, payload)
+    body = client.get("/v1/agents?window_hours=1").json()
+    assert any(a["name"] == "openclaw" for a in body["agents"])
+
+
+def test_non_openclaw_root_names_are_left_alone(client):
+    """The fold must NOT touch other framework names — Mastra,
+    VoltAgent, plain Python SDK agents all keep their identities."""
+    trace_id = _hex_id(32)
+    payload = _otlp_json_payload(trace_id=trace_id, service_name="mastra-app", spans=[{
+        "traceId": trace_id, "spanId": _hex_id(16),
+        "name": "support_bot",  # what a real Mastra agent name looks like
+        "kind": 1,
+        "startTimeUnixNano": _now_ns(),
+        "endTimeUnixNano":   _now_ns(1),
+        "attributes": [],
+    }])
+    _post_json(client, payload)
+    body = client.get("/v1/agents?window_hours=1").json()
+    assert any(a["name"] == "support_bot" for a in body["agents"])
+
+
+def test_child_span_names_unchanged_by_fold(client):
+    """Children inside an OpenClaw trace keep their original names so
+    the span timeline still shows the phase breakdown.
+    """
+    trace_id = _hex_id(32)
+    root_id = _hex_id(16)
+    payload = {
+        "resourceSpans": [{
+            "resource": {"attributes": [
+                {"key": "service.name", "value": {"stringValue": "openclaw"}},
+            ]},
+            "scopeSpans": [{"spans": [
+                {
+                    "traceId": trace_id, "spanId": root_id,
+                    "name": "openclaw.run", "kind": 1,
+                    "startTimeUnixNano": _now_ns(),
+                    "endTimeUnixNano":   _now_ns(2),
+                    "attributes": [],
+                },
+                {
+                    "traceId": trace_id, "spanId": _hex_id(16),
+                    "parentSpanId": root_id,
+                    "name": "openclaw.model.call", "kind": 1,
+                    "startTimeUnixNano": _now_ns(),
+                    "endTimeUnixNano":   _now_ns(1),
+                    "attributes": [
+                        {"key": "openclaw.model", "value": {"stringValue": "qwen2.5:14b"}},
+                    ],
+                },
+            ]}],
+        }]
+    }
+    _post_json(client, payload)
+    trace_uuid = next(
+        t["id"] for t in client.get("/v1/traces").json()
+        if t["id"].replace("-", "") == trace_id
+    )
+    spans = client.get(f"/v1/traces/{trace_uuid}/spans").json()
+    by_id = {s["id"]: s["name"] for s in spans}
+    # Root renamed to "openclaw"; child kept its original name
+    assert "openclaw" in by_id.values()
+    assert "openclaw.model.call" in by_id.values()


### PR DESCRIPTION
Follow-up to #30. Real-world test against `@zistica_lumin_bot` (OpenClaw 2026.5.4 + `@openclaw/diagnostics-otel`) showed the decoder we shipped was too strict-OTel — spans landed in DuckDB but the dashboard rendered `type='custom'` on what were clearly LLM calls, empty input/output columns, and no session grouping.

## Concrete dashboard symptoms before this PR

For a real OpenClaw run on a Telegram message:
- 19× `openclaw.model.call` spans, all `type=custom` (should be `llm`)
- All `input`/`output` columns empty (real prompt + response sat in `metadata`)
- `session_id` null (so /sessions couldn't group the multi-turn chat)

User flagged the trace at `/traces/6c1467c6-2067-2f7d-17bc-b2b773f10488` — caught the regression that automated tests missed because the test fixture used strict-OTel attributes.

## Root cause

OpenClaw's `diagnostics-otel` plugin emits a mix:
- **Strict OTel**: `gen_ai.system`, `gen_ai.request.model`, status, hex IDs ✓
- **Native namespace**: `openclaw.content.*`, `openclaw.session_id`, `openclaw.tool.name`, `openclaw.provider`, etc.

It also emits model-call spans with `SpanKind.INTERNAL` rather than `CLIENT`. Our PR #30 decoder required `CLIENT + gen_ai.*` for `type=llm` — never matched.

## Changes (`otlp_decode.py`)

1. **`_classify_type` reads span name patterns** — `openclaw.model.*` → llm, `openclaw.tool.*` → tool. Existing tool.name / db.system / gen_ai.* rules preserved. Relaxed: gen_ai.* presence alone is enough now (Logfire + Pydantic-AI also emit on INTERNAL).
2. **Model / provider fallbacks** — `openclaw.model` / `openclaw.provider` after the strict OTel keys.
3. **Input / output extraction** — adds `openclaw.content.input_messages`, `.system_prompt`, `.tool_input`, `openclaw.input` (and the output equivalents) to the priority list. Same order as our `@lumin-io/openclaw` TS exporter.
4. **Session ID** — new `_extract_session_id` reads `openclaw.session_id` / `openclaw.channel.id`. Flows into `SpanInput.session_id` so /sessions groups multi-turn OpenClaw chats with no user config.
5. **`_KNOWN_KEYS` expanded** — promoted attributes don't also live in metadata (saves ~150 bytes/span on typical openclaw spans).

## What this does NOT fix

`tokens_input` / `tokens_output` stay `None` for OpenClaw spans — `diagnostics-otel` emits byte counts (`openclaw.model_call.request_bytes` / `response_bytes`), not token counts. Cost calculation accordingly stays `None`. Right fix is upstream in OpenClaw to extract Ollama's `prompt_eval_count` / `eval_count` from the API response and emit them as `gen_ai.usage.*` — separate concern.

## Test plan

- [x] 5 new tests in `tests/test_otlp_ingest.py`:
  - `test_openclaw_model_call_classified_as_llm_via_name`
  - `test_openclaw_content_keys_extracted_to_input_output`
  - `test_openclaw_tool_execution_classified_as_tool`
  - `test_openclaw_session_id_propagates`
  - `test_openclaw_attrs_dont_pollute_metadata`
- [x] **17/17 OTLP tests pass** (was 12 + 5 new)
- [x] **186/186 API tests pass total** (was 181)
- [x] Strict-OTel cases still pass (no regression on `gen_ai.*`-only emitters)
- [ ] Live verification: send a fresh Telegram message through `@zistica_lumin_bot`, verify the new trace shows `type=llm` on model.call spans + `input`/`output` populated