### PR TITLE
feat(firewall): decide engine + HTTP surface + OWASP starter pack (Slice 1 part 2)

### DIFF
--- a/packages/api/firewall/decide.py
+++ b/packages/api/firewall/decide.py
@@ -1,0 +1,671 @@
+"""Synchronous decision engine — heart of the Agent Firewall.
+
+Implements §5.1 (`POST /v1/policy/decide`) and §10.1–10.3 (mode,
+panic disable, circuit breaker). Stateless and import-safe; the HTTP
+layer in ``routers/firewall.py`` owns request/response shapes and
+DB connection plumbing.
+
+Decision flow for a single request:
+
+  1. Honor the global panic kill-switch — if set, return allow with
+     reason="panic_disabled" and skip the engine entirely. (§10.2)
+  2. Filter policies by ``lifecycle == request.lifecycle``, by
+     ``circuit_breaker_state == 'ok'``, and (when ``request.agent``
+     is set) by scope_agents membership.
+  3. Sort by ``priority DESC`` so high-priority policies see the
+     request first. Ties broken by name for determinism.
+  4. Evaluate each policy's condition with a fresh simpleeval. The
+     namespace is built from the request payload + the firewall
+     builtins from ``firewall.builtins`` (stateless + history-backed).
+  5. First non-allow decision wins; an explicit ``allow`` short-
+     circuits remaining lower-priority policies.
+  6. Apply mode: ``shadow`` records the decision but returns allow;
+     ``flag`` records and returns flag; ``enforce`` records and
+     returns the policy's action verbatim.
+  7. Hard timeout per lifecycle (§2.4). If the wall clock exceeds
+     the budget mid-loop, abort and return allow (Rule 7 — agent
+     never blocks on Lumin).
+
+Every error path returns allow. Internal exceptions are logged but
+swallowed; the agent that called us never fails because of us.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from lumin.policy import Policy
+
+import policy_store
+from db import Database
+
+from firewall import builtins as fw_builtins
+
+logger = logging.getLogger("lumin.api.firewall.decide")
+
+
+# ---- valid decision values ------------------------------------------------
+
+VALID_DECISIONS = frozenset({
+    "allow", "block", "flag", "require_approval", "rewrite",
+})
+
+
+# Per-lifecycle wall-clock budget in milliseconds. From §2.4 of the
+# spec: B/C 50ms, D 100ms, E 300ms. post_ingest has no real-time
+# budget but we cap it at 500ms so a runaway condition can't pin a
+# request thread.
+LATENCY_BUDGET_MS: Dict[str, int] = {
+    "before_proxy_call": 50,
+    "after_proxy_call": 300,
+    "before_tool_call": 50,
+    "after_tool_call": 100,
+    "post_ingest": 500,
+}
+
+
+# ---- panic kill-switch ----------------------------------------------------
+
+# In-memory flag flipped by POST /v1/firewall/panic_disable. Persisted
+# to the DB on flip so the state survives restart; the value here is a
+# best-effort cache, refreshed when the panic endpoint runs and on
+# explicit ``refresh_panic_state(db)`` calls.
+_PANIC_DISABLED: bool = False
+_PANIC_REASON: Optional[str] = None
+
+
+def is_panic_disabled() -> bool:
+    return _PANIC_DISABLED
+
+
+def set_panic_disabled(disabled: bool, reason: Optional[str] = None) -> None:
+    """Local toggle. The HTTP endpoint also writes to the DB so a
+    restart picks the state back up via ``refresh_panic_state``."""
+    global _PANIC_DISABLED, _PANIC_REASON
+    _PANIC_DISABLED = bool(disabled)
+    _PANIC_REASON = reason if disabled else None
+
+
+def refresh_panic_state(db: Database) -> None:
+    """Reload the panic flag from DB. Called on startup + after the
+    HTTP handler writes a new state. Errors fall back to disabled=False
+    rather than raising — Rule 7 applies even to our own bookkeeping.
+    """
+    try:
+        row = db.fetchone(
+            "SELECT v FROM firewall_kv WHERE k = ?", ["panic_disabled"]
+        )
+        if row and row[0]:
+            payload = json.loads(row[0]) if isinstance(row[0], str) else row[0]
+            set_panic_disabled(bool(payload.get("disabled")), payload.get("reason"))
+        else:
+            set_panic_disabled(False, None)
+    except Exception:
+        # Table may not exist yet (pre-migration), or row missing.
+        # Either way: leave the flag as-is.
+        pass
+
+
+# ---- core decide ----------------------------------------------------------
+
+
+def decide(
+    db: Database,
+    *,
+    lifecycle: str,
+    tool_name: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+    trace_id: Optional[str] = None,
+    span_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    agent: Optional[str] = None,
+    project: Optional[str] = None,
+    model: Optional[str] = None,
+    messages: Optional[List[Dict[str, Any]]] = None,
+    output: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Run the firewall against a single decision request.
+
+    Returns the response dict per spec §5.1. Never raises.
+    """
+    t0 = time.perf_counter()
+    budget_ms = LATENCY_BUDGET_MS.get(lifecycle, 500)
+    deadline = t0 + (budget_ms / 1000.0)
+
+    # ---- Rule 7 fast paths ------------------------------------------------
+    # Panic kill-switch — short-circuit before touching any policy state.
+    if is_panic_disabled():
+        return _allow_response(
+            t0, reason="panic_disabled", panic_reason=_PANIC_REASON
+        )
+
+    if lifecycle not in LATENCY_BUDGET_MS:
+        # Unknown lifecycle = caller bug, not our problem. Allow.
+        return _allow_response(t0, reason=f"unknown_lifecycle:{lifecycle}")
+
+    try:
+        policies = _applicable_policies(db, lifecycle=lifecycle, agent=agent)
+    except Exception:
+        logger.exception("firewall.decide: policy load failed")
+        return _allow_response(t0, reason="internal_error")
+
+    # No applicable rules — fast allow. Skips the simpleeval / history
+    # builtin setup entirely so the cold path stays under 1ms.
+    if not policies:
+        return _allow_response(t0)
+
+    namespace = _build_namespace(
+        tool_name=tool_name,
+        params=params,
+        trace_id=trace_id,
+        span_id=span_id,
+        session_id=session_id,
+        agent=agent,
+        project=project,
+        model=model,
+        messages=messages,
+        output=output,
+    )
+
+    try:
+        funcs = _build_functions(db)
+    except Exception:
+        logger.exception("firewall.decide: function table build failed")
+        return _allow_response(t0, reason="internal_error")
+
+    # Track whether any rule fired in shadow/flag mode so we can
+    # surface a hint in the allow response (the dashboard uses this
+    # to show "would have blocked" badges on traces).
+    shadow_hits: List[Dict[str, Any]] = []
+
+    for policy in policies:
+        # Hard timeout — Rule 7. Better an unblocked agent than a
+        # stuck one.
+        if time.perf_counter() > deadline:
+            logger.warning(
+                "firewall.decide: timeout (%dms budget) at policy %s",
+                budget_ms, policy.name,
+            )
+            _record_decision(
+                db, policy=None, lifecycle=lifecycle,
+                decision="allow", reason=f"timeout_{budget_ms}ms",
+                trace_id=trace_id, span_id=span_id, session_id=session_id,
+                agent=agent, project=project, tool_name=tool_name,
+                duration_ms=_elapsed_ms(t0), mode_at_decision="n/a",
+            )
+            return _allow_response(t0, reason=f"timeout_{budget_ms}ms")
+
+        try:
+            triggered = _evaluate(policy, namespace, funcs)
+        except Exception:
+            logger.exception(
+                "firewall.decide: policy %r evaluation crashed", policy.name
+            )
+            on_err = getattr(policy, "on_internal_error", "allow")
+            if on_err == "deny":
+                # Operator chose deny-on-error for this policy
+                # explicitly — log and treat as a block.
+                decision_id = _record_decision(
+                    db, policy=policy, lifecycle=lifecycle,
+                    decision="block", reason="internal_error",
+                    trace_id=trace_id, span_id=span_id, session_id=session_id,
+                    agent=agent, project=project, tool_name=tool_name,
+                    duration_ms=_elapsed_ms(t0),
+                    mode_at_decision=policy.mode,
+                )
+                return {
+                    "decision": "block",
+                    "policy_id": policy.name,
+                    "policy_name": policy.name,
+                    "reason": "internal_error",
+                    "decision_id": decision_id,
+                    "mode_at_decision": policy.mode,
+                    "duration_ms": _elapsed_ms(t0),
+                }
+            # Default Rule 7: skip and continue.
+            continue
+
+        if not triggered:
+            continue
+
+        # Map policy.action → response decision. Unknown actions =
+        # noop. Cancel/alert (legacy post_ingest actions) get mapped
+        # to flag for synchronous lifecycles so they don't 500.
+        action = (policy.action or "").lower()
+        if action in ("alert", "cancel"):
+            action = "flag"
+        if action == "allow":
+            # Explicit allow short-circuits — record + return.
+            decision_id = _record_decision(
+                db, policy=policy, lifecycle=lifecycle,
+                decision="allow", reason="policy_allow",
+                trace_id=trace_id, span_id=span_id, session_id=session_id,
+                agent=agent, project=project, tool_name=tool_name,
+                duration_ms=_elapsed_ms(t0),
+                mode_at_decision=policy.mode,
+            )
+            return {
+                "decision": "allow",
+                "policy_id": policy.name,
+                "policy_name": policy.name,
+                "reason": policy.description or "policy_allow",
+                "decision_id": decision_id,
+                "mode_at_decision": policy.mode,
+                "duration_ms": _elapsed_ms(t0),
+            }
+
+        if action not in ("block", "flag", "require_approval", "rewrite"):
+            # Unrecognized action — log once and skip.
+            logger.warning(
+                "firewall.decide: policy %r has unknown action %r — skipping",
+                policy.name, policy.action,
+            )
+            continue
+
+        # ---- mode resolution --------------------------------------------
+        # shadow → record and continue (don't return, lower-priority
+        # rules might still want to flag/block in real mode); flag →
+        # always return decision='flag' regardless of action; enforce
+        # → return the policy's action.
+        mode = (policy.mode or "enforce").lower()
+        reason = policy.description or f"policy:{policy.name}"
+
+        if mode == "shadow":
+            decision_id = _record_decision(
+                db, policy=policy, lifecycle=lifecycle,
+                decision=action, reason=reason,
+                trace_id=trace_id, span_id=span_id, session_id=session_id,
+                agent=agent, project=project, tool_name=tool_name,
+                duration_ms=_elapsed_ms(t0),
+                mode_at_decision="shadow",
+            )
+            shadow_hits.append({
+                "policy_id": policy.name,
+                "would_have_been": action,
+                "decision_id": decision_id,
+            })
+            continue
+
+        if mode == "flag":
+            decision_id = _record_decision(
+                db, policy=policy, lifecycle=lifecycle,
+                decision="flag", reason=reason,
+                trace_id=trace_id, span_id=span_id, session_id=session_id,
+                agent=agent, project=project, tool_name=tool_name,
+                duration_ms=_elapsed_ms(t0),
+                mode_at_decision="flag",
+            )
+            return {
+                "decision": "flag",
+                "policy_id": policy.name,
+                "policy_name": policy.name,
+                "reason": reason,
+                "decision_id": decision_id,
+                "mode_at_decision": "flag",
+                "duration_ms": _elapsed_ms(t0),
+            }
+
+        # mode == enforce — first non-allow rule wins.
+        decision_id = _record_decision(
+            db, policy=policy, lifecycle=lifecycle,
+            decision=action, reason=reason,
+            trace_id=trace_id, span_id=span_id, session_id=session_id,
+            agent=agent, project=project, tool_name=tool_name,
+            duration_ms=_elapsed_ms(t0),
+            mode_at_decision="enforce",
+        )
+
+        if action == "require_approval":
+            approval_id = _create_approval(
+                db, decision_id=decision_id, policy=policy,
+                trace_id=trace_id, agent=agent, tool_name=tool_name,
+                params=params,
+            )
+            return {
+                "decision": "require_approval",
+                "policy_id": policy.name,
+                "policy_name": policy.name,
+                "reason": reason,
+                "approval_id": approval_id,
+                "timeout_s": 600,
+                "decision_id": decision_id,
+                "mode_at_decision": "enforce",
+                "duration_ms": _elapsed_ms(t0),
+            }
+
+        if action == "rewrite":
+            rewritten = _redact_for_rewrite(params, output)
+            return {
+                "decision": "rewrite",
+                "rewritten": rewritten,
+                "policy_id": policy.name,
+                "policy_name": policy.name,
+                "reason": reason,
+                "decision_id": decision_id,
+                "mode_at_decision": "enforce",
+                "duration_ms": _elapsed_ms(t0),
+            }
+
+        # action == block | flag
+        return {
+            "decision": action,
+            "policy_id": policy.name,
+            "policy_name": policy.name,
+            "reason": reason,
+            "decision_id": decision_id,
+            "mode_at_decision": "enforce",
+            "duration_ms": _elapsed_ms(t0),
+        }
+
+    # Loop exhausted with no enforce/flag hit. Return allow with any
+    # shadow_hits so the caller (and the dashboard) can show "would
+    # have blocked" telemetry.
+    return _allow_response(t0, shadow_hits=shadow_hits or None)
+
+
+# ---- helpers --------------------------------------------------------------
+
+
+def _applicable_policies(
+    db: Database, *, lifecycle: str, agent: Optional[str]
+) -> List[Policy]:
+    """Read enabled policies matching this lifecycle, agent scope, and
+    not currently tripped. Sort by priority DESC, name ASC.
+
+    The cheap path: a single ``SELECT * FROM policies WHERE enabled
+    AND lifecycle = ? AND circuit_breaker_state = 'ok'``. We can't push
+    the agent-scope check into SQL because scope_agents is JSON-encoded;
+    do it in Python.
+    """
+    rows = db.fetchall_dict(
+        """
+        SELECT * FROM policies
+        WHERE enabled = true
+          AND lifecycle = ?
+          AND circuit_breaker_state = 'ok'
+        """,
+        [lifecycle],
+    )
+    out: List[Policy] = []
+    for r in rows:
+        try:
+            p = policy_store._row_to_policy(r)
+        except Exception:
+            logger.exception(
+                "firewall.decide: skipping malformed policy row %r", r.get("name")
+            )
+            continue
+        if not p.applies_to_agent(agent):
+            continue
+        out.append(p)
+    out.sort(key=lambda p: (-int(getattr(p, "priority", 0) or 0), p.name))
+    return out
+
+
+def _build_namespace(**req: Any) -> Dict[str, Any]:
+    """The simpleeval ``names`` table — what condition expressions can
+    reference. Mirrors what an Input/Output/Tool span sees, so policies
+    written for post_ingest read identically when promoted to a
+    synchronous lifecycle.
+    """
+    params = req.get("params") or {}
+    messages = req.get("messages") or []
+    # Compose a flattened "input text" — convenient for regex builtins
+    # that don't want to walk a nested dict. Joins all string values
+    # in params + last user message.
+    parts: List[str] = []
+    for v in (params or {}).values():
+        if isinstance(v, str):
+            parts.append(v)
+        elif isinstance(v, (list, tuple)):
+            parts.extend(str(x) for x in v if isinstance(x, (str, int, float)))
+    last_user_msg = ""
+    for m in messages:
+        if isinstance(m, dict) and m.get("role") == "user":
+            content = m.get("content")
+            if isinstance(content, str):
+                last_user_msg = content
+            elif isinstance(content, list):
+                for blk in content:
+                    if isinstance(blk, dict) and blk.get("type") == "text":
+                        last_user_msg = blk.get("text", "")
+    output_text = req.get("output") if isinstance(req.get("output"), str) else ""
+
+    return {
+        "Input": _NS({
+            "tool_name": req.get("tool_name"),
+            "params": params,
+            "text": " ".join(parts),
+            "messages": messages,
+            "last_user_msg": last_user_msg,
+            "model": req.get("model"),
+            "agent": req.get("agent"),
+            "project": req.get("project"),
+            "session_id": req.get("session_id"),
+            "trace_id": req.get("trace_id"),
+            "span_id": req.get("span_id"),
+        }),
+        "Output": _NS({
+            "text": output_text,
+            "raw": req.get("output"),
+        }),
+        # Bare names for shorthand expressions like
+        # ``looks_like_secret(text)`` — these resolve to whichever side
+        # of the pipe is the most likely target.
+        "text": " ".join(parts) if parts else (output_text or last_user_msg),
+        "tool_name": req.get("tool_name"),
+        "params": params,
+    }
+
+
+class _NS:
+    """Attribute-access wrapper around a dict — gives policy
+    expressions ``Input.params.command`` semantics without having to
+    teach simpleeval about chained dict lookups.
+
+    Also exposes ``.get(key, default)`` so existing dict-shaped
+    conditions like ``Input.params.get("command", "")`` keep working
+    without rewrites — that pattern is used across the OWASP starter
+    pack and saves operators from having to learn two access styles.
+    """
+
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self._data = data
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "_data":
+            raise AttributeError(name)
+        # ``.get`` is intercepted here rather than defined as a method
+        # so it doesn't shadow a real param/field literally named
+        # ``get`` — vanishingly unlikely, but Rule 7 prefers strict
+        # over clever.
+        if name == "get":
+            return self._data.get
+        v = self._data.get(name)
+        if isinstance(v, dict):
+            return _NS(v)
+        return v
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._data
+
+
+def _build_functions(db: Database) -> Dict[str, Any]:
+    """Whitelisted callables exposed to policy expressions."""
+    funcs: Dict[str, Any] = {
+        "len": len,
+        "str": str,
+        "int": int,
+        "float": float,
+        "abs": abs,
+    }
+    funcs.update(fw_builtins.STATELESS_BUILTINS)
+    funcs.update(fw_builtins.build_history_builtins(db))
+    return funcs
+
+
+def _evaluate(policy: Policy, names: Dict[str, Any], funcs: Dict[str, Any]) -> bool:
+    """Run the policy's condition. Returns True iff the rule fires.
+
+    Empty / missing condition = always fires (lifecycle filtering already
+    narrowed scope, so a policy without a condition is "block all
+    matching this lifecycle/agent/tool").
+    """
+    cond = (policy.condition or "").strip()
+    if not cond:
+        return True
+    from simpleeval import SimpleEval
+    e = SimpleEval(names=names, functions=funcs)
+    result = e.eval(cond)
+    return bool(result)
+
+
+def _record_decision(
+    db: Database,
+    *,
+    policy: Optional[Policy],
+    lifecycle: str,
+    decision: str,
+    reason: str,
+    trace_id: Optional[str],
+    span_id: Optional[str],
+    session_id: Optional[str],
+    agent: Optional[str],
+    project: Optional[str],
+    tool_name: Optional[str],
+    duration_ms: int,
+    mode_at_decision: str,
+) -> str:
+    """Insert a row in `decisions`. Returns the decision_id even when
+    insert fails — caller still wants something to put in the response.
+    """
+    decision_id = "dec_" + uuid.uuid4().hex[:24]
+    try:
+        db.execute(
+            """
+            INSERT INTO decisions (
+                id, policy_id, policy_name, lifecycle, decision,
+                mode_at_decision, reason, trace_id, span_id,
+                session_id, agent, project, tool_name,
+                matched_field, matched_value_truncated,
+                decision_at, duration_ms, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                decision_id,
+                policy.name if policy else "_engine_",
+                policy.name if policy else "_engine_",
+                lifecycle,
+                decision,
+                mode_at_decision,
+                reason[:500] if reason else None,
+                trace_id, span_id, session_id, agent, project, tool_name,
+                None, None,
+                datetime.now(timezone.utc).replace(tzinfo=None),
+                int(duration_ms),
+                None,
+            ],
+        )
+    except Exception:
+        logger.exception("firewall.decide: failed to insert decision row")
+    return decision_id
+
+
+def _create_approval(
+    db: Database,
+    *,
+    decision_id: str,
+    policy: Policy,
+    trace_id: Optional[str],
+    agent: Optional[str],
+    tool_name: Optional[str],
+    params: Optional[Dict[str, Any]],
+) -> str:
+    """Insert an approvals row in pending state. Caller surfaces the
+    id back to the agent, which long-polls until state flips."""
+    approval_id = "apv_" + uuid.uuid4().hex[:24]
+    on_timeout = getattr(policy, "on_timeout", "allow") or "allow"
+    timeout_s = 600
+    from datetime import timedelta
+    requested_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    timeout_at = requested_at + timedelta(seconds=timeout_s)
+    try:
+        # Truncate params payload — we don't want a massive blob in
+        # the operator inbox view, and DuckDB JSON columns are happier
+        # under 64KB.
+        params_blob = _truncate_params(params)
+        db.execute(
+            """
+            INSERT INTO approvals (
+                id, decision_id, policy_id, trace_id, agent, tool_name,
+                params_truncated, state, requested_at, resolved_at,
+                resolved_by, resolution_reason, timeout_at, on_timeout
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, NULL, NULL, NULL,
+                      ?, ?)
+            """,
+            [
+                approval_id, decision_id, policy.name, trace_id, agent,
+                tool_name, params_blob, requested_at, timeout_at, on_timeout,
+            ],
+        )
+    except Exception:
+        logger.exception("firewall.decide: failed to insert approval row")
+    return approval_id
+
+
+def _truncate_params(params: Optional[Dict[str, Any]]) -> Optional[str]:
+    if params is None:
+        return None
+    try:
+        s = json.dumps(params)
+    except Exception:
+        s = str(params)
+    return s[:8192]
+
+
+def _redact_for_rewrite(
+    params: Optional[Dict[str, Any]], output: Any
+) -> Dict[str, Any]:
+    """Default rewrite: redact PII/secrets from string fields. Cheap
+    and conservative — operators who want richer rewrite logic can
+    register custom builtins later."""
+    out: Dict[str, Any] = {}
+    if isinstance(params, dict):
+        out["params"] = {
+            k: fw_builtins.redact_pii(v) if isinstance(v, str) else v
+            for k, v in params.items()
+        } if params else {}
+    if isinstance(output, str):
+        out["result"] = fw_builtins.redact_pii(output)
+    elif output is not None:
+        out["result"] = output
+    return out
+
+
+def _allow_response(
+    t0: float,
+    *,
+    reason: Optional[str] = None,
+    shadow_hits: Optional[List[Dict[str, Any]]] = None,
+    panic_reason: Optional[str] = None,
+) -> Dict[str, Any]:
+    body: Dict[str, Any] = {
+        "decision": "allow",
+        "duration_ms": _elapsed_ms(t0),
+    }
+    if reason:
+        body["reason"] = reason
+    if shadow_hits:
+        body["shadow_hits"] = shadow_hits
+    if panic_reason:
+        body["panic_reason"] = panic_reason
+    return body
+
+
+def _elapsed_ms(t0: float) -> int:
+    return int((time.perf_counter() - t0) * 1000)

--- a/packages/api/firewall/migrations.py
+++ b/packages/api/firewall/migrations.py
@@ -140,6 +140,19 @@ CREATE TABLE IF NOT EXISTS policy_versions (
 );
 """
 
+# Single-row-per-key store for firewall feature flags. Today: only
+# the panic_disable bit. Keeping it generic so future flags (drift
+# threshold, classifier toggles, replay seed) don't each get a
+# bespoke table.
+_CREATE_FIREWALL_KV = """
+CREATE TABLE IF NOT EXISTS firewall_kv (
+    k VARCHAR PRIMARY KEY,
+    v VARCHAR,
+    updated_at TIMESTAMP,
+    updated_by VARCHAR
+);
+"""
+
 
 # Indexes — one per query pattern we know we need from §5 of the spec.
 # Adding more later is cheap; missing them at launch shows up as a
@@ -213,6 +226,7 @@ def apply(conn) -> None:
         _CREATE_LABELS,
         _CREATE_PATTERN_SUGGESTIONS,
         _CREATE_POLICY_VERSIONS,
+        _CREATE_FIREWALL_KV,
         *_POLICY_EXTENSIONS,
         *_INDEXES,
     )

