### PR TITLE
fix(integrations): drop process.env.LUMIN_HOST from openclaw-diagnostics plugin

### DIFF
--- a/packages/integrations/openclaw-diagnostics/README.md
+++ b/packages/integrations/openclaw-diagnostics/README.md
@@ -59,7 +59,7 @@ All optional, set under `plugins.entries.lumin-diagnostics.config` in `openclaw.
 
 | Key | Default | Description |
 |---|---|---|
-| `host` | `http://localhost:8000` (or `LUMIN_HOST` env) | Lumin API base URL. |
+| `host` | `http://localhost:8000` | Lumin API base URL. Set this in your `openclaw.json` to point at a Lumin instance running anywhere other than the default localhost (e.g. `http://lumin.internal:8000`, `http://host.docker.internal:8000`). |
 | `project` | `openclaw` | Sent as `X-Lumin-Project` so the agent grid groups OpenClaw runs together. |
 | `captureSystemPrompt` | `false` | Whether to write the full system prompt to `metadata.openclaw.content.system_prompt`. Off by default — system prompts are often large and rarely actionable. The character count is captured either way. |
 | `maxContentChars` | `32768` | Per-attribute content cap. Truncated values are tagged `…(truncated)`. |

--- a/packages/integrations/openclaw-diagnostics/src/index.ts
+++ b/packages/integrations/openclaw-diagnostics/src/index.ts
@@ -210,7 +210,17 @@ class LuminClient {
   private failureLogged = false;
 
   constructor(cfg: LuminDiagnosticsConfig) {
-    this.host = (cfg.host || process.env.LUMIN_HOST || DEFAULT_HOST).replace(/\/+$/, "");
+    // Host is sourced from the operator's openclaw.json config only.
+    // Pre-fix this also read process.env.LUMIN_HOST as a fallback,
+    // but ClawHub's static analyzer flagged the env access as
+    // ``suspicious.env_credential_access`` (a false-positive — the
+    // value is a base URL, not a credential — but the trigger was
+    // still firing). The config-only path is functionally
+    // equivalent for every real deployment scenario, including
+    // Docker Compose and Kubernetes, where setting
+    // ``plugins.entries.lumin-diagnostics.config.host`` in the
+    // mounted openclaw.json is the standard pattern.
+    this.host = (cfg.host || DEFAULT_HOST).replace(/\/+$/, "");
     this.project = cfg.project || DEFAULT_PROJECT;
     this.timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
@@ -500,7 +510,7 @@ export default definePluginEntry({
     });
 
     log?.info?.(
-      `lumin-diagnostics: subscribed to llm_input + llm_output → ${cfg.host || process.env.LUMIN_HOST || DEFAULT_HOST}/v1/spans (project=${cfg.project || DEFAULT_PROJECT})`,
+      `lumin-diagnostics: subscribed to llm_input + llm_output → ${cfg.host || DEFAULT_HOST}/v1/spans (project=${cfg.project || DEFAULT_PROJECT})`,
     );
   },
 });


### PR DESCRIPTION
## Summary
ClawHub's static analyzer flagged the env-var read at \`src/index.ts:213\` as \`suspicious.env_credential_access\`. False positive (the value is a base URL, not a credential) but the trigger pushed the release scan into the suspicious bucket, blocking promoted-listing surfaces.

The env-var was a documented config surface for Docker / Kubernetes deployments. In practice every real deployment can set \`plugins.entries.lumin-diagnostics.config.host\` in the mounted \`openclaw.json\` (Compose volumes, K8s ConfigMaps) — same flexibility without the false positive.

## Impact
- Default \`localhost:8000\` path: unchanged.
- \`cfg.host\` users: unchanged.
- \`LUMIN_HOST\` env users: silently fall back to localhost. They'd notice (no traces in their custom Lumin) and migrate to \`cfg.host\`. **Never a crash.**

This is the first of three stacked PRs that together clear all ClawHub scan flags (env access, system-prompt-override pattern match, over-broad tool I/O claim). Targets the plugin branch as base so the diff is reviewable in isolation.

## Test plan
- [ ] \`npm test\` in \`packages/integrations/openclaw-diagnostics\` — 9/9 pass.
- [ ] \`grep -r LUMIN_HOST packages/integrations/openclaw-diagnostics/src\` returns nothing.
- [ ] After publishing the resulting 0.1.3, re-run \`clawhub package readiness @lumin-io/openclaw-diagnostics\` and confirm the static-analysis flag clears.