### PR TITLE
feat(dashboard): chat-shaped trace view + light-mode contrast + URL-backed filters

### DIFF
--- a/packages/dashboard/app/agents/framework/[key]/page.tsx
+++ b/packages/dashboard/app/agents/framework/[key]/page.tsx
@@ -38,6 +38,10 @@ export function generateMetadata({ params }: { params: { key: string } }) {
   return { title: `${projectLabel(params.key)} agents` };
 }
 
+// AgentList reads filters from URL params (window/search/provider) —
+// requires dynamic rendering. See app/agents/page.tsx for context.
+export const dynamic = 'force-dynamic';
+
 /**
  * Dedicated framework view — shows every agent in one project / SDK,
  * with no truncation. Wrapper layout mirrors /agents (max-w-7xl + page

--- a/packages/dashboard/app/agents/page.tsx
+++ b/packages/dashboard/app/agents/page.tsx
@@ -4,6 +4,14 @@ export const metadata = {
   title: 'Agents',
 };
 
+// Force dynamic rendering: AgentList reads filters from URL search params
+// via the URL-backed state hooks, which Next.js requires to be either
+// wrapped in Suspense or rendered dynamically. These pages always need
+// to fetch live data anyway (SWR + WebSocket), so prerendering an empty
+// shell adds no value — making them dynamic is cleaner than scattering
+// Suspense boundaries.
+export const dynamic = 'force-dynamic';
+
 export default function AgentsPage() {
   return (
     <div className="max-w-7xl mx-auto">

--- a/packages/dashboard/app/globals.css
+++ b/packages/dashboard/app/globals.css
@@ -40,6 +40,15 @@
   --wash-violet:   rgba(167, 139, 250, 0.04);
   --wordmark-from: #e7eaee;
   --wordmark-to:   #94a3b8;
+  /* "Thinking" accent used by the chat-shaped trace view's
+     reasoning accordion (and the SpanRow thinking sub-span). Both
+     themes share violet hues so the brand reads consistent —
+     only the contrast swaps. */
+  --thinking-bg:        rgba(167, 139, 250, 0.10);
+  --thinking-bg-hover:  rgba(167, 139, 250, 0.18);
+  --thinking-border:    rgba(167, 139, 250, 0.35);
+  --thinking-fg:        #c4b5fd;
+  --thinking-fg-soft:   #a78bfa;
   /* Color-scheme tells the browser what tone the page is — affects
      native form controls, scrollbars on macOS, and image rendering. */
   color-scheme: dark;
@@ -66,6 +75,15 @@
   --wash-violet:       rgba(139, 92, 246, 0.04);
   --wordmark-from:     #0f172a;
   --wordmark-to:       #475569;
+  /* Light-mode thinking palette: deeper violet text on a faint violet
+     wash so the reasoning text stays readable on a near-white page
+     surface. Without these, the dark-mode lavender-on-deep-violet
+     would render as pale-on-pale and disappear. */
+  --thinking-bg:        rgba(124, 58, 237, 0.06);
+  --thinking-bg-hover:  rgba(124, 58, 237, 0.12);
+  --thinking-border:    rgba(124, 58, 237, 0.30);
+  --thinking-fg:        #5b21b6;
+  --thinking-fg-soft:   #6d28d9;
   color-scheme: light;
 }
 

--- a/packages/dashboard/app/traces/page.tsx
+++ b/packages/dashboard/app/traces/page.tsx
@@ -4,6 +4,10 @@ export const metadata = {
   title: 'Traces',
 };
 