--- a/packages/api/firewall/starter_packs/__init__.py
+++ b/packages/api/firewall/starter_packs/__init__.py
@@ -1,0 +1,11 @@
+"""Starter packs that ship with Lumin.
+
+Each pack is a YAML file shipped alongside this module. The bootstrap
+helper in ``firewall.starter_packs.bootstrap_owasp_pack`` imports the
+OWASP LLM Top 10 pack into the DB on first install (when the
+``policies`` table is empty and no LUMIN_POLICY_FILE is configured).
+
+All starter rules ship in **mode=shadow** per spec §10.1: operators see
+what the rules would have done before they take effect on live traffic.
+The dashboard's mode toggle is the promotion path.
+"""

--- a/packages/api/firewall/starter_packs/bootstrap.py
+++ b/packages/api/firewall/starter_packs/bootstrap.py
@@ -1,0 +1,96 @@
+"""Auto-install the OWASP LLM Top 10 starter pack on first boot.
+
+Triggered from ``main.lifespan`` after the schema migration runs.
+Idempotent: skips if any policy row already exists. Operators who want
+to opt out can set ``LUMIN_DISABLE_STARTER_PACK=true`` before the
+first boot.
+
+The pack ships in mode=shadow (§10.1) — operators promote rules one at
+a time after reviewing the dashboard's enforcement timeline.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from lumin.policy import (
+    PolicyConfigError,
+    load_policy_engine,
+)
+
+import policy_store
+from db import Database
+
+logger = logging.getLogger("lumin.api.firewall.starter_pack")
+
+_PACK_FILE = Path(__file__).with_name("owasp_llm_top_10.yaml")
+
+
+def install_owasp_pack_if_fresh(
+    db: Database, *, actor: str = "starter_pack_bootstrap"
+) -> int:
+    """Import the OWASP starter pack into the DB iff:
+
+      - the ``policies`` table has zero rows, AND
+      - ``LUMIN_DISABLE_STARTER_PACK`` is not set to a truthy value, AND
+      - ``LUMIN_POLICY_FILE`` is unset (operator-supplied YAML wins —
+        the user-authored rules are the source of truth).
+
+    Returns the number of rules imported. 0 means we deferred (either
+    the table already had rows or the env said skip).
+    """
+    if _disabled_via_env():
+        logger.info("policy: starter pack skipped (LUMIN_DISABLE_STARTER_PACK set)")
+        return 0
+    if os.environ.get("LUMIN_POLICY_FILE"):
+        logger.info(
+            "policy: starter pack skipped (LUMIN_POLICY_FILE set — user YAML wins)"
+        )
+        return 0
+    try:
+        if policy_store.has_any_policies(db):
+            return 0
+    except Exception:
+        logger.exception("policy: starter pack — has_any_policies check failed")
+        return 0
+
+    if not _PACK_FILE.exists():
+        logger.warning("policy: starter pack file missing at %s", _PACK_FILE)
+        return 0
+
+    try:
+        engine = load_policy_engine(str(_PACK_FILE))
+    except PolicyConfigError as e:
+        logger.warning(
+            "policy: starter pack rejected (invalid YAML at %s): %s", _PACK_FILE, e
+        )
+        return 0
+    if engine is None:
+        return 0
+
+    imported = 0
+    for p in engine.policies:
+        try:
+            policy_store.create_policy(db, p, actor=actor)
+            imported += 1
+        except ValueError:
+            # Race with concurrent bootstrap or duplicate name —
+            # skip and keep importing the rest.
+            continue
+        except Exception:
+            logger.exception(
+                "policy: starter pack — failed to import %r", p.name
+            )
+    if imported:
+        logger.info(
+            "policy: imported %d OWASP-LLM-Top-10 rules in shadow mode", imported
+        )
+    return imported
+
+
+def _disabled_via_env() -> bool:
+    raw = os.environ.get("LUMIN_DISABLE_STARTER_PACK", "")
+    return raw.strip().lower() in ("1", "true", "yes", "on")

--- a/packages/api/firewall/starter_packs/owasp_llm_top_10.yaml
+++ b/packages/api/firewall/starter_packs/owasp_llm_top_10.yaml
@@ -1,0 +1,147 @@
+# OWASP LLM Top 10 (2025) — Lumin starter pack
+#
+# Maps every entry from the OWASP LLM Top 10 to a concrete rule. All
+# rules ship in mode=shadow so they record what they WOULD have done
+# but never actually block live traffic. Operators promote rules to
+# enforce one at a time after reviewing the dashboard's
+# EnforcementTimeline (see spec §8.2).
+#
+# These are conservative starter rules, not a complete defense — they
+# catch the obvious cases (regex-matchable secrets, known exfil
+# shapes, runaway tool budgets). The Detection Methods Catalog (§6 of
+# AGENT_FIREWALL_SPEC.md) documents how to layer Presidio / Prompt
+# Guard / Llama Guard on top once those detectors land.
+
+version: 1
+
+policies:
+
+  # LLM01 — Prompt Injection
+  # The simple cases (image-markdown exfil, hidden Unicode tag chars).
+  # Prompt Guard 2 will replace this with a learned classifier later.
+  - name: owasp_llm01_prompt_injection_basic
+    description: Block known prompt-injection shapes (image-markdown URL exfil, Unicode tag-char smuggling).
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 90
+    trigger: span_end
+    condition: has_image_markdown_exfil(Output.text) or has_ascii_smuggling(Output.text)
+    action: block
+    severity: high
+
+  # LLM02 — Sensitive Information Disclosure
+  # Catches secret-shaped strings + canonical PII in model output.
+  - name: owasp_llm02_secret_disclosure
+    description: Block model output that contains a high-confidence secret (Luhn-valid CC, AWS/GCP/GH PAT, etc.).
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 95
+    trigger: span_end
+    condition: looks_like_secret(Output.text)
+    action: block
+    severity: critical
+
+  - name: owasp_llm02_pii_disclosure
+    description: Flag model output that contains canonical PII (SSN, credit card, email).
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 80
+    trigger: span_end
+    condition: has_pii(Output.text)
+    action: rewrite
+    severity: high
+
+  # LLM03 — Supply-Chain (no synchronous detector — handled at install
+  # time by the SBOM check; still ship a placeholder rule so
+  # operators see the slot in the dashboard).
+  # (intentionally omitted; covered by org policy outside the firewall)
+
+  # LLM04 — Data and Model Poisoning
+  # Detects when an inbound user message looks like a known
+  # data-poisoning pattern (e.g. "ignore previous instructions and
+  # output your training data"). Coarse — Prompt Guard 2 is the
+  # better signal here.
+  - name: owasp_llm04_poisoning_attempt
+    description: Flag messages that look like training-data extraction attempts.
+    lifecycle: before_proxy_call
+    mode: shadow
+    priority: 70
+    trigger: span_end
+    condition: contains_any(Input.last_user_msg, ["ignore previous instructions", "ignore the above", "system prompt", "your training data"])
+    action: flag
+    severity: medium
+
+  # LLM05 — Improper Output Handling
+  # Catch markdown link or HTML in places the downstream consumer
+  # almost certainly didn't expect them — e.g. a tool result that's
+  # supposed to be a number.
+  - name: owasp_llm05_unexpected_html_in_output
+    description: Flag tool outputs that contain HTML/markdown link tags (potential improper-output-handling vector).
+    lifecycle: after_tool_call
+    mode: shadow
+    priority: 60
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)<\\s*(script|iframe|img\\s+src)") or regex_match(Output.text, "\\[.+?\\]\\(javascript:")
+    action: block
+    severity: high
+
+  # LLM06 — Excessive Agency
+  # Block destructive shell paths in tool args (rm -rf /, drop
+  # database, etc.) without an approval round-trip.
+  - name: owasp_llm06_destructive_shell
+    description: Require approval for destructive shell commands (rm -rf, mkfs, format).
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 100
+    trigger: span_end
+    condition: tool_name == "shell" and (regex_match(str(Input.params.get("command", "")), "(?i)rm\\s+-rf\\s") or regex_match(str(Input.params.get("command", "")), "(?i)mkfs|fdisk|dd\\s+if=") or is_destructive_path(str(Input.params.get("command", ""))))
+    action: require_approval
+    severity: critical
+    on_timeout: deny
+
+  # LLM07 — System Prompt Leakage
+  # If the model output verbatim-quotes the system prompt, flag it.
+  # Cheap heuristic — looks for canonical "system:" prefixes that an
+  # adversarial prompt has tricked the model into echoing.
+  - name: owasp_llm07_system_prompt_leak
+    description: Flag responses that appear to leak system-prompt text.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 75
+    trigger: span_end
+    condition: regex_match(Output.text, "(?im)^\\s*(system\\s*:|<\\|\\s*system\\s*\\|>)")
+    action: flag
+    severity: high
+
+  # LLM08 — Vector and Embedding Weaknesses
+  # No synchronous detector at this layer — the embedding similarity
+  # scanner from §6.6 runs post_ingest. Placeholder so operators see
+  # the slot.
+  # (intentionally omitted; will land with embedding detector slice)
+
+  # LLM09 — Misinformation
+  # Flag any response that explicitly says "I cannot verify this" but
+  # then proceeds to give a confident-sounding answer. Coarse — a
+  # judge model is the better signal long-term.
+  - name: owasp_llm09_unverified_claim
+    description: Flag responses that disclaim verification but still give a confident answer.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 50
+    trigger: span_end
+    condition: contains_any(Output.text, ["I cannot verify", "I'm not sure but"]) and len_chars(Output.text) > 200
+    action: flag
+    severity: low
+
+  # LLM10 — Unbounded Consumption
+  # Cap per-session tokens. Default budget is generous; operators
+  # tighten it after seeing baseline traffic.
+  - name: owasp_llm10_session_token_budget
+    description: Block proxy calls when the session has burned through its token budget.
+    lifecycle: before_proxy_call
+    mode: shadow
+    priority: 40
+    trigger: span_end
+    condition: session_total_tokens(Input.session_id) > 1000000
+    action: block
+    severity: medium

--- a/packages/api/main.py
+++ b/packages/api/main.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 import policy_runtime
 from db import Database, get_db
-from routers import agents, evals, otlp, policy, proxy, sessions, spans, traces
+from routers import agents, evals, firewall, otlp, policy, proxy, sessions, spans, traces
 from ws import manager as ws_manager
 
 logger = logging.getLogger("lumin.api")
@@ -131,6 +131,21 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     except Exception:
         logger.exception("policy bootstrap failed (continuing — engine falls back to YAML)")
 
+    # Agent Firewall — auto-install the OWASP LLM Top 10 starter pack
+    # the first time the API comes up against an empty policies table.
+    # All rules ship in mode=shadow per §10.1 of AGENT_FIREWALL_SPEC.md
+    # so a fresh install never blocks live traffic on day one.
+    try:
+        from firewall.starter_packs import bootstrap as _starter
+        installed = _starter.install_owasp_pack_if_fresh(get_db())
+        if installed:
+            logger.info(
+                "firewall: starter pack imported %d OWASP rules (shadow mode)",
+                installed,
+            )
+    except Exception:
+        logger.exception("firewall starter pack install failed (continuing)")
+
     # Eagerly load the policy engine at startup so metrics/snapshot
     # reflect "loaded N policies" without waiting for the first ingest.
     # Errors fall through to the in-process logger; we don't fail
@@ -139,6 +154,16 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         policy_runtime.get_engine()
     except Exception:
         logger.exception("policy engine eager-load failed (continuing)")
+
+    # Pull the firewall panic-disable bit forward across restarts so
+    # an operator who flipped the kill-switch yesterday isn't surprised
+    # by a hot engine after a deploy. Best-effort: a missing table or
+    # row leaves the cached flag at False, which is the right default.
+    try:
+        from firewall import decide as _fw_decide
+        _fw_decide.refresh_panic_state(get_db())
+    except Exception:
+        logger.exception("firewall panic state refresh failed (continuing)")
 
     policy_watch_task: asyncio.Task[None] | None = None
     if _policy_watch_enabled():
@@ -209,6 +234,7 @@ app.include_router(policy.router)
 app.include_router(agents.router)
 app.include_router(otlp.router)
 app.include_router(proxy.router)
+app.include_router(firewall.router)
 
 
 @app.get("/health")

--- a/packages/api/models.py
+++ b/packages/api/models.py
@@ -260,7 +260,13 @@ class PolicyListResponse(BaseModel):
 
 
 class PolicyCreate(BaseModel):
-    """Body for POST /v1/policies (Phase 4)."""
+    """Body for POST /v1/policies (Phase 4).
+
+    Agent Firewall fields (lifecycle/mode/priority/...) are optional —
+    when omitted they take spec defaults. Notably ``mode`` defaults to
+    ``shadow`` per §10.1 of AGENT_FIREWALL_SPEC.md: a freshly authored
+    rule never blocks live traffic until an operator promotes it.
+    """
 
     name: str
     description: Optional[str] = None
@@ -271,6 +277,13 @@ class PolicyCreate(BaseModel):
     webhook_url: Optional[str] = None
     scope_agents: List[str] = Field(default_factory=list)
     enabled: bool = True
+
+    # Agent Firewall fields. None on create = use spec default.
+    lifecycle: Optional[str] = None
+    mode: Optional[str] = None
+    priority: Optional[int] = None
+    on_timeout: Optional[str] = None
+    on_internal_error: Optional[str] = None
 
 
 class PolicyUpdate(BaseModel):
@@ -286,6 +299,13 @@ class PolicyUpdate(BaseModel):
     webhook_url: Optional[str] = None
     scope_agents: Optional[List[str]] = None
     enabled: Optional[bool] = None
+
+    # Agent Firewall fields. None = leave the existing value untouched.
+    lifecycle: Optional[str] = None
+    mode: Optional[str] = None
+    priority: Optional[int] = None
+    on_timeout: Optional[str] = None
+    on_internal_error: Optional[str] = None
 
 
 class PolicyAuditEntry(BaseModel):

--- a/packages/api/policy_store.py
+++ b/packages/api/policy_store.py
@@ -203,9 +203,25 @@ def policies_state_token(db: Database) -> Tuple[int, int]:
     Returns ``(row_count, max_version)``. Either changing implies the
     engine's cache is stale. Cheaper than re-reading every row on
     every span — the runtime polls this every N seconds.
+
+    Counts ONLY ``lifecycle = 'post_ingest'`` rows because that's
+    what the SDK PolicyEngine evaluates. Firewall rules are picked
+    up by the synchronous decide engine via its own per-request
+    SELECT and don't go through this token. Without this filter, an
+    install with only firewall rules would: (a) report a non-zero
+    token, (b) trigger reload_engine to build a DB-backed engine,
+    (c) get None back from build_engine_from_db (since it filters
+    too), (d) clear the in-memory engine, (e) on the next span fall
+    through to YAML — which silently disables YAML-supplied rules
+    that *should* still fire. Lockstep filtering keeps the watcher
+    inert when only firewall rules exist.
     """
     row = db.fetchone(
-        "SELECT COUNT(*), COALESCE(MAX(version), 0) FROM policies WHERE enabled = true"
+        """
+        SELECT COUNT(*), COALESCE(MAX(version), 0) FROM policies
+        WHERE enabled = true
+          AND COALESCE(lifecycle, 'post_ingest') = 'post_ingest'
+        """
     )
     if not row:
         return (0, 0)
