### PR TITLE
fix: scope locality claim to Lumin, not all data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lumin
 
-> Local-first AI agent observability. Runs on your laptop. No account. No data leaves your machine.
+> Local-first AI agent observability. Runs on your laptop. No account, no telemetry — Lumin never ships your traces anywhere.
 
 [![CI](https://github.com/amitbidlan/zistica-lumin/actions/workflows/ci.yml/badge.svg)](https://github.com/amitbidlan/zistica-lumin/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
@@ -42,7 +42,7 @@ my_agent("What is the capital of France?")
 # Trace appears in the dashboard.
 ```
 
-That's it. No account, no API key, no data leaves your laptop.
+That's it. No account, no API key, and Lumin itself never sends your traces anywhere — they live in a DuckDB file on disk. (Whatever LLM provider your agent calls is its own conversation, of course.)
 
 ---
 

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     template: '%s · Lumin',
   },
   description:
-    'Add 2 lines of code, see every step your agent takes. Runs entirely on your laptop. No account, no credit card, no data leaves your machine.',
+    'Add 2 lines of code, see every step your agent takes. Runs entirely on your laptop. No account, no credit card, no telemetry — Lumin never ships your traces anywhere.',
   applicationName: 'Lumin',
   authors: [{ name: 'Zistica Inc.' }],
   keywords: [
@@ -107,7 +107,7 @@ export default function RootLayout({
                 className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500"
                 aria-hidden
               />
-              Your data never leaves this machine.
+              Lumin runs locally · no telemetry, no cloud sync.
             </span>
             <span className="font-mono">
               Apache 2.0 · Zistica Inc. · 2026


### PR DESCRIPTION
## Summary
- Footer + page metadata + README all said \"no data leaves your machine.\" That reads as a blanket promise — but the LLM your agent calls obviously DOES leave the machine when it's a hosted provider like OpenAI, Anthropic, or Ollama Cloud.
- Reword to a claim Lumin can actually keep: Lumin itself never ships traces anywhere — they live in a local DuckDB file. README adds a parenthetical noting that the agent's LLM provider is its own conversation.

## Test plan
- [ ] Refresh dashboard → footer shows "Lumin runs locally · no telemetry, no cloud sync."
- [ ] View page source → meta description matches new wording.
- [ ] README front-matter scans correctly on GitHub render.