+// See app/agents/page.tsx — TraceList reads filters from URL params,
+// which forces this page out of static prerendering.
+export const dynamic = 'force-dynamic';
+
 export default function TracesPage() {
   return (
     <div className="max-w-7xl mx-auto">

--- a/packages/dashboard/components/AgentList.tsx
+++ b/packages/dashboard/components/AgentList.tsx
@@ -13,6 +13,7 @@ import {
   formatDuration,
 } from '@/lib/api';
 import { useTraceStream, WSMessage, ConnectionState } from '@/lib/websocket';
+import { useUrlNumber, useUrlString } from '@/lib/url-state';
 import Sparkline from '@/components/Sparkline';
 
 const WINDOW_OPTIONS = [
@@ -75,16 +76,16 @@ export default function AgentList({
    * dedicated /agents/framework/[key] route. */
   lockedFramework?: string;
 } = {}) {
-  const [window_, setWindow] = useState(24);
-  const [search, setSearch] = useState('');
-  const [projectFilter,  setProjectFilter]  = useState<string>(lockedFramework ?? 'all');
-  const [providerFilter, setProviderFilter] = useState<string>('all');
-
-  // Keep state in sync if the route prop changes (e.g. client-side
-  // nav from /agents/framework/default → /agents/framework/openclaw).
-  useEffect(() => {
-    if (lockedFramework) setProjectFilter(lockedFramework);
-  }, [lockedFramework]);
+  // Filter state is URL-backed so refresh / deep-link / back-button
+  // preserve what the operator was looking at. ``lockedFramework``
+  // (route param) takes precedence over the URL ``project`` filter
+  // because the dedicated /agents/framework/[key] route IS the
+  // hard-narrowed view.
+  const [window_, setWindow] = useUrlNumber('window', 24);
+  const [search, setSearch] = useUrlString('q', '');
+  const [projectFilterRaw, setProjectFilter] = useUrlString('project', 'all');
+  const [providerFilter, setProviderFilter] = useUrlString('provider', 'all');
+  const projectFilter = lockedFramework ?? projectFilterRaw;
 
   const params = new URLSearchParams();
   params.set('window_hours', String(window_));

--- a/packages/dashboard/components/ChatView.tsx
+++ b/packages/dashboard/components/ChatView.tsx
@@ -117,7 +117,11 @@ function SenderHeader({
 function UserBubble({ text }: { text: string }) {
   return (
     <div className="flex justify-end">
-      <div className="max-w-[80%] rounded-2xl rounded-br-sm bg-[var(--accent-bg,#1f2937)] border border-[var(--border)] px-4 py-2.5 text-sm whitespace-pre-wrap break-words">
+      {/* ``--accent-glow`` is the subtle accent-tinted background that
+          flips between dark and light mode — keeps user bubbles
+          distinguishable from assistant bubbles in both themes
+          without being shouty. */}
+      <div className="max-w-[80%] rounded-2xl rounded-br-sm bg-[var(--accent-glow)] border border-[var(--border)] px-4 py-2.5 text-sm whitespace-pre-wrap break-words">
         <div className="text-[10px] uppercase tracking-wider text-[var(--muted)] mb-1">
           User
         </div>
@@ -138,11 +142,25 @@ function AssistantBubble({ parts }: { parts: ChatAssistantParts }) {
     <div className="flex justify-start">
       <div className="max-w-[80%] space-y-2">
         {hasThinking ? (
-          <div className="rounded-2xl rounded-bl-sm border border-violet-800/60 bg-violet-950/20 overflow-hidden">
+          // Theme-aware reasoning accordion. The violet hue + low-
+          // opacity wash + deep-violet text stays readable in both
+          // light and dark mode because the colors come from
+          // ``--thinking-*`` tokens that flip with ``data-theme``.
+          // Pre-fix this used Tailwind's ``violet-950`` and
+          // ``violet-100`` directly, which collapsed to lavender-on-
+          // pale-violet in light mode and disappeared.
+          <div
+            className="rounded-2xl rounded-bl-sm border overflow-hidden"
+            style={{
+              borderColor: 'var(--thinking-border)',
+              background: 'var(--thinking-bg)',
+            }}
+          >
             <button
               type="button"
               onClick={() => setThinkingOpen(!thinkingOpen)}
-              className="w-full px-4 py-2 flex items-center gap-2 text-xs text-violet-200 hover:bg-violet-900/30 transition-colors"
+              className="w-full px-4 py-2 flex items-center gap-2 text-xs transition-colors hover:[background:var(--thinking-bg-hover)]"
+              style={{ color: 'var(--thinking-fg)' }}
               aria-expanded={thinkingOpen}
             >
               <span aria-hidden>🧠</span>
@@ -153,13 +171,19 @@ function AssistantBubble({ parts }: { parts: ChatAssistantParts }) {
               <span className="ml-auto font-mono">{thinkingOpen ? '−' : '+'}</span>
             </button>
             {thinkingOpen ? (
-              <pre className="px-4 pb-3 text-[12px] font-mono whitespace-pre-wrap break-words text-violet-100 border-t border-violet-800/40">
+              <pre
+                className="px-4 pb-3 text-[12px] font-mono whitespace-pre-wrap break-words border-t"
+                style={{
+                  color: 'var(--thinking-fg)',
+                  borderColor: 'var(--thinking-border)',
+                }}
+              >
                 {parts.thinking}
               </pre>
             ) : null}
           </div>
         ) : null}
-        <div className="rounded-2xl rounded-bl-sm bg-[#0d1014] border border-[var(--border)] px-4 py-2.5 text-sm whitespace-pre-wrap break-words">
+        <div className="rounded-2xl rounded-bl-sm bg-[var(--background-raised)] border border-[var(--border)] px-4 py-2.5 text-sm whitespace-pre-wrap break-words">
           <div className="text-[10px] uppercase tracking-wider text-[var(--muted)] mb-1">
             Assistant
           </div>
@@ -211,7 +235,7 @@ function Avatar({ name }: { name: string }) {
   return (
     <div
       aria-hidden
-      className="h-8 w-8 rounded-full bg-[var(--accent-bg,#1f2937)] border border-[var(--border)] flex items-center justify-center text-xs font-mono"
+      className="h-8 w-8 rounded-full bg-[var(--background-hover)] border border-[var(--border)] flex items-center justify-center text-xs font-mono"
     >
       {initials || '?'}
     </div>

--- a/packages/dashboard/components/ChatView.tsx
+++ b/packages/dashboard/components/ChatView.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+/**
+ * Chat-shaped trace renderer.
+ *
+ * Presents a single trace as a *one-turn conversation*: sender header,
+ * user bubble, optional thinking accordion, assistant bubble. This is
+ * the right view when the underlying agent is conversational
+ * (OpenClaw, Telegram bots, Slack apps) — operators recognize the
+ * shape immediately and don't have to mentally translate from
+ * function-call-shape (Input → Output) into chat-shape.
+ *
+ * The component is fed a single span (the LLM call) plus the parent
+ * trace. Conversation history isn't shown here because it's not on
+ * the span — it's distributed across other traces in the same
+ * session. A future iteration can fetch /v1/sessions/{id}/traces
+ * and render a multi-turn thread.
+ */
+
+import { useState } from 'react';
+import { Span, Trace } from '@/lib/api';
+import {
+  ChatAssistantParts,
+  extractAssistantParts,
+  parseOpenClawPrompt,
+} from '@/lib/chat-shape';
+
+
+export default function ChatView({
+  trace,
+  spans,
+}: {
+  trace: Trace;
+  spans: Span[];
+}) {
+  // The "headline" span for chat view is the LLM call. There's
+  // usually only one per trace under our plugin; if multiple, take
+  // the first ``llm``-typed span.
+  const headline = pickHeadlineSpan(spans);
+  if (!headline) {
+    return (
+      <div className="text-[var(--muted)] text-sm">
+        No LLM span on this trace — chat view needs at least one model call.
+      </div>
+    );
+  }
+  const parsed = parseOpenClawPrompt(headline.input);
+  const assistant = extractAssistantParts(headline);
+
+  return (
+    <div className="space-y-4">
+      <SenderHeader
+        conversation={parsed.conversation}
+        sender={parsed.sender}
+        startedAt={trace.started_at}
+      />
+      <div className="space-y-3">
+        <UserBubble text={parsed.userText} />
+        <AssistantBubble parts={assistant} />
+      </div>
+      <TurnFooter span={headline} />
+    </div>
+  );
+}
+
+
+function pickHeadlineSpan(spans: Span[]): Span | undefined {
+  // Prefer an llm-typed span; fall back to the first span overall.
+  return spans.find((s) => s.type === 'llm') ?? spans[0];
+}
+
+
+// ----- pieces -----------------------------------------------------------
+
+
+function SenderHeader({
+  conversation,
+  sender,
+  startedAt,
+}: {
+  conversation?: Record<string, unknown>;
+  sender?: Record<string, unknown>;
+  startedAt: string | null;
+}) {
+  const senderName =
+    pickString(sender, 'name') ??
+    pickString(sender, 'label') ??
+    pickString(conversation, 'sender');
+  const channel = pickString(conversation, 'chat_id');
+  const messageId = pickString(conversation, 'message_id');
+  const ts = pickString(conversation, 'timestamp');
+
+  if (!senderName && !channel) return null;
+  return (
+    <div className="border border-[var(--border)] rounded p-3 flex items-center justify-between text-xs">
+      <div className="flex items-center gap-3">
+        <Avatar name={senderName ?? 'unknown'} />
+        <div>
+          <div className="font-mono text-sm">{senderName ?? 'Unknown sender'}</div>
+          {channel ? (
+            <div className="text-[var(--muted)] font-mono text-[11px]">
+              via {channel}
+            </div>
+          ) : null}
+        </div>
+      </div>
+      <div className="text-[var(--muted)] font-mono text-[11px] text-right">
+        {ts ? <div>{ts}</div> : null}
+        {messageId ? <div>msg #{messageId}</div> : null}
+        {!ts && startedAt ? <div>{startedAt}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+
+function UserBubble({ text }: { text: string }) {
+  return (
+    <div className="flex justify-end">
+      <div className="max-w-[80%] rounded-2xl rounded-br-sm bg-[var(--accent-bg,#1f2937)] border border-[var(--border)] px-4 py-2.5 text-sm whitespace-pre-wrap break-words">
+        <div className="text-[10px] uppercase tracking-wider text-[var(--muted)] mb-1">
+          User
+        </div>
+        {text || <span className="italic text-[var(--muted)]">(empty)</span>}
+      </div>
+    </div>
+  );
+}
+
+
+function AssistantBubble({ parts }: { parts: ChatAssistantParts }) {
+  // Default-collapsed thinking — reasoning traces are long and most
+  // operators want to see the reply first. Click to expand.
+  const [thinkingOpen, setThinkingOpen] = useState(false);
+  const hasThinking = parts.thinking && parts.thinking.length > 0;
+
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[80%] space-y-2">
+        {hasThinking ? (
+          <div className="rounded-2xl rounded-bl-sm border border-violet-800/60 bg-violet-950/20 overflow-hidden">
+            <button
+              type="button"
+              onClick={() => setThinkingOpen(!thinkingOpen)}
+              className="w-full px-4 py-2 flex items-center gap-2 text-xs text-violet-200 hover:bg-violet-900/30 transition-colors"
+              aria-expanded={thinkingOpen}
+            >
+              <span aria-hidden>🧠</span>
+              <span className="uppercase tracking-wider">Reasoning</span>
+              <span className="text-[var(--muted)] font-mono ml-1">
+                {parts.thinking!.length.toLocaleString()} chars
+              </span>
+              <span className="ml-auto font-mono">{thinkingOpen ? '−' : '+'}</span>
+            </button>
+            {thinkingOpen ? (
+              <pre className="px-4 pb-3 text-[12px] font-mono whitespace-pre-wrap break-words text-violet-100 border-t border-violet-800/40">
+                {parts.thinking}
+              </pre>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="rounded-2xl rounded-bl-sm bg-[#0d1014] border border-[var(--border)] px-4 py-2.5 text-sm whitespace-pre-wrap break-words">
+          <div className="text-[10px] uppercase tracking-wider text-[var(--muted)] mb-1">
+            Assistant
+          </div>
+          {parts.text || <span className="italic text-[var(--muted)]">(no reply)</span>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+function TurnFooter({ span }: { span: Span }) {
+  const md = (span.metadata ?? {}) as Record<string, unknown>;
+  const historyCount = typeof md['openclaw.history_message_count'] === 'number'
+    ? (md['openclaw.history_message_count'] as number)
+    : undefined;
+  const sysPromptChars = typeof md['openclaw.system_prompt_chars'] === 'number'
+    ? (md['openclaw.system_prompt_chars'] as number)
+    : undefined;
+  const thinkingChars = typeof md['openclaw.thinking_chars'] === 'number'
+    ? (md['openclaw.thinking_chars'] as number)
+    : undefined;
+
+  return (
+    <div className="border-t border-[var(--border)] pt-3 flex flex-wrap items-center gap-x-6 gap-y-1 text-[11px] text-[var(--muted)] font-mono">
+      <span>{span.model ?? 'unknown model'}</span>
+      {span.tokens_input != null || span.tokens_output != null ? (
+        <span>
+          {span.tokens_input ?? 0}/{span.tokens_output ?? 0} tok
+        </span>
+      ) : null}
+      {span.duration_ms != null ? <span>{span.duration_ms} ms</span> : null}
+      {historyCount !== undefined ? <span>{historyCount} prior messages</span> : null}
+      {sysPromptChars !== undefined ? <span>{sysPromptChars.toLocaleString()} sysprompt chars</span> : null}
+      {thinkingChars !== undefined ? <span>{thinkingChars.toLocaleString()} thinking chars</span> : null}
+    </div>
+  );
+}
+
+
+function Avatar({ name }: { name: string }) {
+  // First letter of each word, max 2.
+  const initials = name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('');
+  return (
+    <div
+      aria-hidden
+      className="h-8 w-8 rounded-full bg-[var(--accent-bg,#1f2937)] border border-[var(--border)] flex items-center justify-center text-xs font-mono"
+    >
+      {initials || '?'}
+    </div>
+  );
+}
+
+
+function pickString(
+  obj: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  if (!obj) return undefined;
+  const v = obj[key];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}

--- a/packages/dashboard/components/SpanRow.tsx
+++ b/packages/dashboard/components/SpanRow.tsx
@@ -77,7 +77,7 @@ export default function SpanRow({
 
   const rowClass = isThinking
     ? 'w-full text-left px-3 py-2 transition-colors flex items-center gap-3 bg-violet-950/20 hover:bg-violet-950/40 border-l-2 border-violet-700'
-    : 'w-full text-left px-3 py-2 hover:bg-[#111418] transition-colors flex items-center gap-3';
+    : 'w-full text-left px-3 py-2 hover:bg-[var(--background-hover)] transition-colors flex items-center gap-3';
 
   const subtypeBadge = isThinking ? (
     <span
@@ -151,7 +151,7 @@ export default function SpanRow({
       {open && (
         <div
           className={`px-4 pb-3 pt-1 text-xs space-y-3 ${
-            isThinking ? 'bg-violet-950/10 border-l-2 border-violet-800/40' : 'bg-[#0d1014]'
+            isThinking ? 'bg-violet-950/10 border-l-2 border-violet-800/40' : 'bg-[var(--background-raised)]'
           }`}
         >
           {isThinking ? (

--- a/packages/dashboard/components/SpanRow.tsx
+++ b/packages/dashboard/components/SpanRow.tsx
@@ -33,6 +33,32 @@ function thinkingText(input: string | null): string {
   return input;
 }
 
+/**
+ * Pull a model's reasoning trace out of span metadata. Two integrations
+ * use this pattern:
+ *   - @lumin-io/openclaw-diagnostics (typed-hook plugin) writes the
+ *     full thinking blocks to ``openclaw.content.thinking``.
+ *   - Future framework adapters can use ``content.thinking`` as a
+ *     conventional key — we look for both shapes.
+ *
+ * Distinct from the dedicated "thinking" sub-span emitted by the
+ * Anthropic SDK integration (handled above via ``span_subtype ===
+ * 'thinking'``). Reasoning models that don't emit separate spans
+ * still get their reasoning surfaced.
+ */
+function metadataThinking(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== 'object') return null;
+  const md = metadata as Record<string, unknown>;
+  const candidates = [
+    md['openclaw.content.thinking'],
+    md['content.thinking'],
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.length > 0) return c;
+  }
+  return null;
+}
+
 export default function SpanRow({
   span,
   depth,
@@ -135,9 +161,21 @@ export default function SpanRow({
               accent="thinking"
             />
           ) : (
-            span.input != null && span.input !== '' && (
-              <Field label="Input" value={prettyJson(span.input)} />
-            )
+            <>
+              {/* Reasoning trace from metadata (e.g. OpenClaw plugin's
+                  openclaw.content.thinking field). Rendered ABOVE
+                  Input so the operator sees WHY the model answered
+                  before they see the prompt + reply. */}
+              {(() => {
+                const thinking = metadataThinking(span.metadata);
+                return thinking ? (
+                  <Field label="Reasoning" value={thinking} accent="thinking" />
+                ) : null;
+              })()}
+              {span.input != null && span.input !== '' && (
+                <Field label="Input" value={prettyJson(span.input)} />
+              )}
+            </>
           )}
           {!isThinking && span.output != null && span.output !== '' && (
             <Field label="Output" value={prettyJson(span.output)} />

--- a/packages/dashboard/components/TraceDetail.tsx
+++ b/packages/dashboard/components/TraceDetail.tsx
@@ -16,6 +16,8 @@ import {
   formatStartedAt,
 } from '@/lib/api';
 import { useTraceStream, WSMessage } from '@/lib/websocket';
+import { isChatShapedTrace } from '@/lib/chat-shape';
+import ChatView from './ChatView';
 import SpanTimeline from './SpanTimeline';
 
 export default function TraceDetail({ id }: { id: string }) {
@@ -23,7 +25,12 @@ export default function TraceDetail({ id }: { id: string }) {
   const spansKey = `/v1/traces/${id}/spans`;
   const violationsKey = `/v1/violations?trace_id=${id}`;
   const { mutate } = useSWRConfig();
-  const [tab, setTab] = useState<'spans' | 'policy'>('spans');
+  const [tab, setTab] = useState<'spans' | 'chat' | 'policy'>('spans');
+  // Once we've classified this trace as chat-shaped we want the
+  // first render after data loads to land on the Chat tab — but we
+  // shouldn't keep flipping the tab back if the user manually
+  // switches to Spans. ``initialModeApplied`` is the latch.
+  const [initialModeApplied, setInitialModeApplied] = useState(false);
 
   // Subscribe to real-time span events for THIS trace. New spans are
   // appended to the SWR cache, which re-renders SpanTimeline with the
@@ -87,6 +94,20 @@ export default function TraceDetail({ id }: { id: string }) {
     }
   }, [wsState, traceKey, spansKey, mutate]);
 
+  // Auto-default to the Chat tab when the trace is chat-shaped, but
+  // only on first classification — once the operator picks a tab
+  // manually, the latch keeps their choice. Runs after data loads;
+  // the `initialModeApplied` guard prevents flipping back if the
+  // SWR cache revalidates with a different shape.
+  useEffect(() => {
+    if (initialModeApplied) return;
+    if (!traceQ.data || !spansQ.data) return;
+    if (isChatShapedTrace(traceQ.data, spansQ.data)) {
+      setTab('chat');
+    }
+    setInitialModeApplied(true);
+  }, [initialModeApplied, traceQ.data, spansQ.data]);
+
   if (traceQ.error) {
     return (
       <div className="text-red-400">
@@ -100,6 +121,7 @@ export default function TraceDetail({ id }: { id: string }) {
 
   const trace = traceQ.data;
   const spans = spansQ.data;
+  const chatShaped = isChatShapedTrace(trace, spans);
 
   return (
     <div className="space-y-6">
@@ -140,6 +162,15 @@ export default function TraceDetail({ id }: { id: string }) {
 
       <section>
         <div className="flex items-center gap-1 border-b border-[var(--border)] mb-3">
+          {/* The Chat tab is conditional: surfacing it on every trace
+              (e.g. a Python SDK function-call agent) would be noisy.
+              It only appears for chat-shaped traces — chat-shaped
+              integrations also default into it. */}
+          {chatShaped ? (
+            <TabButton active={tab === 'chat'} onClick={() => setTab('chat')}>
+              Chat
+            </TabButton>
+          ) : null}
           <TabButton active={tab === 'spans'} onClick={() => setTab('spans')}>
             Spans ({spans.length})
           </TabButton>
@@ -151,7 +182,9 @@ export default function TraceDetail({ id }: { id: string }) {
           </TabButton>
         </div>
 
-        {tab === 'spans' ? (
+        {tab === 'chat' ? (
+          <ChatView trace={trace} spans={spans} />
+        ) : tab === 'spans' ? (
           spans.length === 0 ? (
             <div className="text-[var(--muted)] text-sm">
               No spans for this trace.

--- a/packages/dashboard/components/TraceList.tsx
+++ b/packages/dashboard/components/TraceList.tsx
@@ -13,6 +13,7 @@ import {
   formatStartedAt,
 } from '@/lib/api';
 import { useTraceStream, WSMessage } from '@/lib/websocket';
+import { useUrlBoolean, useUrlNumber } from '@/lib/url-state';
 
 const COLS =
   'grid grid-cols-[1fr_180px_100px_120px_100px_80px_110px] gap-4 px-4 py-2.5';
@@ -32,9 +33,14 @@ function readStoredPageSize(): number {
 }
 
 export default function TraceList() {
-  const [page, setPage] = useState(0);
+  // URL-backed so refresh, deep links, and back/forward all preserve
+  // the operator's filter set. ``page`` and ``onlyViolated`` go in
+  // the URL directly. ``pageSize`` keeps its existing localStorage
+  // home — it's a personal preference, not a per-view filter, and
+  // shouldn't bloat shared links.
+  const [page, setPage] = useUrlNumber('page', 0);
   const [pageSize, setPageSizeState] = useState(PAGE_SIZE_DEFAULT);
-  const [onlyViolated, setOnlyViolated] = useState(false);
+  const [onlyViolated, setOnlyViolated] = useUrlBoolean('violated', false);
 
   useEffect(() => {
     const stored = readStoredPageSize();
@@ -234,14 +240,14 @@ export default function TraceList() {
             </button>
           ) : null}
           <button
-            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            onClick={() => setPage(Math.max(0, page - 1))}
             disabled={page === 0}
             className="pill disabled:opacity-30 disabled:cursor-not-allowed"
           >
             ← Previous
           </button>
           <button
-            onClick={() => setPage((p) => p + 1)}
+            onClick={() => setPage(page + 1)}
             disabled={!hasMore}
             className="pill disabled:opacity-30 disabled:cursor-not-allowed"
           >

--- a/packages/dashboard/lib/chat-shape.ts
+++ b/packages/dashboard/lib/chat-shape.ts
@@ -1,0 +1,171 @@
+/**
+ * Detect chat-shaped traces and parse their content.
+ *
+ * Most Lumin integrations are *task-shaped* — one input → one output,
+ * no surrounding conversation. But OpenClaw (and any framework that
+ * runs over Telegram / Slack / Discord) is *chat-shaped*: every trace
+ * is one turn in an ongoing conversation, and the model sees prior
+ * history every turn.
+ *
+ * The trace detail page picks a renderer based on the answer to
+ * `isChatShapedTrace(...)`. This avoids per-framework UI forks —
+ * future chat-style integrations (Mastra-chat, VoltAgent-chat) reuse
+ * the same chat view as long as they emit the same metadata signals.
+ *
+ * Signals we look for, ranked by strength:
+ *   1. ``openclaw.history_message_count`` on any span — strongest
+ *      signal, written by ``@lumin-io/openclaw-diagnostics`` at
+ *      every turn.
+ *   2. Presence of ``chat_id`` (Telegram / Slack / Discord conventions)
+ *      anywhere in the input — survives integrations that don't yet
+ *      emit the structured metadata field.
+ *   3. ``span.session_id`` set AND a known chat provider name on the
+ *      trace — fallback for purely heuristic detection.
+ *
+ * Pure functions only — no React, no I/O. Component renders the
+ * result; the helper just classifies and parses.
+ */
+
+import { Span, Trace } from './api';
+
+
+// ----- detection --------------------------------------------------------
+
+
+export function isChatShapedTrace(trace: Trace, spans: Span[]): boolean {
+  for (const s of spans) {
+    if (looksChatShapedFromMetadata(s.metadata)) return true;
+  }
+  // Trace-level metadata fallback (the trace row's own metadata).
+  if (looksChatShapedFromMetadata(trace.metadata)) return true;
+  // Heuristic: a spans list with an openclaw-prefixed span name and
+  // a session_id is chat-shaped even if the metadata didn't survive.
+  const hasOpenClawSpan = spans.some(
+    (s) => (s.name ?? '').startsWith('openclaw'),
+  );
+  if (hasOpenClawSpan && trace.session_id) return true;
+  return false;
+}
+
+function looksChatShapedFromMetadata(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== 'object') return false;
+  const md = metadata as Record<string, unknown>;
+  if (typeof md['openclaw.history_message_count'] === 'number') return true;
+  if (typeof md['chat.history_count'] === 'number') return true;
+  // Also accept the presence of a ``chat_id`` key under nested
+  // ``conversation`` or ``sender`` metadata.
+  const conv = md.conversation;
+  if (conv && typeof conv === 'object' && 'chat_id' in (conv as object)) {
+    return true;
+  }
+  return false;
+}
+
+
+// ----- input parsing ----------------------------------------------------
+//
+// OpenClaw wraps every user prompt with a verbose metadata header:
+//
+//   Conversation info (untrusted metadata):
+//   ```json
+//   { "chat_id": "telegram:...", "message_id": "...", ... }
+//   ```
+//
+//   Sender (untrusted metadata):
+//   ```json
+//   { "label": "...", "id": "...", "name": "..." }
+//   ```
+//
+//   <actual user text>
+//
+// In the generic span detail view operators see the whole wall. The
+// chat view parses it apart so the bubble shows just the user's
+// actual text, with conversation+sender metadata rendered as a small
+// header.
+
+export interface ParsedChatPrompt {
+  conversation?: Record<string, unknown>;
+  sender?: Record<string, unknown>;
+  userText: string;
+}
+
+
+export function parseOpenClawPrompt(prompt: string | null | undefined): ParsedChatPrompt {
+  if (!prompt) return { userText: '' };
+
+  // Pull out the two named JSON blocks. Match either ``json fenced
+  // blocks (most common) or a bare JSON object on the line below the
+  // header. The regex tolerates extra whitespace + supports both
+  // labels in either order.
+  const blocks = extractLabeledJsonBlocks(prompt);
+  let remaining = prompt;
+  for (const b of blocks) {
+    remaining = remaining.replace(b.fullMatch, '');
+  }
+  // After stripping, collapse repeated blank lines and trim.
+  const userText = remaining.replace(/\n{3,}/g, '\n\n').trim();
+
+  return {
+    conversation: blocks.find((b) => /conversation/i.test(b.label))?.parsed,
+    sender: blocks.find((b) => /sender/i.test(b.label))?.parsed,
+    userText: userText || prompt.trim(),
+  };
+}
+
+
+interface LabeledBlock {
+  label: string;
+  parsed: Record<string, unknown> | undefined;
+  fullMatch: string;
+}
+
+
+function extractLabeledJsonBlocks(text: string): LabeledBlock[] {
+  // Match: <label> (untrusted metadata):\n```json\n{...}\n```
+  const re = /([A-Za-z][A-Za-z ]+?)\s*\(untrusted metadata\):\s*```json\s*([\s\S]*?)```/g;
+  const out: LabeledBlock[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text))) {
+    const label = m[1].trim();
+    const body = m[2].trim();
+    let parsed: Record<string, unknown> | undefined;
+    try {
+      const v = JSON.parse(body);
+      if (v && typeof v === 'object' && !Array.isArray(v)) {
+        parsed = v as Record<string, unknown>;
+      }
+    } catch {
+      // Leave parsed undefined; the chat view falls back to the raw text.
+    }
+    out.push({ label, parsed, fullMatch: m[0] });
+  }
+  return out;
+}
+
+
+// ----- assistant content extraction --------------------------------------
+
+
+export interface ChatAssistantParts {
+  thinking?: string;
+  text?: string;
+}
+
+
+/**
+ * Extract the assistant's reasoning + visible reply for chat
+ * rendering. Two sources, in priority order:
+ *   1. ``metadata.openclaw.content.thinking`` — the structured field
+ *      our plugin writes. Cleanest, no parsing needed.
+ *   2. The span's plain ``output`` field as the visible text.
+ */
+export function extractAssistantParts(span: Span): ChatAssistantParts {
+  const md = (span.metadata ?? {}) as Record<string, unknown>;
+  const thinking = typeof md['openclaw.content.thinking'] === 'string'
+    ? (md['openclaw.content.thinking'] as string)
+    : typeof md['content.thinking'] === 'string'
+      ? (md['content.thinking'] as string)
+      : undefined;
+  const text = span.output ?? undefined;
+  return { thinking, text };
+}

--- a/packages/dashboard/lib/url-state.ts
+++ b/packages/dashboard/lib/url-state.ts
@@ -1,0 +1,91 @@
+'use client';
+
+/**
+ * URL-backed state hooks.
+ *
+ * Local ``useState`` for dashboard filters resets every time the
+ * operator refreshes the page — frustrating when they've narrowed a
+ * grid down to "openclaw + ollama + last 7d" and just want to
+ * re-fetch. These hooks source state from the URL search params
+ * instead so refresh, deep links, and browser back/forward all
+ * preserve the operator's filter set.
+ *
+ * Two flavors:
+ *   - ``useUrlString(key, default)`` — string filter (e.g. project,
+ *     provider, search box)
+ *   - ``useUrlNumber(key, default)`` — numeric filter (e.g. activity
+ *     window in hours)
+ *   - ``useUrlBoolean(key, default)`` — boolean toggle (e.g. "only
+ *     violated traces")
+ *
+ * Each behaves like ``useState`` but writes via ``router.replace``
+ * (so the back stack doesn't fill with filter changes). Default
+ * values are NEVER written to the URL — keeps the address bar tidy
+ * for the no-filter common case.
+ */
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback } from 'react';
+
+
+function setOrDelete(
+  params: URLSearchParams,
+  key: string,
+  value: string,
+  defaultValue: string,
+): URLSearchParams {
+  const out = new URLSearchParams(params.toString());
+  if (!value || value === defaultValue) out.delete(key);
+  else out.set(key, value);
+  return out;
+}
+
+
+export function useUrlString(
+  key: string,
+  defaultValue: string,
+): [string, (next: string) => void] {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const value = params.get(key) ?? defaultValue;
+  const setValue = useCallback(
+    (next: string) => {
+      const updated = setOrDelete(params, key, next, defaultValue);
+      const qs = updated.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [params, pathname, router, key, defaultValue],
+  );
+  return [value, setValue];
+}
+
+
+export function useUrlNumber(
+  key: string,
+  defaultValue: number,
+): [number, (next: number) => void] {
+  const [str, setStr] = useUrlString(key, String(defaultValue));
+  const parsed = Number.parseInt(str, 10);
+  const value = Number.isFinite(parsed) ? parsed : defaultValue;
+  const setValue = useCallback((next: number) => setStr(String(next)), [setStr]);
+  return [value, setValue];
+}
+
+
+export function useUrlBoolean(
+  key: string,
+  defaultValue: boolean,
+): [boolean, (next: boolean) => void] {
+  // Encode booleans as "1"/"0" so the URL stays terse. We treat any
+  // non-"1" / non-"true" value as false — generous parsing for hand-
+  // typed deep links.
+  const def = defaultValue ? '1' : '0';
+  const [str, setStr] = useUrlString(key, def);
+  const value = str === '1' || str === 'true';
+  const setValue = useCallback(
+    (next: boolean) => setStr(next ? '1' : '0'),
+    [setStr],
+  );
+  return [value, setValue];
+}


### PR DESCRIPTION
## Summary
Three dashboard improvements driven by the OpenClaw integration work:

### Chat-shaped trace view
- Most Lumin integrations are task-shaped (one input → one output), but agents that run over Telegram/Slack/Discord are chat-shaped. Generic Input/Output panels make operators read a wall of metadata wrappers when they want a chat thread.
- New \`lib/chat-shape.ts\`: detection (\`isChatShapedTrace\`) + parsing (\`parseOpenClawPrompt\`, \`extractAssistantParts\`) helpers.
- New \`components/ChatView.tsx\`: sender header (avatar, channel, message id), user bubble (wrapper stripped), reasoning accordion (collapsed by default), assistant bubble, turn footer with model/tokens/history-count/sysprompt-size/thinking-size.
- Conditional Chat tab on \`TraceDetail\` — only shown for chat-shaped traces, auto-defaults to it on first load.

### Light-mode contrast fix
- ChatView bubbles + SpanRow expanded panel were hardcoded \`bg-[#0d1014]\`/\`#1f2937\`/\`#111418\` — invisible in light mode.
- Routed through existing theme tokens (\`--background-raised\`, \`--background-hover\`, \`--accent-glow\`).
- New \`--thinking-{bg,fg,border}\` token set with separate light/dark values for the violet reasoning accordion (deep-violet text on pale wash for light, lavender on dark wash for dark).

### URL-backed filter persistence
- AgentList (window/search/project/provider) and TraceList (page, only-violated) all stored filters in local \`useState\`. Refresh dropped operators back to the unfiltered grid.
- New \`lib/url-state.ts\` with \`useUrlString\`/\`useUrlNumber\`/\`useUrlBoolean\` hooks. Refresh, deep-links, and browser back/forward all preserve filters; default values stay out of the URL.

## Test plan
- [ ] \`npx tsc --noEmit\` — clean.
- [ ] OpenClaw trace → Chat tab default, sender header + bubbles render.
- [ ] Toggle dashboard to light mode → bubbles readable, reasoning accordion legible.
- [ ] Filter agents grid → refresh → filters persist.
- [ ] Filter trace list → click into trace → back → page + violated filter still set.