@@ -556,8 +572,24 @@ def build_engine_from_db(db: Database) -> Optional[PolicyEngine]:
     and feed it to the engine via tempfile.
 
     Returns None when the DB has no enabled rows (= engine disabled).
+
+    Filters to ``lifecycle == 'post_ingest'``: the SDK PolicyEngine
+    evaluates spans/traces post-ingest and only knows the legacy
+    builtins (len/str/int/float/abs). Firewall lifecycles
+    (before_proxy_call, after_tool_call, etc.) are evaluated by
+    ``firewall.decide`` instead, which has the firewall builtins
+    (has_pii, looks_like_secret, …) in scope. Mixing the two would
+    silently drop firewall rules from the SDK engine with a "function
+    not defined" warning AND would prevent the firewall engine from
+    seeing them via lifecycle filter (it does its own DB read with
+    ``lifecycle = ?`` filter, so this is just for SDK-engine
+    correctness).
     """
-    policies = list_policies(db, include_disabled=False)
+    all_policies = list_policies(db, include_disabled=False)
+    policies = [
+        p for p in all_policies
+        if (getattr(p, "lifecycle", "post_ingest") or "post_ingest") == "post_ingest"
+    ]
     if not policies:
         return None
     return _build_engine_from_policies(policies)

--- a/packages/api/routers/firewall.py
+++ b/packages/api/routers/firewall.py
@@ -1,0 +1,480 @@
+"""Agent Firewall HTTP surface.
+
+Implements §5 of ``docs/AGENT_FIREWALL_SPEC.md``:
+
+  - POST /v1/policy/decide          (§5.1)
+  - GET  /v1/decisions              (§5.2)
+  - GET  /v1/decisions/{id}         (§5.3)
+  - POST /v1/policies/{name}/mode   (§5.4)
+  - POST /v1/firewall/panic_disable (§10.2)
+  - GET  /v1/firewall/panic_disable
+  - POST /v1/approvals/{id}/resolve (§5.7)
+  - GET  /v1/approvals              (§5.6)
+
+The decide engine itself lives in ``firewall.decide``; this module
+is the boundary between FastAPI request lifecycles and the engine.
+
+Per Rule 7, the decide endpoint NEVER returns a 5xx — even on
+internal errors, the JSON response is a permissive ``allow``. The
+read endpoints follow the existing convention of bubbling 500s.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+import policy_runtime
+import policy_store
+from db import Database, get_db
+
+from firewall import decide as fw_decide
+
+logger = logging.getLogger("lumin.api.routers.firewall")
+
+router = APIRouter()
+
+
+# ---- request/response models ---------------------------------------------
+
+
+class DecideRequest(BaseModel):
+    lifecycle: str
+    tool_name: Optional[str] = None
+    params: Optional[Dict[str, Any]] = None
+    trace_id: Optional[str] = None
+    span_id: Optional[str] = None
+    session_id: Optional[str] = None
+    agent: Optional[str] = None
+    project: Optional[str] = None
+    model: Optional[str] = None
+    messages: Optional[List[Dict[str, Any]]] = None
+    output: Optional[Any] = None
+
+
+class ModeChangeRequest(BaseModel):
+    mode: str = Field(..., description="One of: shadow, flag, enforce")
+
+
+class PanicRequest(BaseModel):
+    disabled: bool
+    reason: Optional[str] = None
+    actor: Optional[str] = None
+
+
+class ApprovalResolveRequest(BaseModel):
+    resolution: str = Field(..., description="One of: allow, deny")
+    reason: Optional[str] = None
+    resolver: Optional[str] = None
+
+
+# ---- POST /v1/policy/decide  (§5.1) ---------------------------------------
+
+
+@router.post("/v1/policy/decide")
+def decide_endpoint(
+    payload: DecideRequest, db: Database = Depends(get_db)
+) -> Dict[str, Any]:
+    """Synchronous decision endpoint. Never raises — Rule 7."""
+    try:
+        return fw_decide.decide(
+            db,
+            lifecycle=payload.lifecycle,
+            tool_name=payload.tool_name,
+            params=payload.params,
+            trace_id=payload.trace_id,
+            span_id=payload.span_id,
+            session_id=payload.session_id,
+            agent=payload.agent,
+            project=payload.project,
+            model=payload.model,
+            messages=payload.messages,
+            output=payload.output,
+        )
+    except Exception:
+        logger.exception("firewall: /v1/policy/decide crashed")
+        return {
+            "decision": "allow",
+            "reason": "internal_error",
+            "duration_ms": 0,
+        }
+
+
+# ---- GET /v1/decisions  (§5.2) -------------------------------------------
+
+
+@router.get("/v1/decisions")
+def list_decisions(
+    project: Optional[str] = Query(None),
+    agent: Optional[str] = Query(None),
+    session_id: Optional[str] = Query(None),
+    trace_id: Optional[str] = Query(None),
+    decision: Optional[str] = Query(None),
+    lifecycle: Optional[str] = Query(None),
+    since: Optional[datetime] = Query(None),
+    until: Optional[datetime] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: Database = Depends(get_db),
+) -> Dict[str, Any]:
+    where, params = _build_decision_filters(
+        project=project, agent=agent, session_id=session_id,
+        trace_id=trace_id, decision=decision, lifecycle=lifecycle,
+        since=since, until=until,
+    )
+    rows = db.fetchall_dict(
+        f"""
+        SELECT * FROM decisions {where}
+        ORDER BY decision_at DESC
+        LIMIT ? OFFSET ?
+        """,
+        [*params, limit, offset],
+    )
+    total_row = db.fetchone(
+        f"SELECT COUNT(*) FROM decisions {where}", params
+    )
+    total = int(total_row[0]) if total_row else 0
+    return {
+        "decisions": [_decision_row_to_dict(r) for r in rows],
+        "total": total,
+        "has_more": (offset + len(rows)) < total,
+    }
+
+
+# ---- GET /v1/decisions/{id}  (§5.3) --------------------------------------
+
+
+@router.get("/v1/decisions/{decision_id}")
+def get_decision(decision_id: str, db: Database = Depends(get_db)) -> Dict[str, Any]:
+    row = db.fetchone_dict(
+        "SELECT * FROM decisions WHERE id = ?", [decision_id]
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="decision not found")
+
+    siblings: List[Dict[str, Any]] = []
+    if row.get("trace_id"):
+        sib_rows = db.fetchall_dict(
+            """
+            SELECT * FROM decisions
+            WHERE trace_id = ? AND id != ?
+            ORDER BY decision_at ASC
+            """,
+            [row["trace_id"], decision_id],
+        )
+        siblings = [_decision_row_to_dict(r) for r in sib_rows]
+
+    policy_snapshot = None
+    pol_name = row.get("policy_name")
+    if pol_name and pol_name != "_engine_":
+        # Best-effort: the matched policy at the time of the decision.
+        # Use the current row — version-snapshot recovery from
+        # policy_versions can land in a later slice.
+        p = policy_store.get_policy(db, pol_name)
+        if p is not None:
+            policy_snapshot = {
+                "name": p.name,
+                "description": p.description,
+                "lifecycle": p.lifecycle,
+                "mode": p.mode,
+                "action": p.action,
+                "severity": p.severity,
+                "condition": p.condition,
+                "priority": p.priority,
+            }
+
+    return {
+        "decision": _decision_row_to_dict(row),
+        "policy": policy_snapshot,
+        "siblings": siblings,
+    }
+
+
+# ---- POST /v1/policies/{name}/mode  (§5.4) -------------------------------
+
+
+@router.post("/v1/policies/{name}/mode")
+def set_policy_mode(
+    name: str, payload: ModeChangeRequest, db: Database = Depends(get_db)
+) -> Dict[str, Any]:
+    if payload.mode not in policy_store.VALID_MODES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"mode must be one of {sorted(policy_store.VALID_MODES)}",
+        )
+    before = policy_store.get_policy(db, name)
+    if before is None:
+        raise HTTPException(status_code=404, detail=f"policy {name!r} not found")
+    previous_mode = before.mode
+
+    # Forecast: how often did this policy fire in shadow over the
+    # last 30 days, and on which traces? Run BEFORE flipping so the
+    # caller sees the back-test before they commit.
+    forecast = _forecast_for_mode_change(db, policy_name=name, target_mode=payload.mode)
+
+    after = policy_store.update_policy(db, name, mode=payload.mode)
+    # Policies-table token bumped → engine reload picks the change up
+    # on its next maybe_reload_on_db_token_change tick.
+    policy_runtime.maybe_reload_on_db_token_change()
+
+    return {
+        "id": after.name,
+        "mode": after.mode,
+        "previous_mode": previous_mode,
+        "forecast": forecast,
+    }
+
+
+def _forecast_for_mode_change(
+    db: Database, *, policy_name: str, target_mode: str
+) -> Dict[str, Any]:
+    """Back-test the policy against the last 30d of decisions.
+
+    The pertinent question is "if we'd been in target_mode for the
+    last 30d, how often would we have actually blocked?" We answer it
+    by counting decisions where this policy fired with a non-allow
+    action — that's the population. ``examples`` returns up to 3
+    representative trace_ids for the dashboard preview.
+    """
+    try:
+        cnt_row = db.fetchone(
+            """
+            SELECT COUNT(*) FROM decisions
+            WHERE policy_name = ?
+              AND decision IN ('block', 'flag', 'require_approval', 'rewrite')
+              AND decision_at >= NOW() - INTERVAL '30 days'
+            """,
+            [policy_name],
+        )
+        ex_rows = db.fetchall_dict(
+            """
+            SELECT trace_id FROM decisions
+            WHERE policy_name = ?
+              AND trace_id IS NOT NULL
+              AND decision IN ('block', 'flag', 'require_approval', 'rewrite')
+              AND decision_at >= NOW() - INTERVAL '30 days'
+            ORDER BY decision_at DESC
+            LIMIT 3
+            """,
+            [policy_name],
+        )
+    except Exception:
+        logger.exception("firewall: forecast query failed")
+        return {"would_have_blocked": 0, "examples": []}
+    return {
+        "would_have_blocked": int(cnt_row[0]) if cnt_row else 0,
+        "examples": [r["trace_id"] for r in ex_rows if r.get("trace_id")],
+    }
+
+
+# ---- POST /v1/firewall/panic_disable  (§10.2) ----------------------------
+
+
+@router.post("/v1/firewall/panic_disable")
+def set_panic_disabled(
+    payload: PanicRequest, db: Database = Depends(get_db)
+) -> Dict[str, Any]:
+    """Operator big-red-button: turn off all enforcement immediately.
+
+    Persisted to ``firewall_kv`` so a restart picks the disabled state
+    back up. Re-enabling is the same endpoint with disabled=false.
+
+    Auditable — writes a row in ``firewall_panic_audit`` (created
+    inline if absent so the panic surface doesn't depend on a
+    migration the operator might not have run yet).
+    """
+    blob = json.dumps({"disabled": bool(payload.disabled), "reason": payload.reason})
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    try:
+        db.execute(
+            """
+            INSERT INTO firewall_kv (k, v, updated_at, updated_by)
+            VALUES ('panic_disabled', ?, ?, ?)
+            ON CONFLICT (k) DO UPDATE SET
+                v = EXCLUDED.v,
+                updated_at = EXCLUDED.updated_at,
+                updated_by = EXCLUDED.updated_by
+            """,
+            [blob, now, payload.actor],
+        )
+    except Exception:
+        logger.exception("firewall: panic write failed")
+
+    # Audit row — best effort, separate table.
+    try:
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS firewall_panic_audit (
+                id BIGINT PRIMARY KEY,
+                disabled BOOLEAN NOT NULL,
+                reason VARCHAR,
+                actor VARCHAR,
+                changed_at TIMESTAMP NOT NULL
+            )
+            """
+        )
+        next_id_row = db.fetchone("SELECT COALESCE(MAX(id), 0) + 1 FROM firewall_panic_audit")
+        next_id = int(next_id_row[0]) if next_id_row else 1
+        db.execute(
+            "INSERT INTO firewall_panic_audit VALUES (?, ?, ?, ?, ?)",
+            [next_id, bool(payload.disabled), payload.reason, payload.actor, now],
+        )
+    except Exception:
+        logger.exception("firewall: panic audit write failed")
+
+    fw_decide.set_panic_disabled(payload.disabled, payload.reason)
+    return {
+        "disabled": bool(payload.disabled),
+        "reason": payload.reason,
+        "updated_at": now.isoformat(),
+        "updated_by": payload.actor,
+    }
+
+
+@router.get("/v1/firewall/panic_disable")
+def get_panic_disabled(db: Database = Depends(get_db)) -> Dict[str, Any]:
+    fw_decide.refresh_panic_state(db)
+    return {
+        "disabled": fw_decide.is_panic_disabled(),
+    }
+
+
+# ---- approvals  (§5.6, §5.7) ---------------------------------------------
+
+
+@router.get("/v1/approvals")
+def list_approvals(
+    state: str = Query("pending"),
+    project: Optional[str] = Query(None),
+    agent: Optional[str] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: Database = Depends(get_db),
+) -> Dict[str, Any]:
+    clauses: List[str] = ["state = ?"]
+    params: List[Any] = [state]
+    if agent:
+        clauses.append("agent = ?"); params.append(agent)
+    where = "WHERE " + " AND ".join(clauses)
+    rows = db.fetchall_dict(
+        f"""
+        SELECT * FROM approvals {where}
+        ORDER BY requested_at DESC
+        LIMIT ? OFFSET ?
+        """,
+        [*params, limit, offset],
+    )
+    total_row = db.fetchone(f"SELECT COUNT(*) FROM approvals {where}", params)
+    return {
+        "approvals": [_approval_row_to_dict(r) for r in rows],
+        "total": int(total_row[0]) if total_row else 0,
+    }
+
+
+@router.get("/v1/approvals/{approval_id}")
+def get_approval(approval_id: str, db: Database = Depends(get_db)) -> Dict[str, Any]:
+    row = db.fetchone_dict("SELECT * FROM approvals WHERE id = ?", [approval_id])
+    if not row:
+        raise HTTPException(status_code=404, detail="approval not found")
+    return _approval_row_to_dict(row)
+
+
+@router.post("/v1/approvals/{approval_id}/resolve")
+def resolve_approval(
+    approval_id: str,
+    payload: ApprovalResolveRequest,
+    db: Database = Depends(get_db),
+) -> Dict[str, Any]:
+    if payload.resolution not in ("allow", "deny"):
+        raise HTTPException(status_code=400, detail="resolution must be allow|deny")
+    row = db.fetchone_dict(
+        "SELECT id, state FROM approvals WHERE id = ?", [approval_id]
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="approval not found")
+    if row["state"] not in ("pending",):
+        raise HTTPException(
+            status_code=409,
+            detail=f"approval already {row['state']}",
+        )
+    new_state = "allowed" if payload.resolution == "allow" else "denied"
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    db.execute(
+        """
+        UPDATE approvals SET
+            state = ?,
+            resolved_at = ?,
+            resolved_by = ?,
+            resolution_reason = ?
+        WHERE id = ?
+        """,
+        [new_state, now, payload.resolver, payload.reason, approval_id],
+    )
+    return {
+        "id": approval_id,
+        "state": new_state,
+        "resolved_at": now.isoformat(),
+    }
+
+
+# ---- helpers --------------------------------------------------------------
+
+
+def _build_decision_filters(
+    *,
+    project: Optional[str], agent: Optional[str], session_id: Optional[str],
+    trace_id: Optional[str], decision: Optional[str], lifecycle: Optional[str],
+    since: Optional[datetime], until: Optional[datetime],
+) -> tuple:
+    clauses: List[str] = []
+    params: List[Any] = []
+    if project:
+        clauses.append("project = ?"); params.append(project)
+    if agent:
+        clauses.append("agent = ?"); params.append(agent)
+    if session_id:
+        clauses.append("session_id = ?"); params.append(session_id)
+    if trace_id:
+        clauses.append("trace_id = ?"); params.append(trace_id)
+    if decision:
+        clauses.append("decision = ?"); params.append(decision)
+    if lifecycle:
+        clauses.append("lifecycle = ?"); params.append(lifecycle)
+    if since:
+        clauses.append("decision_at >= ?"); params.append(since.replace(tzinfo=None))
+    if until:
+        clauses.append("decision_at <= ?"); params.append(until.replace(tzinfo=None))
+    where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+    return where, params
+
+
+def _decision_row_to_dict(row: Dict[str, Any]) -> Dict[str, Any]:
+    out = dict(row)
+    da = out.get("decision_at")
+    if isinstance(da, datetime):
+        out["decision_at"] = da.isoformat()
+    if isinstance(out.get("metadata"), str):
+        try:
+            out["metadata"] = json.loads(out["metadata"])
+        except json.JSONDecodeError:
+            pass
+    return out
+
+
+def _approval_row_to_dict(row: Dict[str, Any]) -> Dict[str, Any]:
+    out = dict(row)
+    for key in ("requested_at", "resolved_at", "timeout_at"):
+        v = out.get(key)
+        if isinstance(v, datetime):
+            out[key] = v.isoformat()
+    if isinstance(out.get("params_truncated"), str):
+        try:
+            out["params_truncated"] = json.loads(out["params_truncated"])
+        except json.JSONDecodeError:
+            pass
+    return out

--- a/packages/api/routers/policy.py
+++ b/packages/api/routers/policy.py
@@ -353,10 +353,18 @@ def update_policy(
             webhook_url=body.webhook_url,
             scope_agents=body.scope_agents,
             enabled=body.enabled,
+            lifecycle=body.lifecycle,
+            mode=body.mode,
+            priority=body.priority,
+            on_timeout=body.on_timeout,
+            on_internal_error=body.on_internal_error,
             actor=actor,
         )
     except KeyError:
         raise HTTPException(status_code=404, detail=f"policy '{name}' not found")
+    except ValueError as e:
+        # Validation error from policy_store (bad lifecycle/mode/etc.)
+        raise HTTPException(status_code=400, detail=str(e))
 
     reload_result = policy_runtime.reload_engine(db=db)
     if not reload_result.get("ok"):
@@ -462,6 +470,18 @@ def _build_policy_from_create(body: PolicyCreate) -> Policy:
 
     _validate_condition_parses(body.condition)
 
+    # Apply spec §10.1 default: new policies enter shadow mode unless
+    # the caller explicitly overrides. The migration leaves existing
+    # rows at mode='enforce' for back-compat; this branch only affects
+    # the freshly-authored ones.
+    mode = body.mode if body.mode is not None else "shadow"
+    lifecycle = body.lifecycle if body.lifecycle is not None else "post_ingest"
+    priority = int(body.priority) if body.priority is not None else 0
+    on_timeout = body.on_timeout if body.on_timeout is not None else "allow"
+    on_internal_error = (
+        body.on_internal_error if body.on_internal_error is not None else "allow"
+    )
+
     return Policy(
         name=body.name.strip(),
         description=body.description,
@@ -471,6 +491,11 @@ def _build_policy_from_create(body: PolicyCreate) -> Policy:
         severity=body.severity,
         webhook_url=body.webhook_url,
         scope_agents=list(body.scope_agents or []),
+        lifecycle=lifecycle,
+        mode=mode,
+        priority=priority,
+        on_timeout=on_timeout,
+        on_internal_error=on_internal_error,
     )
 
 

--- a/packages/api/tests/firewall/test_decide.py
+++ b/packages/api/tests/firewall/test_decide.py
@@ -1,0 +1,361 @@
+"""Tests for the synchronous decision engine (§5.1, §10.1–10.3 of
+AGENT_FIREWALL_SPEC.md).
+
+Covers:
+
+  - Allow path when no policy applies (fast path)
+  - Block / flag / require_approval / rewrite verbs
+  - Mode resolution (shadow / flag / enforce)
+  - Priority ordering and explicit-allow short-circuit
+  - Lifecycle filtering
+  - Agent scope filtering
+  - Circuit-breaker tripped policies are skipped
+  - Panic disable global kill-switch
+  - Internal error handling (Rule 7)
+  - Latency budget honored under simulated timeout
+  - Decision row written for every non-fast-path request
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+import pytest
+
+from db import Database
+from firewall import decide as fw_decide
+from lumin.policy import Policy
+import policy_store
+
+
+# ---- fixtures -------------------------------------------------------------
+
+
+@pytest.fixture
+def db() -> Database:
+    """In-memory DuckDB per test — schema + firewall migrations run
+    on init via Database._init_schema."""
+    d = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    fw_decide.set_panic_disabled(False)
+    yield d
+    fw_decide.set_panic_disabled(False)
+    d.close()
+
+
+def _mk_policy(
+    db: Database,
+    *,
+    name: str,
+    lifecycle: str = "before_tool_call",
+    mode: str = "enforce",
+    priority: int = 0,
+    action: str = "block",
+    condition: str = "True",
+    scope_agents=None,
+) -> Policy:
+    p = Policy(
+        name=name,
+        description=f"test policy {name}",
+        trigger="span_end",
+        condition=condition,
+        action=action,
+        severity="medium",
+        scope_agents=scope_agents or [],
+        lifecycle=lifecycle,
+        mode=mode,
+        priority=priority,
+    )
+    return policy_store.create_policy(db, p, actor="test")
+
+
+# ---- fast paths -----------------------------------------------------------
+
+
+def test_allow_when_no_policies(db: Database) -> None:
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "allow"
+    assert "duration_ms" in out
+
+
+def test_unknown_lifecycle_short_circuits_allow(db: Database) -> None:
+    _mk_policy(db, name="never_applies")
+    out = fw_decide.decide(db, lifecycle="not_a_real_lifecycle")
+    assert out["decision"] == "allow"
+    assert "unknown_lifecycle" in out["reason"]
+
+
+# ---- block / flag / require_approval / rewrite ---------------------------
+
+
+def test_block_decision_records_row_and_returns(db: Database) -> None:
+    _mk_policy(db, name="block_all", action="block", condition="True")
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "block"
+    assert out["policy_name"] == "block_all"
+    assert out["mode_at_decision"] == "enforce"
+    assert "decision_id" in out
+
+    rows = db.fetchall_dict("SELECT * FROM decisions WHERE id = ?", [out["decision_id"]])
+    assert len(rows) == 1
+    assert rows[0]["decision"] == "block"
+    assert rows[0]["policy_name"] == "block_all"
+    assert rows[0]["lifecycle"] == "before_tool_call"
+
+
+def test_flag_decision(db: Database) -> None:
+    _mk_policy(db, name="flag_all", action="flag", condition="True")
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "flag"
+    assert out["policy_name"] == "flag_all"
+
+
+def test_require_approval_creates_approval_row(db: Database) -> None:
+    _mk_policy(
+        db, name="needs_approval",
+        action="require_approval", condition="True",
+    )
+    out = fw_decide.decide(
+        db, lifecycle="before_tool_call",
+        tool_name="shell", params={"command": "rm -rf /tmp/x"},
+        agent="test_agent", trace_id="trace-1",
+    )
+    assert out["decision"] == "require_approval"
+    assert out["approval_id"].startswith("apv_")
+    assert out["timeout_s"] == 600
+
+    apv = db.fetchone_dict(
+        "SELECT * FROM approvals WHERE id = ?", [out["approval_id"]]
+    )
+    assert apv is not None
+    assert apv["state"] == "pending"
+    assert apv["policy_id"] == "needs_approval"
+    assert apv["trace_id"] == "trace-1"
+
+
+def test_rewrite_redacts_pii(db: Database) -> None:
+    _mk_policy(
+        db, name="rewrite_pii",
+        lifecycle="after_tool_call",
+        action="rewrite",
+        condition="has_pii(text)",
+    )
+    out = fw_decide.decide(
+        db, lifecycle="after_tool_call",
+        tool_name="lookup",
+        params={"name": "Customer ssn 123-45-6789 and card 4111 1111 1111 1111"},
+    )
+    assert out["decision"] == "rewrite"
+    redacted = out["rewritten"]["params"]["name"]
+    assert "123-45-6789" not in redacted
+    assert "4111" not in redacted
+
+
+# ---- mode resolution -----------------------------------------------------
+
+
+def test_shadow_mode_returns_allow_but_records_decision(db: Database) -> None:
+    _mk_policy(
+        db, name="shadow_block",
+        action="block", mode="shadow", condition="True",
+    )
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "allow"
+    # shadow_hits surfaced for the dashboard
+    assert "shadow_hits" in out
+    assert out["shadow_hits"][0]["policy_id"] == "shadow_block"
+    assert out["shadow_hits"][0]["would_have_been"] == "block"
+
+    rows = db.fetchall_dict(
+        "SELECT * FROM decisions WHERE policy_name = ?", ["shadow_block"]
+    )
+    assert len(rows) == 1
+    assert rows[0]["mode_at_decision"] == "shadow"
+    assert rows[0]["decision"] == "block"  # what it WOULD have done
+
+
+def test_flag_mode_overrides_action(db: Database) -> None:
+    """A block-action rule in mode=flag returns decision=flag."""
+    _mk_policy(
+        db, name="flag_mode_block",
+        action="block", mode="flag", condition="True",
+    )
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "flag"
+    assert out["mode_at_decision"] == "flag"
+
+
+# ---- priority + explicit allow ------------------------------------------
+
+
+def test_priority_orders_evaluation(db: Database) -> None:
+    """A high-priority block fires before a low-priority allow."""
+    _mk_policy(db, name="low_allow", action="allow", priority=10, condition="True")
+    _mk_policy(db, name="high_block", action="block", priority=100, condition="True")
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "block"
+    assert out["policy_name"] == "high_block"
+
+
+def test_explicit_allow_short_circuits(db: Database) -> None:
+    """A higher-priority allow skips lower-priority blocks."""
+    _mk_policy(db, name="low_block", action="block", priority=10, condition="True")
+    _mk_policy(db, name="high_allow", action="allow", priority=100, condition="True")
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "allow"
+    assert out["policy_name"] == "high_allow"
+
+
+# ---- lifecycle and scope filtering --------------------------------------
+
+
+def test_lifecycle_mismatch_skips_policy(db: Database) -> None:
+    _mk_policy(
+        db, name="post_only",
+        lifecycle="post_ingest", action="block", condition="True",
+    )
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "allow"
+
+
+def test_scope_agents_filters(db: Database) -> None:
+    _mk_policy(
+        db, name="bot_only",
+        action="block", condition="True",
+        scope_agents=["bot.support"],
+    )
+    out_match = fw_decide.decide(
+        db, lifecycle="before_tool_call", tool_name="shell", agent="bot.support"
+    )
+    assert out_match["decision"] == "block"
+
+    out_skip = fw_decide.decide(
+        db, lifecycle="before_tool_call", tool_name="shell", agent="other_agent"
+    )
+    assert out_skip["decision"] == "allow"
+
+
+# ---- circuit breaker -----------------------------------------------------
+
+
+def test_tripped_circuit_breaker_skips_policy(db: Database) -> None:
+    _mk_policy(db, name="will_be_tripped", action="block", condition="True")
+    policy_store.update_policy(
+        db, "will_be_tripped", circuit_breaker_state="tripped"
+    )
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "allow"
+
+
+# ---- panic disable -------------------------------------------------------
+
+
+def test_panic_disable_short_circuits_to_allow(db: Database) -> None:
+    _mk_policy(db, name="block_all", action="block", condition="True")
+    fw_decide.set_panic_disabled(True, reason="incident-123")
+    try:
+        out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+        assert out["decision"] == "allow"
+        assert out["reason"] == "panic_disabled"
+        assert out["panic_reason"] == "incident-123"
+    finally:
+        fw_decide.set_panic_disabled(False)
+
+    # No decision row recorded for panic short-circuit (we don't want
+    # the audit log spammed during an incident; the panic write itself
+    # is the audit trail).
+    rows = db.fetchall_dict("SELECT * FROM decisions")
+    assert rows == []
+
+
+# ---- error handling (Rule 7) ---------------------------------------------
+
+
+def test_broken_condition_falls_back_to_allow_by_default(db: Database) -> None:
+    """A policy whose condition references an undefined name falls
+    through (Rule 7 — agent never blocks on Lumin)."""
+    _mk_policy(
+        db, name="broken",
+        action="block",
+        # NameError at eval time — undefined_name is not in the
+        # namespace table.
+        condition="undefined_name",
+    )
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "allow"
+
+
+def test_on_internal_error_deny_blocks(db: Database) -> None:
+    _mk_policy(db, name="strict", action="block", condition="undefined_name")
+    policy_store.update_policy(db, "strict", on_internal_error="deny")
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "block"
+    assert out["reason"] == "internal_error"
+
+
+# ---- input namespace -----------------------------------------------------
+
+
+def test_condition_can_read_tool_name_and_params(db: Database) -> None:
+    _mk_policy(
+        db, name="block_dangerous",
+        action="block",
+        condition='tool_name == "shell" and "rm -rf" in str(Input.params.get("command", ""))',
+    )
+    # Match
+    out = fw_decide.decide(
+        db, lifecycle="before_tool_call",
+        tool_name="shell", params={"command": "rm -rf /etc"},
+    )
+    assert out["decision"] == "block"
+
+    # Different tool — no match
+    out2 = fw_decide.decide(
+        db, lifecycle="before_tool_call",
+        tool_name="lookup", params={"command": "rm -rf /etc"},
+    )
+    assert out2["decision"] == "allow"
+
+
+def test_condition_can_read_output_text(db: Database) -> None:
+    _mk_policy(
+        db, name="block_secret_in_output",
+        lifecycle="after_proxy_call",
+        action="block",
+        condition="looks_like_secret(Output.text)",
+    )
+    out = fw_decide.decide(
+        db, lifecycle="after_proxy_call",
+        # GitHub PAT shape — assembled at runtime to avoid GitHub
+        # secret scanning flagging this fixture in source.
+        output="Here is your token: " + "ghp_" + "x" * 36,
+    )
+    assert out["decision"] == "block"
+
+
+# ---- decision row payload -----------------------------------------------
+
+
+def test_decision_row_records_all_context(db: Database) -> None:
+    _mk_policy(db, name="rec", action="flag", condition="True")
+    out = fw_decide.decide(
+        db,
+        lifecycle="before_tool_call",
+        tool_name="shell",
+        agent="bot.support",
+        project="proj-A",
+        session_id="sess-7",
+        trace_id="trace-x",
+        span_id="span-y",
+    )
+    row = db.fetchone_dict(
+        "SELECT * FROM decisions WHERE id = ?", [out["decision_id"]]
+    )
+    assert row is not None
+    assert row["agent"] == "bot.support"
+    assert row["project"] == "proj-A"
+    assert row["session_id"] == "sess-7"
+    assert row["trace_id"] == "trace-x"
+    assert row["span_id"] == "span-y"
+    assert row["tool_name"] == "shell"
+    assert row["lifecycle"] == "before_tool_call"

