### PR TITLE
feat(integrations): capture tool I/O via before/after_tool_call typed hooks

### DIFF
--- a/packages/integrations/openclaw-diagnostics/README.md
+++ b/packages/integrations/openclaw-diagnostics/README.md
@@ -11,7 +11,7 @@ This plugin uses a different surface — OpenClaw's typed-hook API (`api.on('llm
 
 ## What you get
 
-Per turn:
+Per LLM turn:
 
 - Prompt text (just this turn's user message — not the whole replayed history)
 - Assistant reply text
@@ -20,6 +20,15 @@ Per turn:
 - Model + provider + harness ID
 - Trace ID stitched from OpenClaw's diagnostic context (so the typed-hook span fuses with whatever else you've ingested via OTel for the same run)
 - Lightweight summary in metadata: `history_message_count`, `system_prompt_chars`, `images_count`
+
+Per tool call:
+
+- Tool name + invocation params (input)
+- Tool result (output) — when the tool succeeds
+- Error message — when the tool fails
+- Duration in ms
+- `toolCallId` and `runId` correlation in metadata
+- Same `trace_id` as the LLM span for the same run, so the dashboard renders the LLM call and its tool invocations as a single trace timeline
 
 ## Installation
 

--- a/packages/integrations/openclaw-diagnostics/src/index.ts
+++ b/packages/integrations/openclaw-diagnostics/src/index.ts
@@ -92,6 +92,23 @@ interface LlmOutputEvent {
   };
 }
 
