### PR TITLE
fix(api): fold openclaw.* root span names into one agent on /v1/spans ingest

### DIFF
--- a/packages/api/routers/spans.py
+++ b/packages/api/routers/spans.py
@@ -68,6 +68,40 @@ def _parse_ts(ts: Optional[str]) -> Optional[datetime]:
     return dt
 
 
+# Known multi-phase frameworks: each emits N distinct root span names
+# per user interaction (``openclaw.run``, ``openclaw.message.processed``,
+# ``openclaw.harness.run``, ``openclaw.context.assembled``,
+# ``openclaw.diagnostic.phase``, ``openclaw.llm`` from this repo's plugin,
+# etc.). Without folding, the agent grid shows 5+ cards for what
+# operators reasonably think of as one agent.
+#
+# This mirrors ``otlp_decode._resolve_agent_identity``; the rule lives
+# in two places so each ingest rail can apply it without depending on
+# the other. ``_insert_span`` is the right home — it sits below both
+# the /v1/spans router and the /v1/otlp router, so any caller that
+# eventually persists a span gets the fold for free.
+_MULTI_PHASE_PREFIXES: tuple[str, ...] = ("openclaw.",)
+
+
+def _fold_agent_identity(name: Optional[str], parent_span_id: Optional[str]) -> Optional[str]:
+    """Collapse multi-phase ROOT span names under a single agent identity.
+
+    Only triggers on root spans (``parent_span_id is None``) — children
+    keep their phase names so the timeline still shows the breakdown.
+    Idempotent: ``openclaw`` itself doesn't start with ``openclaw.`` so
+    re-applying is a no-op (relevant when OTLP-side already folded).
+    """
+    if parent_span_id:
+        return name
+    if not name:
+        return name
+    for prefix in _MULTI_PHASE_PREFIXES:
+        if name.startswith(prefix):
+            # Strip the trailing "." so "openclaw.run" → "openclaw".
+            return prefix.rstrip(".")
+    return name
+
+
 def _resolve_status_and_error(span: SpanInput) -> tuple[str, Optional[str]]:
     error_message = span.error_message or span.error
     if span.status:
@@ -85,6 +119,7 @@ def _insert_span(db: Database, span: SpanInput, project: Optional[str] = None) -
     started_at = _parse_ts(span.started_at)
     ended_at = _parse_ts(span.ended_at)
     metadata_str = json.dumps(span.metadata) if span.metadata is not None else None
+    name = _fold_agent_identity(span.name, span.parent_span_id)
 
     db.execute(
         """
@@ -122,7 +157,7 @@ def _insert_span(db: Database, span: SpanInput, project: Optional[str] = None) -
             trace_id,
             span.parent_span_id,
             span.type or "custom",
-            span.name,
+            name,
             span.input,
             span.output,
             span.model,
@@ -173,6 +208,10 @@ def _upsert_trace_from_span(db: Database, span: SpanInput, project: Optional[str
     is_new_trace = pre_existing is None
 
     if span.parent_span_id is None:
+        # Apply the same fold as _insert_span so trace.name and
+        # span.name stay aligned (the dashboard groups agents by
+        # trace.name; mismatched values would split cards again).
+        folded_name = _fold_agent_identity(span.name, span.parent_span_id)
         db.execute(
             """
             INSERT INTO traces (
@@ -191,7 +230,7 @@ def _upsert_trace_from_span(db: Database, span: SpanInput, project: Optional[str
                 project = COALESCE(EXCLUDED.project, traces.project)
             """,
             [
-                trace_id, span.name, span.input, span.output,
+                trace_id, folded_name, span.input, span.output,
                 started_at, ended_at, span.session_id, ingest_at, project,
             ],
         )

--- a/packages/api/tests/test_ingest.py
+++ b/packages/api/tests/test_ingest.py
@@ -184,3 +184,55 @@ def test_partial_batch_failure_aborts_whole_batch(client):
     # Confirm the good span did NOT land
     r = client.get("/v1/traces/ok-1")
     assert r.status_code == 404
+
+
+def test_openclaw_root_spans_fold_into_one_agent(client):
+    """Three different openclaw.* root-span names ingest as three
+    traces, all named 'openclaw' — agent grid sees one card."""
+    payload = {"spans": [
+        {"id": "t1", "trace_id": "t1", "name": "openclaw.run",
+         "started_at": "2026-05-06T05:00:00Z"},
+        {"id": "t2", "trace_id": "t2", "name": "openclaw.harness.run",
+         "started_at": "2026-05-06T05:00:01Z"},
+        {"id": "t3", "trace_id": "t3", "name": "openclaw.llm",
+         "started_at": "2026-05-06T05:00:02Z"},
+    ]}
+    r = client.post("/v1/spans", json=payload)
+    assert r.status_code == 200
+
+    for tid in ("t1", "t2", "t3"):
+        trace = client.get(f"/v1/traces/{tid}").json()
+        assert trace["name"] == "openclaw", f"{tid} got name={trace['name']!r}"
+
+    spans = client.get("/v1/traces/t1/spans").json()
+    assert spans[0]["name"] == "openclaw"
+
+
+def test_child_openclaw_spans_keep_phase_names(client):
+    """Children of an openclaw root keep their original phase names so
+    the timeline still shows model.call / tool.execution / etc."""
+    payload = {"spans": [
+        {"id": "root", "trace_id": "root", "name": "openclaw.run",
+         "started_at": "2026-05-06T05:00:00Z"},
+        {"id": "child", "trace_id": "root", "parent_span_id": "root",
+         "name": "openclaw.model.call", "type": "llm",
+         "started_at": "2026-05-06T05:00:01Z"},
+    ]}
+    r = client.post("/v1/spans", json=payload)
+    assert r.status_code == 200
+
+    spans = client.get("/v1/traces/root/spans").json()
+    by_id = {s["id"]: s for s in spans}
+    assert by_id["root"]["name"] == "openclaw"
+    assert by_id["child"]["name"] == "openclaw.model.call"
+
+
+def test_non_openclaw_names_pass_through(client):
+    """The fold is namespaced — anything that doesn't start with
+    a known multi-phase prefix is left alone."""
+    r = client.post("/v1/spans", json={"spans": [
+        {"id": "x", "trace_id": "x", "name": "my-custom-agent",
+         "started_at": "2026-05-06T05:00:00Z"},
+    ]})
+    assert r.status_code == 200
+    assert client.get("/v1/traces/x").json()["name"] == "my-custom-agent"


### PR DESCRIPTION
## Summary
- OpenClaw emits 5+ distinct root span names per user interaction (\`openclaw.run\`, \`openclaw.harness.run\`, \`openclaw.message.processed\`, \`openclaw.context.assembled\`, \`openclaw.diagnostic.phase\`, plus \`openclaw.llm\` from \`@lumin-io/openclaw-diagnostics\`). The agent grid groups by trace.name → operators saw 5+ cards for what is conceptually one bot.
- Adds \`_fold_agent_identity\` in \`routers/spans.py\`, applied inside both \`_insert_span\` and \`_upsert_trace_from_span\`. Because both /v1/spans and /v1/otlp persist via these helpers, the fold covers both ingest rails — no per-rail duplication needed.
- Children keep their phase names so the trace timeline still shows the phase breakdown.

## Test plan
- [ ] \`pytest tests/test_ingest.py\` — 3 new tests, full suite stays green at 184.
- [ ] Send 5+ openclaw.* root spans → \`/v1/agents?project=openclaw\` returns one card named \`openclaw\`.
- [ ] Send a child span named \`openclaw.model.call\` → name is preserved on the child.