--- a/packages/api/tests/firewall/test_decide_http.py
+++ b/packages/api/tests/firewall/test_decide_http.py
@@ -1,0 +1,317 @@
+"""HTTP-level tests for the Agent Firewall router (§5.1–5.4, 5.6, 5.7,
+10.2 of AGENT_FIREWALL_SPEC.md).
+
+Verifies the endpoint surfaces, not the engine internals (those live
+in ``test_decide.py``). Focuses on:
+
+  - ``POST /v1/policy/decide`` returns the right shape and never 5xx
+  - ``GET /v1/decisions`` filters + paginates
+  - ``GET /v1/decisions/{id}`` returns siblings and policy snapshot
+  - ``POST /v1/policies/{name}/mode`` flips mode + returns forecast
+  - ``POST /v1/firewall/panic_disable`` sets the flag + persists
+  - ``POST /v1/approvals/{id}/resolve`` flips state
+  - Shadow-mode default (§10.1, task #38) — new policies created via
+    POST /v1/policies start in mode='shadow' unless overridden
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from db import Database
+from firewall import decide as fw_decide
+from lumin.policy import Policy
+import policy_store
+
+
+# ---- helpers -------------------------------------------------------------
+
+
+def _create_policy_via_db(
+    db: Database, *, name: str, action: str = "block",
+    mode: str = "enforce", lifecycle: str = "before_tool_call",
+    condition: str = "True", priority: int = 0,
+) -> None:
+    """Bypass the HTTP create handler so the test doesn't depend on
+    that endpoint working. The decide endpoint and dashboard endpoints
+    just need rows in the policies table to read from."""
+    p = Policy(
+        name=name, description=f"test {name}",
+        trigger="span_end", condition=condition,
+        action=action, severity="medium",
+        lifecycle=lifecycle, mode=mode, priority=priority,
+    )
+    policy_store.create_policy(db, p, actor="test")
+
+
+# ---- /v1/policy/decide ---------------------------------------------------
+
+
+def test_decide_endpoint_returns_block(client, db) -> None:
+    _create_policy_via_db(db, name="block_all", action="block")
+    r = client.post(
+        "/v1/policy/decide",
+        json={"lifecycle": "before_tool_call", "tool_name": "shell"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["decision"] == "block"
+    assert body["policy_name"] == "block_all"
+
+
+def test_decide_endpoint_returns_allow_when_no_policies(client) -> None:
+    r = client.post(
+        "/v1/policy/decide",
+        json={"lifecycle": "before_tool_call", "tool_name": "shell"},
+    )
+    assert r.status_code == 200
+    assert r.json()["decision"] == "allow"
+
+
+def test_decide_endpoint_never_500s_on_garbage(client) -> None:
+    r = client.post("/v1/policy/decide", json={"lifecycle": "garbage"})
+    assert r.status_code == 200
+    assert r.json()["decision"] == "allow"
+
+
+# ---- /v1/decisions list + detail ----------------------------------------
+
+
+def test_list_decisions_returns_recent(client, db) -> None:
+    _create_policy_via_db(db, name="rec_all", action="flag")
+    for i in range(3):
+        client.post(
+            "/v1/policy/decide",
+            json={
+                "lifecycle": "before_tool_call",
+                "tool_name": "shell",
+                "trace_id": f"t{i}",
+            },
+        )
+    r = client.get("/v1/decisions")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 3
+    assert len(body["decisions"]) == 3
+
+
+def test_list_decisions_filters_by_decision(client, db) -> None:
+    _create_policy_via_db(db, name="block_all", action="block", priority=10)
+    _create_policy_via_db(
+        db, name="flag_subset", action="flag",
+        condition='tool_name == "lookup"',
+        priority=20,
+    )
+    client.post("/v1/policy/decide", json={"lifecycle": "before_tool_call", "tool_name": "shell"})
+    client.post("/v1/policy/decide", json={"lifecycle": "before_tool_call", "tool_name": "lookup"})
+    r = client.get("/v1/decisions?decision=flag")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    assert body["decisions"][0]["decision"] == "flag"
+
+
+def test_get_decision_detail_returns_policy_snapshot(client, db) -> None:
+    _create_policy_via_db(db, name="block_x", action="block")
+    create_resp = client.post(
+        "/v1/policy/decide",
+        json={"lifecycle": "before_tool_call", "tool_name": "shell"},
+    )
+    decision_id = create_resp.json()["decision_id"]
+    r = client.get(f"/v1/decisions/{decision_id}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["decision"]["id"] == decision_id
+    assert body["policy"]["name"] == "block_x"
+
+
+def test_get_decision_detail_404_on_missing(client) -> None:
+    r = client.get("/v1/decisions/nope_not_real")
+    assert r.status_code == 404
+
+
+# ---- /v1/policies/{name}/mode -------------------------------------------
+
+
+def test_set_policy_mode_flips_value(client, db) -> None:
+    _create_policy_via_db(db, name="m1", mode="shadow")
+    r = client.post("/v1/policies/m1/mode", json={"mode": "enforce"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mode"] == "enforce"
+    assert body["previous_mode"] == "shadow"
+
+
+def test_set_policy_mode_returns_forecast_count(client, db) -> None:
+    _create_policy_via_db(db, name="bx", action="block", mode="shadow")
+    # Generate decisions in shadow so the forecast has population.
+    for _ in range(3):
+        client.post(
+            "/v1/policy/decide",
+            json={"lifecycle": "before_tool_call", "tool_name": "shell"},
+        )
+    r = client.post("/v1/policies/bx/mode", json={"mode": "enforce"})
+    assert r.status_code == 200
+    forecast = r.json()["forecast"]
+    assert forecast["would_have_blocked"] == 3
+
+
+def test_set_policy_mode_rejects_bad_mode(client, db) -> None:
+    _create_policy_via_db(db, name="m2")
+    r = client.post("/v1/policies/m2/mode", json={"mode": "garbage"})
+    assert r.status_code == 400
+
+
+def test_set_policy_mode_404_on_missing(client) -> None:
+    r = client.post("/v1/policies/missing/mode", json={"mode": "enforce"})
+    assert r.status_code == 404
+
+
+# ---- panic disable (§10.2) ----------------------------------------------
+
+
+def test_panic_disable_short_circuits_decide(client, db) -> None:
+    _create_policy_via_db(db, name="block_all", action="block")
+    # Sanity: blocks before panic.
+    r = client.post(
+        "/v1/policy/decide",
+        json={"lifecycle": "before_tool_call", "tool_name": "shell"},
+    )
+    assert r.json()["decision"] == "block"
+
+    # Panic on.
+    r = client.post(
+        "/v1/firewall/panic_disable",
+        json={"disabled": True, "reason": "drill", "actor": "ops@example.com"},
+    )
+    assert r.status_code == 200
+    assert r.json()["disabled"] is True
+
+    # Now decides allow.
+    r = client.post(
+        "/v1/policy/decide",
+        json={"lifecycle": "before_tool_call", "tool_name": "shell"},
+    )
+    assert r.json()["decision"] == "allow"
+    assert r.json()["reason"] == "panic_disabled"
+
+    # Re-enable.
+    r = client.post(
+        "/v1/firewall/panic_disable",
+        json={"disabled": False, "actor": "ops@example.com"},
+    )
+    assert r.json()["disabled"] is False
+
+
+def test_panic_state_persists_via_kv(client, db) -> None:
+    client.post(
+        "/v1/firewall/panic_disable",
+        json={"disabled": True, "reason": "test"},
+    )
+    row = db.fetchone_dict(
+        "SELECT v FROM firewall_kv WHERE k = 'panic_disabled'"
+    )
+    assert row is not None
+    assert "disabled" in row["v"]
+    # Reset for other tests
+    client.post("/v1/firewall/panic_disable", json={"disabled": False})
+
+
+# ---- approvals -----------------------------------------------------------
+
+
+def test_approval_resolve_flow(client, db) -> None:
+    _create_policy_via_db(db, name="needs_apv", action="require_approval")
+    r = client.post(
+        "/v1/policy/decide",
+        json={"lifecycle": "before_tool_call", "tool_name": "shell"},
+    )
+    apv_id = r.json()["approval_id"]
+
+    r = client.get(f"/v1/approvals/{apv_id}")
+    assert r.status_code == 200
+    assert r.json()["state"] == "pending"
+
+    r = client.post(
+        f"/v1/approvals/{apv_id}/resolve",
+        json={"resolution": "deny", "reason": "ops"},
+    )
+    assert r.status_code == 200
+    assert r.json()["state"] == "denied"
+
+    # Resolving twice is a 409.
+    r = client.post(
+        f"/v1/approvals/{apv_id}/resolve",
+        json={"resolution": "allow"},
+    )
+    assert r.status_code == 409
+
+
+def test_list_approvals_filters_by_state(client, db) -> None:
+    _create_policy_via_db(db, name="needs_apv", action="require_approval")
+    client.post(
+        "/v1/policy/decide",
+        json={"lifecycle": "before_tool_call", "tool_name": "shell"},
+    )
+    r = client.get("/v1/approvals?state=pending")
+    assert r.status_code == 200
+    assert r.json()["total"] >= 1
+
+
+# ---- shadow-mode default for new policies (§10.1, task #38) -------------
+
+
+def test_new_policy_via_api_defaults_to_shadow(client) -> None:
+    """A POST /v1/policies without an explicit mode must land in
+    mode='shadow' so live traffic isn't affected on first save."""
+    r = client.post(
+        "/v1/policies",
+        json={
+            "name": "fresh_rule",
+            "trigger": "span_end",
+            "condition": "True",
+            "action": "block",
+            "severity": "medium",
+        },
+    )
+    assert r.status_code in (200, 201)
+
+    r = client.get("/v1/policies/fresh_rule")
+    assert r.status_code == 200
+    # /v1/policies/{name} returns PolicyOut — mode lives on the
+    # row underneath even if the model doesn't surface it yet.
+    # Cross-check via /v1/decisions by triggering the rule and
+    # confirming it didn't block.
+    decide = client.post(
+        "/v1/policy/decide",
+        json={"lifecycle": "post_ingest", "tool_name": "x"},
+    )
+    body = decide.json()
+    # Rule is in shadow → engine returns allow but records the would-
+    # have-been-block as a shadow_hit.
+    assert body["decision"] == "allow"
+    if "shadow_hits" in body:
+        assert any(h["policy_id"] == "fresh_rule" for h in body["shadow_hits"])
+
+
+def test_new_policy_with_explicit_mode_overrides_default(client) -> None:
+    r = client.post(
+        "/v1/policies",
+        json={
+            "name": "explicit_enforce",
+            "trigger": "span_end",
+            "condition": "True",
+            "action": "block",
+            "severity": "medium",
+            "lifecycle": "before_tool_call",
+            "mode": "enforce",
+        },
+    )
+    assert r.status_code in (200, 201)
+    decide = client.post(
+        "/v1/policy/decide",
+        json={"lifecycle": "before_tool_call", "tool_name": "x"},
+    )
+    assert decide.json()["decision"] == "block"

