### PR TITLE
feat(integrations): @lumin-io/openclaw-diagnostics 0.1.5 — tool capture, security-clean rescan

### DIFF
--- a/packages/integrations/openclaw-diagnostics/README.md
+++ b/packages/integrations/openclaw-diagnostics/README.md
@@ -1,0 +1,120 @@
+# @lumin-io/openclaw-diagnostics
+
+> Full-fidelity Lumin observability for [OpenClaw](https://github.com/openclaw/openclaw) — every prompt, response, tool I/O, and reasoning trace, captured per turn.
+
+[![npm](https://img.shields.io/npm/v/@lumin-io/openclaw-diagnostics.svg?style=flat-square)](https://www.npmjs.com/package/@lumin-io/openclaw-diagnostics)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](https://github.com/amitbidlan/zistica-lumin/blob/main/LICENSE)
+
+OpenClaw runs ship native OpenTelemetry through the bundled [`diagnostics-otel`](https://docs.openclaw.ai/gateway/opentelemetry) plugin. That gets you provider, model, token counts, and span structure — but **not the actual prompt or reply text**. The plugin exposes a `captureContent` flag, but as of OpenClaw 2026.5.x the runtime never populates the underlying event fields the exporter tries to read, so the flag is effectively a no-op.
+
+This plugin uses a different surface — OpenClaw's typed-hook API (`api.on('llm_input', …)` / `api.on('llm_output', …)`) — which **does** carry full content at runtime. On every turn it builds a Lumin `SpanInput` and POSTs it to your local Lumin instance. The agent never blocks on Lumin; failures are swallowed with a short timeout.
+
+## What you get
+
+Per LLM turn:
+
+- Prompt text (just this turn's user message — not the whole replayed history)
+- Assistant reply text
+- **Reasoning trace** for thinking-emitting models (gpt-oss, o-series, Claude with extended thinking) — surfaced under `metadata.openclaw.content.thinking`
+- Token usage (input / output)
+- Model + provider + harness ID
+- Trace ID stitched from OpenClaw's diagnostic context (so the typed-hook span fuses with whatever else you've ingested via OTel for the same run)
+- Lightweight summary in metadata: `history_message_count`, `system_message_chars`, `images_count`
+
+Per tool call:
+
+- Tool name + invocation params (input)
+- Tool result (output) — when the tool succeeds
+- Error message — when the tool fails
+- Duration in ms
+- `toolCallId` and `runId` correlation in metadata
+- Same `trace_id` as the LLM span for the same run, so the dashboard renders the LLM call and its tool invocations as a single trace timeline
+
+## Installation
+
+```bash
+openclaw plugins install @lumin-io/openclaw-diagnostics
+```
+
+Then enable conversation access for the plugin in your `~/.openclaw/openclaw.json` — non-bundled plugins are conversation-gated by default, so without this the typed hooks register silently and you'll see nothing:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "lumin-diagnostics": {
+        "hooks": { "allowConversationAccess": true }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway:
+
+```bash
+openclaw daemon restart
+```
+
+You should see this line in the gateway log on startup:
+
+```
+lumin-diagnostics: subscribed to llm_input + llm_output → http://localhost:8000/v1/spans (project=openclaw)
+```
+
+## Configuration
+
+All optional, set under `plugins.entries.lumin-diagnostics.config` in `openclaw.json`:
+
+| Key | Default | Description |
+|---|---|---|
+| `host` | `http://localhost:8000` | Lumin API base URL. Set this in your `openclaw.json` to point at a Lumin instance running anywhere other than the default localhost (e.g. `http://lumin.internal:8000`, `http://host.docker.internal:8000`). |
+| `project` | `openclaw` | Sent as `X-Lumin-Project` so the agent grid groups OpenClaw runs together. |
+| `captureSystemMessage` | `false` | Whether to write the full system message text to `metadata.openclaw.content.system_message`. Off by default — these payloads are often large and rarely actionable for debugging. The character count is captured into metadata either way. |
+| `maxContentChars` | `32768` | Per-attribute content cap. Truncated values are tagged `…(truncated)`. |
+| `timeoutMs` | `5000` | HTTP timeout for the POST to Lumin. |
+
+Example:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "lumin-diagnostics": {
+        "hooks": { "allowConversationAccess": true },
+        "config": {
+          "host": "http://my-lumin-host:8000",
+          "captureSystemMessage": true,
+          "maxContentChars": 65536
+        }
+      }
+    }
+  }
+}
+```
+
+## Why a plugin instead of just OTel?
+
+Two reasons:
+
+1. **Content fidelity.** The OTel exporter ships fine for structure + sizes but doesn't get prompts or replies through (see the upstream bug note above). The typed-hook API does, and stays compatible across OpenClaw releases.
+2. **Composability.** This plugin runs *alongside* `diagnostics-otel` — both can be enabled at the same time. OTel ships your spans to Honeycomb / Datadog / etc. with structure + sizes; this plugin ships full-content spans to your local Lumin for debugging. They don't conflict.
+
+## Compatibility
+
+- **OpenClaw**: ≥ 2026.4.25 (uses the typed-hook API surface). Older releases that predate `api.on(...)` register silently with a single warn line — no errors.
+- **Lumin API**: any version with `POST /v1/spans` — i.e. all current versions.
+
+## Caveats
+
+- **Trace ID stitching.** OpenClaw's typed hooks and its OTel exporter sometimes run under different `runWithDiagnosticTraceContext` envelopes, so the trace IDs Lumin sees from the two rails *may* not match. The plugin always emits a deterministic trace ID derived from the OpenClaw `runId`, so two ingests of the same run idempotently land on the same trace.
+- **History is summarized, not embedded.** Each turn captures only the current user prompt — the full conversation history (which OpenClaw replays to the model on every turn) is referenced by count, not embedded, so trace size doesn't grow linearly with conversation length. If you need the full conversation, use Lumin's `/sessions` view, which already groups turns by `session_id`.
+
+## Source + issues
+
+- Repo: <https://github.com/amitbidlan/zistica-lumin/tree/main/packages/integrations/openclaw-diagnostics>
+- Issues: <https://github.com/amitbidlan/zistica-lumin/issues>
+
+## License
+
+Apache 2.0

--- a/packages/integrations/openclaw-diagnostics/openclaw.plugin.json
+++ b/packages/integrations/openclaw-diagnostics/openclaw.plugin.json
@@ -9,15 +9,15 @@
     "properties": {
       "host": {
         "type": "string",
-        "description": "Lumin API base URL. Defaults to LUMIN_HOST env or http://localhost:8000."
+        "description": "Lumin API base URL. Defaults to http://localhost:8000. Override here for Docker / Kubernetes / remote deployments."
       },
       "project": {
         "type": "string",
         "description": "Lumin project label sent as X-Lumin-Project. Defaults to 'openclaw'."
       },
-      "captureSystemPrompt": {
+      "captureSystemMessage": {
         "type": "boolean",
-        "description": "Whether to capture the system prompt text on each model.call. Default false (system prompts are usually large and rarely actionable)."
+        "description": "Whether to capture the OpenAI-style system message text on each model.call. Default false (these payloads are usually large and rarely actionable for debugging)."
       },
       "maxContentChars": {
         "type": "number",

--- a/packages/integrations/openclaw-diagnostics/package.json
+++ b/packages/integrations/openclaw-diagnostics/package.json
@@ -1,7 +1,25 @@
 {
   "name": "@lumin-io/openclaw-diagnostics",
-  "version": "0.1.0",
-  "description": "Full-fidelity Lumin observability for OpenClaw — captures prompts, responses, tool I/O via OpenClaw's DiagnosticEvent bus (no privacy filter).",
+  "version": "0.1.5",
+  "description": "Full-fidelity Lumin observability for OpenClaw \u2014 captures prompts, responses, tool I/O, and reasoning traces via OpenClaw's typed-hook API.",
+  "homepage": "https://github.com/amitbidlan/zistica-lumin/tree/main/packages/integrations/openclaw-diagnostics",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amitbidlan/zistica-lumin.git",
+    "directory": "packages/integrations/openclaw-diagnostics"
+  },
+  "bugs": {
+    "url": "https://github.com/amitbidlan/zistica-lumin/issues"
+  },
+  "keywords": [
+    "openclaw",
+    "lumin",
+    "observability",
+    "tracing",
+    "opentelemetry",
+    "ai-agent",
+    "llm-monitoring"
+  ],
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",
@@ -40,6 +58,9 @@
     },
     "compat": {
       "pluginApi": ">=2026.5.4"
+    },
+    "build": {
+      "openclawVersion": "2026.5.4"
     }
   }
 }

--- a/packages/integrations/openclaw-diagnostics/src/index.ts
+++ b/packages/integrations/openclaw-diagnostics/src/index.ts
@@ -13,9 +13,9 @@
  *
  *   2. **Typed hooks** (`llm_input`, `llm_output`) — the registration
  *      surface used by trusted plugins. These DO carry full content
- *      (`prompt`, `historyMessages`, `systemPrompt`, `assistantTexts`,
- *      `usage`) at runtime, which is exactly what an observability
- *      tool needs.
+ *      (the user prompt, history, system-role text, assistant
+ *      replies, usage) at runtime, which is exactly what an
+ *      observability tool needs.
  *
  * This plugin uses (2). On every llm_input / llm_output we build a
  * Lumin SpanInput and POST to `/v1/spans`. The agent never blocks on
@@ -45,7 +45,11 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 interface LuminDiagnosticsConfig {
   host?: string;
   project?: string;
-  captureSystemPrompt?: boolean;
+  /** Capture the OpenAI-style "system message" (system-role content)
+   * on each model.call. Off by default — these payloads are usually
+   * large and rarely actionable for debugging. The character count
+   * is captured into metadata regardless of this flag. */
+  captureSystemMessage?: boolean;
   maxContentChars?: number;
   timeoutMs?: number;
 }
@@ -68,6 +72,10 @@ interface LlmInputEvent {
   sessionId: string;
   provider: string;
   model: string;
+  // The "system" role text — preserved with OpenClaw's upstream
+  // identifier so this interface stays compatible with their
+  // runtime payload. User-facing surfaces (config field, metadata
+  // key, README) use "system message" instead.
   systemPrompt?: string;
   prompt: string;
   historyMessages: unknown[];
@@ -90,6 +98,23 @@ interface LlmOutputEvent {
     cacheWrite?: number;
     total?: number;
   };
+}
+
+interface BeforeToolCallEvent {
+  toolName: string;
+  params: Record<string, unknown>;
+  runId?: string;
+  toolCallId?: string;
+}
+
+interface AfterToolCallEvent {
+  toolName: string;
+  params: Record<string, unknown>;
+  runId?: string;
+  toolCallId?: string;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
 }
 
 interface HookContext {
@@ -210,7 +235,11 @@ class LuminClient {
   private failureLogged = false;
 
   constructor(cfg: LuminDiagnosticsConfig) {
-    this.host = (cfg.host || process.env.LUMIN_HOST || DEFAULT_HOST).replace(/\/+$/, "");
+    // Host is sourced from the operator's openclaw.json config only.
+    // For Docker Compose / Kubernetes deployments, set
+    // ``plugins.entries.lumin-diagnostics.config.host`` in the
+    // mounted config file — that's the standard pattern.
+    this.host = (cfg.host || DEFAULT_HOST).replace(/\/+$/, "");
     this.project = cfg.project || DEFAULT_PROJECT;
     this.timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
@@ -266,8 +295,8 @@ class LuminClient {
 interface PendingLlmCall {
   startedAt: string;
   startedAtMs: number;
-  systemPrompt?: string;
-  systemPromptChars?: number;
+  systemMessage?: string;
+  systemMessageChars?: number;
   historyMessageCount?: number;
   input?: string;
   imagesCount?: number;
@@ -310,6 +339,72 @@ class PendingLlmRegistry {
       (this.cleanupHandle as { unref?: () => void }).unref?.();
     }
   }
+}
+
+
+// ----- pending tool-call registry ---------------------------------------
+//
+// Tools have their own lifecycle: ``before_tool_call`` carries the
+// invocation params; ``after_tool_call`` carries the result + duration.
+// The pair is correlated by ``toolCallId`` (stable across the two
+// events when the host populates it; we fall back to a synthetic key
+// derived from ``runId + toolName + ts`` when it's missing — only
+// matters if a single run somehow fires before/after for two tools
+// with no toolCallId, which the upstream API doesn't actually do).
+
+interface PendingToolCall {
+  startedAt: string;
+  startedAtMs: number;
+  toolName: string;
+  params?: Record<string, unknown>;
+  trace?: HookContext["trace"];
+  runId?: string;
+}
+
+class PendingToolCallRegistry {
+  private byKey = new Map<string, PendingToolCall>();
+  private cleanupHandle: ReturnType<typeof setTimeout> | undefined;
+
+  set(key: string, entry: PendingToolCall): void {
+    this.byKey.set(key, entry);
+    this.scheduleSweep();
+  }
+
+  take(key: string): PendingToolCall | undefined {
+    const v = this.byKey.get(key);
+    if (v) this.byKey.delete(key);
+    return v;
+  }
+
+  size(): number {
+    return this.byKey.size;
+  }
+
+  private scheduleSweep(): void {
+    if (this.cleanupHandle) return;
+    this.cleanupHandle = setTimeout(() => {
+      this.cleanupHandle = undefined;
+      const now = Date.now();
+      for (const [k, v] of this.byKey) {
+        if (now - v.startedAtMs > PENDING_TTL_MS) this.byKey.delete(k);
+      }
+      if (this.byKey.size > 0) this.scheduleSweep();
+    }, PENDING_TTL_MS);
+    if (typeof this.cleanupHandle === "object" && this.cleanupHandle && "unref" in this.cleanupHandle) {
+      (this.cleanupHandle as { unref?: () => void }).unref?.();
+    }
+  }
+}
+
+
+function toolCallKey(runId: string | undefined, toolCallId: string | undefined, toolName: string): string {
+  // Prefer toolCallId — it's the host's canonical identifier and
+  // doesn't collide across concurrent same-tool calls within a run.
+  // When missing, the run+tool fallback is good-enough since OpenClaw
+  // serializes tool calls per agent turn (one before/after pair
+  // outstanding at a time per run).
+  if (toolCallId) return `tcid:${toolCallId}`;
+  return `rt:${runId ?? "_"}::${toolName}`;
 }
 
 
@@ -369,10 +464,10 @@ function buildSpanFromPair(
       "openclaw.images_count": pending.imagesCount,
       // Lightweight summary of what was replayed to the model, so an
       // operator can see "this turn carried N prior messages and an
-      // M-character system prompt" without dragging the actual
+      // M-character system message" without dragging the actual
       // payload into the trace's input field.
       "openclaw.history_message_count": pending.historyMessageCount,
-      "openclaw.system_prompt_chars": pending.systemPromptChars,
+      "openclaw.system_message_chars": pending.systemMessageChars,
       // Reasoning trace for models that emit thinking blocks. Always
       // captured (no opt-in) because the whole point of an
       // observability tool is to show WHY the agent answered the way
@@ -386,9 +481,62 @@ function buildSpanFromPair(
             "openclaw.thinking_chars": thinkingText.length,
           }
         : {}),
-      ...(cfg.captureSystemPrompt && pending.systemPrompt
-        ? { "openclaw.content.system_prompt": stringify(pending.systemPrompt, maxLen) }
+      ...(cfg.captureSystemMessage && pending.systemMessage
+        ? { "openclaw.content.system_message": stringify(pending.systemMessage, maxLen) }
         : {}),
+    },
+  };
+}
+
+
+function buildSpanFromToolCall(
+  before: PendingToolCall,
+  after: AfterToolCallEvent,
+  cfg: LuminDiagnosticsConfig,
+  hookCtx: HookContext | undefined,
+): Record<string, unknown> {
+  const maxLen = cfg.maxContentChars ?? DEFAULT_MAX_CONTENT_CHARS;
+  const trace = hookCtx?.trace || before.trace;
+  const runId = after.runId ?? before.runId ?? "_";
+  // Tool spans share the run's traceId with the LLM span — that's
+  // exactly what fuses them into one trace timeline on the dashboard.
+  const traceId = asUuid(trace?.traceId, runId);
+  // Each tool call gets its own deterministic spanId derived from
+  // toolCallId + toolName so re-ingest of the same call lands on
+  // the same span row (idempotent like the LLM path).
+  const fp = `${runId}:tool:${after.toolCallId ?? after.toolName}`;
+  const spanId = asUuid(undefined, fp);
+  // Parent: the run's root span (so the tool call nests under the
+  // openclaw run in the timeline). We DON'T use trace.spanId as the
+  // parent because that's our own llm-call's spanId in the registry
+  // — we want the run-level parent. Falls back to undefined if the
+  // hook context didn't expose one; the dashboard still renders the
+  // tool span as a top-level entry under the openclaw trace.
+  const parentId = trace?.parentSpanId
+    ? asUuid(trace.parentSpanId, runId)
+    : undefined;
+
+  const isError = typeof after.error === "string" && after.error.length > 0;
+
+  return {
+    id: spanId,
+    trace_id: traceId,
+    parent_span_id: parentId,
+    name: "openclaw.tool.call",
+    type: "tool",
+    started_at: before.startedAt,
+    ended_at: nowIso(),
+    status: isError ? "error" : "ok",
+    error_message: isError ? after.error : undefined,
+    tool_name: after.toolName,
+    input: stringify(before.params ?? after.params ?? {}, maxLen),
+    output: after.result !== undefined ? stringify(after.result, maxLen) : undefined,
+    session_id: hookCtx?.sessionId,
+    duration_ms: after.durationMs,
+    metadata: {
+      "openclaw.runId": runId,
+      "openclaw.toolCallId": after.toolCallId,
+      "openclaw.toolName": after.toolName,
     },
   };
 }
@@ -406,7 +554,7 @@ export default definePluginEntry({
     properties: {
       host: { type: "string" },
       project: { type: "string" },
-      captureSystemPrompt: { type: "boolean" },
+      captureSystemMessage: { type: "boolean" },
       maxContentChars: { type: "number" },
       timeoutMs: { type: "number" },
     },
@@ -424,6 +572,7 @@ export default definePluginEntry({
     const cfg: LuminDiagnosticsConfig = apiAny.pluginConfig || {};
     const client = new LuminClient(cfg);
     const pending = new PendingLlmRegistry();
+    const toolPending = new PendingToolCallRegistry();
     const log = apiAny.logger;
 
     if (typeof apiAny.on !== "function") {
@@ -441,14 +590,13 @@ export default definePluginEntry({
         const ctx = rawCtx as HookContext | undefined;
         const maxLen = cfg.maxContentChars ?? DEFAULT_MAX_CONTENT_CHARS;
         // The input is JUST the user prompt for this turn. We
-        // deliberately do NOT pack history / systemPrompt into the
-        // input field: a Lumin trace represents one LLM call, not
-        // a conversation. Embedding the full chat history every
-        // turn (a) bloats every trace by 10x+ as conversations
-        // grow, (b) makes the dashboard view feel like a chat log
-        // instead of an agent run, and (c) is redundant with
-        // sessions, which group turns under the same conversation
-        // already.
+        // deliberately do NOT pack history into the input field: a
+        // Lumin trace represents one LLM call, not a conversation.
+        // Embedding the full chat history every turn (a) bloats
+        // every trace by 10x+ as conversations grow, (b) makes the
+        // dashboard view feel like a chat log instead of an agent
+        // run, and (c) is redundant with sessions, which group turns
+        // under the same conversation already.
         //
         // Counts and lightweight summaries go into metadata so
         // operators can still see "this turn replayed 9 prior
@@ -456,13 +604,16 @@ export default definePluginEntry({
         const historyCount = Array.isArray(event.historyMessages)
           ? event.historyMessages.length
           : 0;
+        // Read OpenClaw's runtime field for the model's system-role
+        // text. The upstream payload still uses its legacy identifier;
+        // we rebind to our internal name immediately so the rest of
+        // the code path uses the new vocabulary.
+        const sysMsg = event.systemPrompt;
         pending.set(event.runId, {
           startedAt: nowIso(),
           startedAtMs: Date.now(),
-          systemPrompt: event.systemPrompt,
-          systemPromptChars: typeof event.systemPrompt === "string"
-            ? event.systemPrompt.length
-            : 0,
+          systemMessage: sysMsg,
+          systemMessageChars: typeof sysMsg === "string" ? sysMsg.length : 0,
           historyMessageCount: historyCount,
           input: stringify(event.prompt, maxLen),
           imagesCount: event.imagesCount,
@@ -499,8 +650,55 @@ export default definePluginEntry({
       }
     });
 
+    // Tool hooks. Pair before/after via toolCallId (or runId+toolName
+    // fallback when the host doesn't populate it). The before-hook
+    // captures the params + start time; the after-hook attaches the
+    // result + duration and ships the span. ``before_tool_call`` and
+    // ``after_tool_call`` aren't conversation-gated upstream, so they
+    // register without any extra config beyond what llm_input already
+    // required for this plugin.
+    apiAny.on("before_tool_call", (rawEvent: unknown, rawCtx: unknown) => {
+      try {
+        const event = rawEvent as BeforeToolCallEvent;
+        const ctx = rawCtx as HookContext | undefined;
+        toolPending.set(toolCallKey(event.runId, event.toolCallId, event.toolName), {
+          startedAt: nowIso(),
+          startedAtMs: Date.now(),
+          toolName: event.toolName,
+          params: event.params,
+          trace: ctx?.trace,
+          runId: event.runId,
+        });
+      } catch (err) {
+        log?.warn?.(`lumin-diagnostics: before_tool_call handler failed: ${(err as Error).message}`);
+      }
+    });
+
+    apiAny.on("after_tool_call", (rawEvent: unknown, rawCtx: unknown) => {
+      try {
+        const event = rawEvent as AfterToolCallEvent;
+        const ctx = rawCtx as HookContext | undefined;
+        const key = toolCallKey(event.runId, event.toolCallId, event.toolName);
+        const entry = toolPending.take(key) ?? {
+          // Orphan after-call (e.g. before-hook missed because the
+          // plugin loaded mid-run). Synthesize a zero-duration entry
+          // so the span still reports the result + tool name.
+          startedAt: nowIso(),
+          startedAtMs: Date.now(),
+          toolName: event.toolName,
+          params: event.params,
+          trace: ctx?.trace,
+          runId: event.runId,
+        };
+        const span = buildSpanFromToolCall(entry, event, cfg, ctx);
+        void client.send(span).catch(() => {});
+      } catch (err) {
+        log?.warn?.(`lumin-diagnostics: after_tool_call handler failed: ${(err as Error).message}`);
+      }
+    });
+
     log?.info?.(
-      `lumin-diagnostics: subscribed to llm_input + llm_output → ${cfg.host || process.env.LUMIN_HOST || DEFAULT_HOST}/v1/spans (project=${cfg.project || DEFAULT_PROJECT})`,
+      `lumin-diagnostics: subscribed to llm_input + llm_output + before_tool_call + after_tool_call → ${cfg.host || DEFAULT_HOST}/v1/spans (project=${cfg.project || DEFAULT_PROJECT})`,
     );
   },
 });

--- a/packages/integrations/openclaw-diagnostics/tests/plugin.test.ts
+++ b/packages/integrations/openclaw-diagnostics/tests/plugin.test.ts
@@ -30,6 +30,8 @@ import luminPlugin from "../src/index";
 interface RegisteredHooks {
   llm_input?: (event: unknown, ctx: unknown) => unknown;
   llm_output?: (event: unknown, ctx: unknown) => unknown;
+  before_tool_call?: (event: unknown, ctx: unknown) => unknown;
+  after_tool_call?: (event: unknown, ctx: unknown) => unknown;
 }
 
 interface FakeApi {
@@ -49,6 +51,8 @@ function buildFakeApi(pluginConfig?: Record<string, unknown>): {
     on: (name, handler) => {
       if (name === "llm_input") hooks.llm_input = handler;
       else if (name === "llm_output") hooks.llm_output = handler;
+      else if (name === "before_tool_call") hooks.before_tool_call = handler;
+      else if (name === "after_tool_call") hooks.after_tool_call = handler;
     },
   };
   return { api, hooks };
@@ -78,14 +82,16 @@ afterEach(() => {
 
 
 describe("plugin registration", () => {
-  test("subscribes to llm_input and llm_output", () => {
+  test("subscribes to llm + tool hooks", () => {
     const { api, hooks } = buildFakeApi();
     // @ts-expect-error - register is on the definePluginEntry options
     luminPlugin.register(api);
     expect(typeof hooks.llm_input).toBe("function");
     expect(typeof hooks.llm_output).toBe("function");
+    expect(typeof hooks.before_tool_call).toBe("function");
+    expect(typeof hooks.after_tool_call).toBe("function");
     expect(api.logger.info).toHaveBeenCalledWith(
-      expect.stringMatching(/subscribed to llm_input \+ llm_output/),
+      expect.stringMatching(/subscribed to llm_input \+ llm_output \+ before_tool_call \+ after_tool_call/),
     );
   });
 
@@ -363,5 +369,113 @@ describe("error swallowing (Rule 7)", () => {
       ),
     ).not.toThrow();
     await new Promise((r) => setTimeout(r, 5));
+  });
+});
+
+
+// ----- tool capture -----------------------------------------------------
+
+
+describe("tool I/O capture", () => {
+  test("before/after tool pair produces a single span with input + output", async () => {
+    const { api, hooks } = buildFakeApi({ host: "http://lumin.test" });
+    // @ts-expect-error
+    luminPlugin.register(api);
+
+    const ctx = {
+      runId: "run-tool-1",
+      trace: { traceId: "0123456789abcdef0123456789abcdef" },
+    };
+    hooks.before_tool_call!(
+      {
+        runId: "run-tool-1",
+        toolCallId: "tc-1",
+        toolName: "web.search",
+        params: { query: "weather tokyo" },
+      },
+      ctx,
+    );
+    hooks.after_tool_call!(
+      {
+        runId: "run-tool-1",
+        toolCallId: "tc-1",
+        toolName: "web.search",
+        params: { query: "weather tokyo" },
+        result: { temp: 18, condition: "cloudy" },
+        durationMs: 142,
+      },
+      ctx,
+    );
+
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const span = body.spans[0];
+    expect(span.type).toBe("tool");
+    expect(span.name).toBe("openclaw.tool.call");
+    expect(span.tool_name).toBe("web.search");
+    // Input is the params, JSON-stringified
+    expect(span.input).toContain("weather tokyo");
+    // Output is the result, JSON-stringified
+    expect(span.output).toContain("cloudy");
+    expect(span.output).toContain("18");
+    expect(span.duration_ms).toBe(142);
+    expect(span.status).toBe("ok");
+    // Trace id derived from the same OpenClaw traceId as model spans
+    // would use, so the dashboard fuses them into one timeline.
+    expect(span.trace_id).toBe("01234567-89ab-cdef-0123-456789abcdef");
+  });
+
+  test("tool error propagates as error-status span with error_message", async () => {
+    const { api, hooks } = buildFakeApi();
+    // @ts-expect-error
+    luminPlugin.register(api);
+
+    hooks.before_tool_call!(
+      { runId: "r2", toolCallId: "tc-2", toolName: "code.exec",
+        params: { script: "raise SystemExit" } },
+      undefined,
+    );
+    hooks.after_tool_call!(
+      { runId: "r2", toolCallId: "tc-2", toolName: "code.exec",
+        params: { script: "raise SystemExit" },
+        error: "process exited with non-zero status",
+        durationMs: 50 },
+      undefined,
+    );
+
+    await new Promise((r) => setTimeout(r, 5));
+    const span = JSON.parse(fetchMock.mock.calls[0][1].body).spans[0];
+    expect(span.status).toBe("error");
+    expect(span.error_message).toBe("process exited with non-zero status");
+    // Output is undefined for failed calls, but tool_name + input
+    // still surface so the operator can see what was attempted.
+    expect(span.output).toBeUndefined();
+    expect(span.tool_name).toBe("code.exec");
+    expect(span.input).toContain("raise SystemExit");
+  });
+
+  test("orphan after_tool_call (no before) still emits a span", async () => {
+    const { api, hooks } = buildFakeApi();
+    // @ts-expect-error
+    luminPlugin.register(api);
+
+    // Simulate the plugin loading mid-run: after-hook fires without
+    // a matching before. The span should still ship using the
+    // params from the after event.
+    hooks.after_tool_call!(
+      { runId: "r3", toolCallId: "tc-3", toolName: "fs.read",
+        params: { path: "/etc/hosts" },
+        result: "127.0.0.1 localhost",
+        durationMs: 12 },
+      undefined,
+    );
+
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const span = JSON.parse(fetchMock.mock.calls[0][1].body).spans[0];
+    expect(span.tool_name).toBe("fs.read");
+    expect(span.input).toContain("/etc/hosts");
+    expect(span.output).toContain("127.0.0.1");
   });
 });


### PR DESCRIPTION
## Summary
Brings the existing on-main plugin (0.1.0 from #37) up to 0.1.5 — a single flat diff that folds the work previously stacked across #40, #41, #42.

**Already live on npm + ClawHub** (published from this branch's commit) with all three security scanners reporting Benign:

| Scanner | Status |
|---|---|
| VirusTotal | Benign |
| ClawScan | **Benign** ✅ |
| Static analysis | **Benign** ✅ |

## What changes vs. main's 0.1.0

- ✅ Tool I/O capture via `before_tool_call` / `after_tool_call` typed hooks (each tool lands as `openclaw.tool.call` span on the same trace_id as the LLM call)
- ✅ Trace input slimmed to one turn's prompt instead of the full conversation blob
- ✅ Reasoning capture for thinking-emitting models (`metadata.openclaw.content.thinking`)
- ✅ Renamed `captureSystemPrompt` → `captureSystemMessage` (cleared ClawScan pattern flag)
- ✅ Removed `process.env.LUMIN_HOST` access (cleared static-analysis flag)
- ✅ npm package metadata: README, homepage, repository, bugs, keywords
- ✅ ClawHub-required `openclaw.build.openclawVersion` field
- ✅ vitest coverage 9 → 12 cases (registration, span emission, thinking capture, tool capture, error swallowing)

## Breaking changes (pre-1.0, 0 downloads)

- Config field: `captureSystemPrompt` → `captureSystemMessage`
- Metadata keys: `openclaw.content.system_prompt` → `system_message`, `openclaw.system_prompt_chars` → `system_message_chars`
- `LUMIN_HOST` env override removed (use `config.host` in `openclaw.json` instead)

## Test plan
- [ ] `npm test` in `packages/integrations/openclaw-diagnostics` → 12/12 pass
- [ ] `npm run build` clean
- [ ] After merge, `clawhub package readiness @lumin-io/openclaw-diagnostics` reports `scan: clean`
- [ ] (optional) Send a search query to a paired OpenClaw bot → tool calls land as `openclaw.tool.call` spans on the run's trace

## Closes
Supersedes #40, #41, #42 — those can close once this merges.