+interface BeforeToolCallEvent {
+  toolName: string;
+  params: Record<string, unknown>;
+  runId?: string;
+  toolCallId?: string;
+}
+
+interface AfterToolCallEvent {
+  toolName: string;
+  params: Record<string, unknown>;
+  runId?: string;
+  toolCallId?: string;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
+}
+
 interface HookContext {
   runId?: string;
   jobId?: string;
@@ -323,6 +340,72 @@ class PendingLlmRegistry {
 }
 
 
+// ----- pending tool-call registry ---------------------------------------
+//
+// Tools have their own lifecycle: ``before_tool_call`` carries the
+// invocation params; ``after_tool_call`` carries the result + duration.
+// The pair is correlated by ``toolCallId`` (stable across the two
+// events when the host populates it; we fall back to a synthetic key
+// derived from ``runId + toolName + ts`` when it's missing — only
+// matters if a single run somehow fires before/after for two tools
+// with no toolCallId, which the upstream API doesn't actually do).
+
+interface PendingToolCall {
+  startedAt: string;
+  startedAtMs: number;
+  toolName: string;
+  params?: Record<string, unknown>;
+  trace?: HookContext["trace"];
+  runId?: string;
+}
+
+class PendingToolCallRegistry {
+  private byKey = new Map<string, PendingToolCall>();
+  private cleanupHandle: ReturnType<typeof setTimeout> | undefined;
+
+  set(key: string, entry: PendingToolCall): void {
+    this.byKey.set(key, entry);
+    this.scheduleSweep();
+  }
+
+  take(key: string): PendingToolCall | undefined {
+    const v = this.byKey.get(key);
+    if (v) this.byKey.delete(key);
+    return v;
+  }
+
+  size(): number {
+    return this.byKey.size;
+  }
+
+  private scheduleSweep(): void {
+    if (this.cleanupHandle) return;
+    this.cleanupHandle = setTimeout(() => {
+      this.cleanupHandle = undefined;
+      const now = Date.now();
+      for (const [k, v] of this.byKey) {
+        if (now - v.startedAtMs > PENDING_TTL_MS) this.byKey.delete(k);
+      }
+      if (this.byKey.size > 0) this.scheduleSweep();
+    }, PENDING_TTL_MS);
+    if (typeof this.cleanupHandle === "object" && this.cleanupHandle && "unref" in this.cleanupHandle) {
+      (this.cleanupHandle as { unref?: () => void }).unref?.();
+    }
+  }
+}
+
+
+function toolCallKey(runId: string | undefined, toolCallId: string | undefined, toolName: string): string {
+  // Prefer toolCallId — it's the host's canonical identifier and
+  // doesn't collide across concurrent same-tool calls within a run.
+  // When missing, the run+tool fallback is good-enough since OpenClaw
+  // serializes tool calls per agent turn (one before/after pair
+  // outstanding at a time per run).
+  if (toolCallId) return `tcid:${toolCallId}`;
+  return `rt:${runId ?? "_"}::${toolName}`;
+}
+
+
 // ----- per-event translators ---------------------------------------------
 
 function buildSpanFromPair(
@@ -404,6 +487,59 @@ function buildSpanFromPair(
 }
 
 
+function buildSpanFromToolCall(
+  before: PendingToolCall,
+  after: AfterToolCallEvent,
+  cfg: LuminDiagnosticsConfig,
+  hookCtx: HookContext | undefined,
+): Record<string, unknown> {
+  const maxLen = cfg.maxContentChars ?? DEFAULT_MAX_CONTENT_CHARS;
+  const trace = hookCtx?.trace || before.trace;
+  const runId = after.runId ?? before.runId ?? "_";
+  // Tool spans share the run's traceId with the LLM span — that's
+  // exactly what fuses them into one trace timeline on the dashboard.
+  const traceId = asUuid(trace?.traceId, runId);
+  // Each tool call gets its own deterministic spanId derived from
+  // toolCallId + toolName so re-ingest of the same call lands on
+  // the same span row (idempotent like the LLM path).
+  const fp = `${runId}:tool:${after.toolCallId ?? after.toolName}`;
+  const spanId = asUuid(undefined, fp);
+  // Parent: the run's root span (so the tool call nests under the
+  // openclaw run in the timeline). We DON'T use trace.spanId as the
+  // parent because that's our own llm-call's spanId in the registry
+  // — we want the run-level parent. Falls back to undefined if the
+  // hook context didn't expose one; the dashboard still renders the
+  // tool span as a top-level entry under the openclaw trace.
+  const parentId = trace?.parentSpanId
+    ? asUuid(trace.parentSpanId, runId)
+    : undefined;
+
+  const isError = typeof after.error === "string" && after.error.length > 0;
+
+  return {
+    id: spanId,
+    trace_id: traceId,
+    parent_span_id: parentId,
+    name: "openclaw.tool.call",
+    type: "tool",
+    started_at: before.startedAt,
+    ended_at: nowIso(),
+    status: isError ? "error" : "ok",
+    error_message: isError ? after.error : undefined,
+    tool_name: after.toolName,
+    input: stringify(before.params ?? after.params ?? {}, maxLen),
+    output: after.result !== undefined ? stringify(after.result, maxLen) : undefined,
+    session_id: hookCtx?.sessionId,
+    duration_ms: after.durationMs,
+    metadata: {
+      "openclaw.runId": runId,
+      "openclaw.toolCallId": after.toolCallId,
+      "openclaw.toolName": after.toolName,
+    },
+  };
+}
+
+
 // ----- plugin entry -------------------------------------------------------
 
 export default definePluginEntry({
@@ -434,6 +570,7 @@ export default definePluginEntry({
     const cfg: LuminDiagnosticsConfig = apiAny.pluginConfig || {};
     const client = new LuminClient(cfg);
     const pending = new PendingLlmRegistry();
+    const toolPending = new PendingToolCallRegistry();
     const log = apiAny.logger;
 
     if (typeof apiAny.on !== "function") {
@@ -509,8 +646,55 @@ export default definePluginEntry({
       }
     });
 
+    // Tool hooks. Pair before/after via toolCallId (or runId+toolName
+    // fallback when the host doesn't populate it). The before-hook
+    // captures the params + start time; the after-hook attaches the
+    // result + duration and ships the span. ``before_tool_call`` and
+    // ``after_tool_call`` aren't conversation-gated upstream, so they
+    // register without any extra config beyond what llm_input already
+    // required for this plugin.
+    apiAny.on("before_tool_call", (rawEvent: unknown, rawCtx: unknown) => {
+      try {
+        const event = rawEvent as BeforeToolCallEvent;
+        const ctx = rawCtx as HookContext | undefined;
+        toolPending.set(toolCallKey(event.runId, event.toolCallId, event.toolName), {
+          startedAt: nowIso(),
+          startedAtMs: Date.now(),
+          toolName: event.toolName,
+          params: event.params,
+          trace: ctx?.trace,
+          runId: event.runId,
+        });
+      } catch (err) {
+        log?.warn?.(`lumin-diagnostics: before_tool_call handler failed: ${(err as Error).message}`);
+      }
+    });
+
+    apiAny.on("after_tool_call", (rawEvent: unknown, rawCtx: unknown) => {
+      try {
+        const event = rawEvent as AfterToolCallEvent;
+        const ctx = rawCtx as HookContext | undefined;
+        const key = toolCallKey(event.runId, event.toolCallId, event.toolName);
+        const entry = toolPending.take(key) ?? {
+          // Orphan after-call (e.g. before-hook missed because the
+          // plugin loaded mid-run). Synthesize a zero-duration entry
+          // so the span still reports the result + tool name.
+          startedAt: nowIso(),
+          startedAtMs: Date.now(),
+          toolName: event.toolName,
+          params: event.params,
+          trace: ctx?.trace,
+          runId: event.runId,
+        };
+        const span = buildSpanFromToolCall(entry, event, cfg, ctx);
+        void client.send(span).catch(() => {});
+      } catch (err) {
+        log?.warn?.(`lumin-diagnostics: after_tool_call handler failed: ${(err as Error).message}`);
+      }
+    });
+
     log?.info?.(
-      `lumin-diagnostics: subscribed to llm_input + llm_output → ${cfg.host || DEFAULT_HOST}/v1/spans (project=${cfg.project || DEFAULT_PROJECT})`,
+      `lumin-diagnostics: subscribed to llm_input + llm_output + before_tool_call + after_tool_call → ${cfg.host || DEFAULT_HOST}/v1/spans (project=${cfg.project || DEFAULT_PROJECT})`,
     );
   },
 });

--- a/packages/integrations/openclaw-diagnostics/tests/plugin.test.ts
+++ b/packages/integrations/openclaw-diagnostics/tests/plugin.test.ts
@@ -30,6 +30,8 @@ import luminPlugin from "../src/index";
 interface RegisteredHooks {
   llm_input?: (event: unknown, ctx: unknown) => unknown;
   llm_output?: (event: unknown, ctx: unknown) => unknown;
+  before_tool_call?: (event: unknown, ctx: unknown) => unknown;
+  after_tool_call?: (event: unknown, ctx: unknown) => unknown;
 }
 
 interface FakeApi {
@@ -49,6 +51,8 @@ function buildFakeApi(pluginConfig?: Record<string, unknown>): {
     on: (name, handler) => {
       if (name === "llm_input") hooks.llm_input = handler;
       else if (name === "llm_output") hooks.llm_output = handler;
+      else if (name === "before_tool_call") hooks.before_tool_call = handler;
+      else if (name === "after_tool_call") hooks.after_tool_call = handler;
     },
   };
   return { api, hooks };
@@ -78,14 +82,16 @@ afterEach(() => {
 
 
 describe("plugin registration", () => {
-  test("subscribes to llm_input and llm_output", () => {
+  test("subscribes to llm + tool hooks", () => {
     const { api, hooks } = buildFakeApi();
     // @ts-expect-error - register is on the definePluginEntry options
     luminPlugin.register(api);
     expect(typeof hooks.llm_input).toBe("function");
     expect(typeof hooks.llm_output).toBe("function");
+    expect(typeof hooks.before_tool_call).toBe("function");
+    expect(typeof hooks.after_tool_call).toBe("function");
     expect(api.logger.info).toHaveBeenCalledWith(
-      expect.stringMatching(/subscribed to llm_input \+ llm_output/),
+      expect.stringMatching(/subscribed to llm_input \+ llm_output \+ before_tool_call \+ after_tool_call/),
     );
   });
 
@@ -363,5 +369,113 @@ describe("error swallowing (Rule 7)", () => {
       ),
     ).not.toThrow();
     await new Promise((r) => setTimeout(r, 5));
+  });
+});
+
+
+// ----- tool capture -----------------------------------------------------
+
+
+describe("tool I/O capture", () => {
+  test("before/after tool pair produces a single span with input + output", async () => {
+    const { api, hooks } = buildFakeApi({ host: "http://lumin.test" });
+    // @ts-expect-error
+    luminPlugin.register(api);
+
+    const ctx = {
+      runId: "run-tool-1",
+      trace: { traceId: "0123456789abcdef0123456789abcdef" },
+    };
+    hooks.before_tool_call!(
+      {
+        runId: "run-tool-1",
+        toolCallId: "tc-1",
+        toolName: "web.search",
+        params: { query: "weather tokyo" },
+      },
+      ctx,
+    );
+    hooks.after_tool_call!(
+      {
+        runId: "run-tool-1",
+        toolCallId: "tc-1",
+        toolName: "web.search",
+        params: { query: "weather tokyo" },
+        result: { temp: 18, condition: "cloudy" },
+        durationMs: 142,
+      },
+      ctx,
+    );
+
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const span = body.spans[0];
+    expect(span.type).toBe("tool");
+    expect(span.name).toBe("openclaw.tool.call");
+    expect(span.tool_name).toBe("web.search");
+    // Input is the params, JSON-stringified
+    expect(span.input).toContain("weather tokyo");
+    // Output is the result, JSON-stringified
+    expect(span.output).toContain("cloudy");
+    expect(span.output).toContain("18");
+    expect(span.duration_ms).toBe(142);
+    expect(span.status).toBe("ok");
+    // Trace id derived from the same OpenClaw traceId as model spans
+    // would use, so the dashboard fuses them into one timeline.
+    expect(span.trace_id).toBe("01234567-89ab-cdef-0123-456789abcdef");
+  });
+
+  test("tool error propagates as error-status span with error_message", async () => {
+    const { api, hooks } = buildFakeApi();
+    // @ts-expect-error
+    luminPlugin.register(api);
+
+    hooks.before_tool_call!(
+      { runId: "r2", toolCallId: "tc-2", toolName: "code.exec",
+        params: { script: "raise SystemExit" } },
+      undefined,
+    );
+    hooks.after_tool_call!(
+      { runId: "r2", toolCallId: "tc-2", toolName: "code.exec",
+        params: { script: "raise SystemExit" },
+        error: "process exited with non-zero status",
+        durationMs: 50 },
+      undefined,
+    );
+
+    await new Promise((r) => setTimeout(r, 5));
+    const span = JSON.parse(fetchMock.mock.calls[0][1].body).spans[0];
+    expect(span.status).toBe("error");
+    expect(span.error_message).toBe("process exited with non-zero status");
+    // Output is undefined for failed calls, but tool_name + input
+    // still surface so the operator can see what was attempted.
+    expect(span.output).toBeUndefined();
+    expect(span.tool_name).toBe("code.exec");
+    expect(span.input).toContain("raise SystemExit");
+  });
+
+  test("orphan after_tool_call (no before) still emits a span", async () => {
+    const { api, hooks } = buildFakeApi();
+    // @ts-expect-error
+    luminPlugin.register(api);
+
+    // Simulate the plugin loading mid-run: after-hook fires without
+    // a matching before. The span should still ship using the
+    // params from the after event.
+    hooks.after_tool_call!(
+      { runId: "r3", toolCallId: "tc-3", toolName: "fs.read",
+        params: { path: "/etc/hosts" },
+        result: "127.0.0.1 localhost",
+        durationMs: 12 },
+      undefined,
+    );
+
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const span = JSON.parse(fetchMock.mock.calls[0][1].body).spans[0];
+    expect(span.tool_name).toBe("fs.read");
+    expect(span.input).toContain("/etc/hosts");
+    expect(span.output).toContain("127.0.0.1");
   });
 });


### PR DESCRIPTION
## Summary
The package description claims \"captures tool I/O\" but the plugin only subscribed to \`llm_input\`/\`llm_output\` until now — tool calls were never recorded. ClawScan flagged this as an \"over-broad marketing claim\" during its review pass.

This PR closes the gap. Each tool call becomes one \`openclaw.tool.call\` span on the same trace_id as the model call that invoked it, so the dashboard renders LLM + tool invocations as one timeline.

Pairing is done via \`toolCallId\` (host's canonical id) with a \`runId+toolName\` fallback. Span shape:

- \`name: openclaw.tool.call\`, \`type: tool\`
- \`input\`: JSON-stringified params
- \`output\`: JSON-stringified result (\`undefined\` on error)
- \`error_message\`: from \`after.error\` on failure
- \`tool_name\`, \`duration_ms\`, \`session_id\` captured

\`PendingToolCallRegistry\` mirrors the existing \`PendingLlmRegistry\` — same 5-min TTL sweep, same idempotent take semantics.

Stacked on #40 (drop env host); base is set accordingly so the diff stays focused.

## Test plan
- [ ] \`npm test\` — 12/12 (was 9 + 3 new): tool success, tool error, orphan-after.
- [ ] Live test on a paired OpenClaw bot that uses tools (e.g. Brave search) → tool spans appear under the run trace, with input args + output JSON visible.