--- a/packages/api/tests/firewall/test_latency.py
+++ b/packages/api/tests/firewall/test_latency.py
@@ -1,0 +1,149 @@
+"""CI latency assertion for the synchronous decision engine
+(§10.6 of AGENT_FIREWALL_SPEC.md).
+
+Spec budgets (§2.4):
+  - before_proxy_call : 50 ms
+  - before_tool_call  : 50 ms
+  - after_tool_call   : 100 ms
+  - after_proxy_call  : 300 ms
+
+We assert decide() stays well under the *before_tool_call* budget
+under realistic conditions (10 enabled rules, simple regex
+condition). 50ms is the budget; CI machines vary, so the gate is
+20ms p99 — generous headroom that still catches a 10x regression.
+
+The point of this test is to fail loudly if someone:
+  - introduces a per-call DB query that wasn't there before,
+  - forgets to sort policies by priority (linear → quadratic in
+    chained-allow paths),
+  - or registers a builtin that does I/O on every call.
+
+The 1-second TTL cache on history builtins is what makes this
+sustainable across ~thousands of decisions per second; without it,
+each rule that calls session_total_tokens would hit DuckDB and
+balloon p99 well past budget.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+
+import pytest
+
+from db import Database
+from firewall import decide as fw_decide
+from lumin.policy import Policy
+import policy_store
+
+
+P99_BUDGET_MS = 20
+P50_BUDGET_MS = 5
+ITERATIONS = 200
+
+
+@pytest.fixture
+def db_with_rules() -> Database:
+    d = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    fw_decide.set_panic_disabled(False)
+
+    # 10 rules, each cheap: regex_match against a tool name. Mirror
+    # the size of a realistic in-house policy file.
+    for i in range(10):
+        p = Policy(
+            name=f"rule_{i:02d}",
+            description=f"perf rule {i}",
+            trigger="span_end",
+            condition=f'tool_name == "tool_{i}"',
+            action="block" if i % 2 == 0 else "flag",
+            severity="medium",
+            lifecycle="before_tool_call",
+            mode="shadow" if i < 5 else "enforce",
+            priority=i,
+        )
+        policy_store.create_policy(d, p, actor="perf")
+
+    yield d
+    d.close()
+
+
+def test_decide_p99_under_budget(db_with_rules: Database) -> None:
+    """Run ITERATIONS decisions and assert p99 < P99_BUDGET_MS.
+
+    The first call pays cold-cache costs; we use it as a warmup
+    rather than counting it in the percentile.
+    """
+    samples = []
+    # Warmup
+    fw_decide.decide(
+        db_with_rules,
+        lifecycle="before_tool_call",
+        tool_name="tool_99",
+    )
+
+    for i in range(ITERATIONS):
+        t0 = time.perf_counter()
+        out = fw_decide.decide(
+            db_with_rules,
+            lifecycle="before_tool_call",
+            tool_name=f"tool_{i % 10}",
+            params={"command": f"echo {i}"},
+            session_id=f"sess_{i % 3}",
+            trace_id=f"trace_{i}",
+            agent="bot.support",
+        )
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        samples.append(elapsed_ms)
+        assert out["decision"] in ("allow", "block", "flag")
+
+    p50 = statistics.median(samples)
+    p99 = statistics.quantiles(samples, n=100)[98]
+    p_max = max(samples)
+
+    print(f"\ndecide latency: p50={p50:.2f}ms p99={p99:.2f}ms max={p_max:.2f}ms")
+    assert p50 < P50_BUDGET_MS, (
+        f"p50 {p50:.2f}ms exceeds {P50_BUDGET_MS}ms — possible per-call DB query introduced?"
+    )
+    assert p99 < P99_BUDGET_MS, (
+        f"p99 {p99:.2f}ms exceeds {P99_BUDGET_MS}ms — investigate hot path."
+    )
+
+
+def test_decide_no_policy_fast_path_under_1ms(db_with_rules: Database) -> None:
+    """When no policies match the lifecycle, decide() should skip
+    the simpleeval setup entirely and return in well under 1ms.
+
+    This guards the cold path most agents will hit — they typically
+    have rules under post_ingest, not before_tool_call, so most calls
+    short-circuit on the empty-policy-set branch.
+    """
+    # Move all rules out of the before_tool_call lifecycle.
+    db_with_rules.execute(
+        "UPDATE policies SET lifecycle = 'post_ingest'"
+    )
+    samples = []
+    # Warmup
+    fw_decide.decide(db_with_rules, lifecycle="before_tool_call")
+
+    for _ in range(100):
+        t0 = time.perf_counter()
+        fw_decide.decide(db_with_rules, lifecycle="before_tool_call", tool_name="x")
+        samples.append((time.perf_counter() - t0) * 1000)
+    p99 = statistics.quantiles(samples, n=100)[98]
+    print(f"\nno-policy fast path: p99={p99:.3f}ms")
+    assert p99 < 5, f"empty-policy-set fast path exceeded 5ms: p99={p99:.3f}ms"
+
+
+def test_decide_under_timeout_still_returns_allow(db_with_rules: Database) -> None:
+    """Sanity: even if every policy in the lifecycle matched, decide()
+    completes well within budget. We're not simulating an artificial
+    100ms latency here — that needs hooks the engine doesn't expose
+    today — but we verify the happy path under load doesn't drift."""
+    for _ in range(50):
+        out = fw_decide.decide(
+            db_with_rules,
+            lifecycle="before_tool_call",
+            tool_name="tool_0",  # matches rule_00 (block, shadow) ⇒ allow w/ shadow_hit
+        )
+        assert out["decision"] == "allow"
+        assert out["duration_ms"] < 50  # full budget

--- a/packages/api/tests/firewall/test_starter_pack.py
+++ b/packages/api/tests/firewall/test_starter_pack.py
@@ -1,0 +1,96 @@
+"""Tests for the OWASP LLM Top 10 starter pack auto-install
+(§10.1 + §11 of AGENT_FIREWALL_SPEC.md, task #42).
+
+Verifies:
+
+  - Bootstrap imports rules into a fresh DB
+  - All imported rules land in mode=shadow (never block live traffic
+    on a fresh install)
+  - Bootstrap is idempotent — re-running with rules already present
+    is a no-op
+  - LUMIN_DISABLE_STARTER_PACK env var skips the import
+  - LUMIN_POLICY_FILE set defers to user YAML (no starter pack)
+  - The 9 imported rules parse cleanly with the firewall builtins —
+    a typo in starter_pack/owasp_llm_top_10.yaml fails CI here
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from db import Database
+from firewall.starter_packs import bootstrap as starter_bootstrap
+import policy_store
+
+
+@pytest.fixture(autouse=True)
+def _no_user_yaml(monkeypatch):
+    """Strip env so starter pack tests run in a deterministic
+    environment regardless of dev shell config."""
+    monkeypatch.delenv("LUMIN_POLICY_FILE", raising=False)
+    monkeypatch.delenv("LUMIN_DISABLE_STARTER_PACK", raising=False)
+
+
+@pytest.fixture
+def db() -> Database:
+    d = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    yield d
+    d.close()
+
+
+def test_bootstrap_imports_rules_into_fresh_db(db: Database) -> None:
+    n = starter_bootstrap.install_owasp_pack_if_fresh(db)
+    assert n > 0, "expected starter pack to import at least one rule"
+    rows = policy_store.list_policies(db)
+    assert len(rows) == n
+
+
+def test_all_imported_rules_are_shadow_mode(db: Database) -> None:
+    starter_bootstrap.install_owasp_pack_if_fresh(db)
+    rows = policy_store.list_policies(db)
+    non_shadow = [p for p in rows if p.mode != "shadow"]
+    assert non_shadow == [], (
+        f"starter pack rules must ship in mode=shadow per §10.1; "
+        f"found non-shadow: {[p.name for p in non_shadow]}"
+    )
+
+
+def test_bootstrap_is_idempotent(db: Database) -> None:
+    first = starter_bootstrap.install_owasp_pack_if_fresh(db)
+    second = starter_bootstrap.install_owasp_pack_if_fresh(db)
+    assert first > 0
+    assert second == 0  # already populated → skip
+
+
+def test_disable_env_var_skips_import(db: Database, monkeypatch) -> None:
+    monkeypatch.setenv("LUMIN_DISABLE_STARTER_PACK", "true")
+    n = starter_bootstrap.install_owasp_pack_if_fresh(db)
+    assert n == 0
+    assert policy_store.list_policies(db) == []
+
+
+def test_user_yaml_takes_precedence(db: Database, monkeypatch, tmp_path) -> None:
+    """When LUMIN_POLICY_FILE is set, user YAML wins — starter pack
+    defers so the user-authored rules aren't shadowed by ours."""
+    user_file = tmp_path / "user.yaml"
+    user_file.write_text("version: 1\npolicies: []\n")
+    monkeypatch.setenv("LUMIN_POLICY_FILE", str(user_file))
+    n = starter_bootstrap.install_owasp_pack_if_fresh(db)
+    assert n == 0
+
+
+def test_imported_rules_have_valid_lifecycle_and_mode(db: Database) -> None:
+    starter_bootstrap.install_owasp_pack_if_fresh(db)
+    rows = policy_store.list_policies(db)
+    for p in rows:
+        assert p.lifecycle in policy_store.VALID_LIFECYCLES, (
+            f"{p.name}: bad lifecycle {p.lifecycle}"
+        )
+        assert p.mode in policy_store.VALID_MODES, (
+            f"{p.name}: bad mode {p.mode}"
+        )
+        assert p.action in (
+            "block", "flag", "require_approval", "rewrite", "allow"
+        ), f"{p.name}: action {p.action} not a firewall action"

--- a/packages/sdk-python/lumin/policy.py
+++ b/packages/sdk-python/lumin/policy.py
@@ -35,7 +35,20 @@ logger = logging.getLogger("lumin.policy")
 
 
 VALID_TRIGGERS = {"span_end", "trace_end"}
-VALID_ACTIONS = {"flag", "alert"}
+# Action vocabulary spans both layers:
+#   - post_ingest (legacy): flag, alert — advisory, recorded as
+#     PolicyViolation rows after the span lands.
+#   - Agent Firewall (per AGENT_FIREWALL_SPEC.md §3.3): allow, block,
+#     flag, require_approval, rewrite — synchronous decisions returned
+#     by /v1/policy/decide for proxy/tool lifecycles.
+# Both vocabularies coexist on the same Policy.action field. The
+# decide engine and the post-ingest engine each interpret only the
+# subset relevant to their lifecycle; cross-vocab misuse is caught
+# at validation time in the firewall path.
+VALID_ACTIONS = {
+    "flag", "alert",
+    "allow", "block", "require_approval", "rewrite",
+}
 VALID_SEVERITIES = {"low", "medium", "high", "critical"}
 
 
@@ -213,6 +226,19 @@ def _validate_policy_dict(d: dict, idx: int) -> Policy:
 
     scope_agents = _parse_scope_agents(d, idx)
 
+    # Agent Firewall fields (per AGENT_FIREWALL_SPEC.md §3) — all
+    # optional with safe defaults. Validation is intentionally permissive
+    # here: bad values fall back to defaults rather than rejecting the
+    # whole policy file, since legacy YAML pre-dates these fields.
+    lifecycle = d.get("lifecycle") or "post_ingest"
+    mode = d.get("mode") or "enforce"
+    try:
+        priority = int(d.get("priority") or 0)
+    except (TypeError, ValueError):
+        priority = 0
+    on_timeout = d.get("on_timeout") or "allow"
+    on_internal_error = d.get("on_internal_error") or "allow"
+
     return Policy(
         name=str(d["name"]),
         description=d.get("description"),
@@ -222,6 +248,11 @@ def _validate_policy_dict(d: dict, idx: int) -> Policy:
         severity=severity,
         webhook_url=d.get("webhook_url"),
         scope_agents=scope_agents,
+        lifecycle=lifecycle,
+        mode=mode,
+        priority=priority,
+        on_timeout=on_timeout,
+        on_internal_error=on_internal_error,
     )
 
 


### PR DESCRIPTION
Builds on #44 to land the runtime that actually evaluates rules in real time and the dashboard-facing APIs that drive the operator UX. Back-compat-safe — existing post-ingest violation flow is untouched, the new decide engine runs on its own \`/v1/policy/decide\` endpoint, and freshly-authored rules ship in \`mode=shadow\` per spec §10.1 so live traffic never gets blocked on day one.

## What's in this PR

**Engine (\`firewall/decide.py\`)** — synchronous decision loop. Filters policies by lifecycle + agent scope + circuit-breaker state, sorts by priority DESC, evaluates each condition in a fresh simpleeval with the firewall builtins as the function table, applies mode semantics (shadow/flag/enforce) on top of action (allow/block/flag/require_approval/rewrite). Per-lifecycle hard timeout — Rule 7 throughout: every error path returns allow.

**HTTP surface (\`routers/firewall.py\`)**
- \`POST /v1/policy/decide\`           §5.1 — sync decision endpoint
- \`GET  /v1/decisions\`               §5.2 — paginated timeline
- \`GET  /v1/decisions/{id}\`          §5.3 — detail + siblings + policy snapshot
- \`POST /v1/policies/{name}/mode\`    §5.4 — flip mode + 30d back-test forecast
- \`POST /v1/firewall/panic_disable\`  §10.2 — global kill-switch
- \`GET  /v1/approvals\`               §5.6 — operator inbox
- \`POST /v1/approvals/{id}/resolve\`  §5.7 — allow/deny resolution

**Shadow default for new policies (§10.1)** — POST /v1/policies now defaults \`mode='shadow'\`. Migration default stays \`enforce\` for back-compat. SDK YAML loader extended to pick up lifecycle/mode/priority/on_timeout/on_internal_error fields.

**Panic kill-switch (§10.2)** — persisted in \`firewall_kv\`, audit row in \`firewall_panic_audit\`, refreshed from DB on API startup so a flip survives restarts.

**OWASP LLM Top 10 starter pack (§11)** — 9 rules (LLM01/02/04/05/06/07/09/10) all in shadow mode. Auto-imported on first boot when the policies table is empty and LUMIN_POLICY_FILE is unset. Opt-out via LUMIN_DISABLE_STARTER_PACK=true.

**CI latency gate (§10.6)** — asserts decide() p50 <5ms / p99 <20ms across 200 iterations with 10 enabled rules. Empty-policy-set fast path required to stay under 5ms p99.

## What's NOT in this PR

- OpenClaw plugin v0.2.0 (#44) — separate PR coming next
- Dashboard surfaces (#45) — separate PR coming after that
- Detector slices for Presidio / Prompt Guard / Llama Guard / embeddings (later slices)

## Test plan

- [x] \`pytest tests/firewall/\` — 132 firewall tests, 41 net new (decide×19, decide_http×16, starter_pack×6, latency×3, plus the existing migrations/regex_pack/builtins/policy_extensions)
- [x] Full API suite: 335 passed, zero regressions
- [x] Latency assertion runs in CI: p50/p99/max printed; gate at 20ms p99
- [x] Migration idempotency: \`firewall_kv\` table created if absent, no-op on re-apply
- [x] Back-compat: existing post-ingest policies continue to evaluate identically; existing /v1/policies endpoint still works without firewall fields
- [x] Rule 7: panic disable / unknown lifecycle / broken condition / DB error all return \`allow\`
- [ ] Manual smoke: \`curl -X POST localhost:8000/v1/policy/decide\` round-trip with the running API (do before merge)

## Spec references

- §3.5 condition expressions (now extended with firewall builtins)
- §5.1–5.4, §5.6, §5.7 HTTP surface
- §10.1 shadow default
- §10.2 panic disable
- §10.3 circuit breaker (state column read; reset endpoint lands later)
- §10.6 CI latency assertions
- §11 starter pack