### PR TITLE
feat(dashboard): EnforcementTimeline + DecisionDetailPanel + ModeToggle + PanicBanner (Slice 1 part 3)

### DIFF
--- a/packages/dashboard/app/decisions/[id]/page.tsx
+++ b/packages/dashboard/app/decisions/[id]/page.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+
+import DecisionDetailPanel from '@/components/DecisionDetailPanel';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Decision',
+};
+
+export default function DecisionDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  return (
+    <div className="max-w-5xl mx-auto">
+      <div className="mb-5">
+        <Link
+          href="/decisions"
+          className="text-sm text-[var(--muted)] hover:underline"
+        >
+          ← All decisions
+        </Link>
+      </div>
+      <DecisionDetailPanel decisionId={params.id} />
+    </div>
+  );
+}

--- a/packages/dashboard/app/decisions/page.tsx
+++ b/packages/dashboard/app/decisions/page.tsx
@@ -1,0 +1,24 @@
+import EnforcementTimeline from '@/components/EnforcementTimeline';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Decisions',
+};
+
+export default function DecisionsPage() {
+  return (
+    <div className="max-w-7xl mx-auto">
+      <div className="mb-5">
+        <h1 className="text-lg font-semibold">Firewall decisions</h1>
+        <p className="text-sm text-[var(--muted)] mt-1">
+          Every policy evaluation, in real time. Use the filters to drill in by
+          decision verb, lifecycle, or agent. Shadow-mode firings show what the
+          firewall <em>would</em> have done — useful for tuning a rule before
+          you flip it to enforce.
+        </p>
+      </div>
+      <EnforcementTimeline />
+    </div>
+  );
+}

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Logo from '@/components/Logo';
 import ViolationsNavLink from '@/components/ViolationsNavLink';
 import NavLink from '@/components/NavLink';
+import PanicBanner from '@/components/PanicBanner';
 import ThemeToggle from '@/components/ThemeToggle';
 
 // Pre-hydration script — sets data-theme on <html> BEFORE React
@@ -52,6 +53,7 @@ export default function RootLayout({
       </head>
       <body>
         <div className="min-h-screen flex flex-col">
+          <PanicBanner />
           <header className="app-header px-6 py-3 flex items-center justify-between gap-4">
             <Link
               href="/agents"
@@ -71,6 +73,7 @@ export default function RootLayout({
               <NavLink href="/traces">Traces</NavLink>
               <NavLink href="/sessions">Sessions</NavLink>
               <NavLink href="/policies">Policies</NavLink>
+              <NavLink href="/decisions">Decisions</NavLink>
               <ViolationsNavLink />
               <span className="opacity-30 mx-1">·</span>
               <a

--- a/packages/dashboard/components/DecisionDetailPanel.tsx
+++ b/packages/dashboard/components/DecisionDetailPanel.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import Link from 'next/link';
+import useSWR from 'swr';
+
+import {
+  DecisionDetailResponse,
+  fetchDecisionDetail,
+} from '@/lib/api';
+
+import { DecisionBadge } from './EnforcementTimeline';
+
+/**
+ * "Why was this blocked?" view (§5.3 / §8.2). Renders a single
+ * decision plus:
+ *   - the matched policy snapshot (current YAML/DB shape)
+ *   - sibling decisions on the same trace (cross-policy ordering)
+ *   - the matched value (truncated to 200 chars by the API)
+ *
+ * The detail page at /decisions/[id] hosts this; it can also be
+ * mounted from a trace detail view to surface the firewall context
+ * inline.
+ */
+export default function DecisionDetailPanel({ decisionId }: { decisionId: string }) {
+  const { data, error, isLoading } = useSWR<DecisionDetailResponse>(
+    `decision:${decisionId}`,
+    () => fetchDecisionDetail(decisionId),
+  );
+
+  if (error) {
+    return (
+      <div className="card p-6 text-rose-400">
+        Failed to load decision: {String(error.message ?? error)}
+      </div>
+    );
+  }
+  if (isLoading || !data) {
+    return <div className="card p-8 text-center text-[var(--muted)]">Loading…</div>;
+  }
+
+  const d = data.decision;
+  return (
+    <div className="space-y-6">
+      <div className="card p-5 space-y-4">
+        <div className="flex items-center gap-3 flex-wrap">
+          <DecisionBadge decision={d.decision} mode={d.mode_at_decision} />
+          <span className="text-sm text-[var(--muted)]">{d.lifecycle}</span>
+          <span className="text-sm text-[var(--muted)]">·</span>
+          <span className="text-sm text-[var(--muted)]">{d.duration_ms}ms</span>
+          <span className="text-sm text-[var(--muted)]">·</span>
+          <span className="text-sm text-[var(--muted)]">{d.decision_at}</span>
+        </div>
+
+        <h2 className="text-xl font-semibold">{d.policy_name}</h2>
+
+        {d.reason && (
+          <p className="text-sm text-[var(--foreground-soft)]">{d.reason}</p>
+        )}
+
+        <DefList
+          rows={[
+            ['Trace', d.trace_id ? <TraceLink id={d.trace_id} /> : '—'],
+            ['Span', d.span_id || '—'],
+            ['Session', d.session_id || '—'],
+            ['Agent', d.agent || '—'],
+            ['Project', d.project || '—'],
+            ['Tool', d.tool_name || '—'],
+            ['Matched field', d.matched_field || '—'],
+          ]}
+        />
+
+        {d.matched_value_truncated && (
+          <div>
+            <div className="text-xs uppercase tracking-wide text-[var(--muted)] mb-1">
+              Offending value
+            </div>
+            <pre className="text-xs bg-[var(--surface-elev)] p-3 rounded border border-[var(--border)] overflow-x-auto whitespace-pre-wrap">
+              {d.matched_value_truncated}
+            </pre>
+          </div>
+        )}
+      </div>
+
+      {data.policy && (
+        <div className="card p-5 space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold">Matched policy</h3>
+            <Link
+              href={`/policies/${encodeURIComponent(data.policy.name)}`}
+              className="text-xs text-[var(--accent)] hover:underline"
+            >
+              Open editor →
+            </Link>
+          </div>
+          {data.policy.description && (
+            <p className="text-sm text-[var(--foreground-soft)]">{data.policy.description}</p>
+          )}
+          <DefList
+            rows={[
+              ['Lifecycle', data.policy.lifecycle],
+              ['Mode', data.policy.mode],
+              ['Action', data.policy.action],
+              ['Severity', data.policy.severity],
+              ['Priority', String(data.policy.priority)],
+            ]}
+          />
+          <div>
+            <div className="text-xs uppercase tracking-wide text-[var(--muted)] mb-1">
+              Condition
+            </div>
+            <pre className="text-xs bg-[var(--surface-elev)] p-3 rounded border border-[var(--border)] overflow-x-auto">
+              {data.policy.condition}
+            </pre>
+          </div>
+        </div>
+      )}
+
+      {data.siblings.length > 0 && (
+        <div className="card p-5 space-y-3">
+          <h3 className="text-lg font-semibold">
+            Other decisions on this trace ({data.siblings.length})
+          </h3>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wide text-[var(--muted)] border-b border-[var(--border)]">
+                <th className="py-2">When</th>
+                <th className="py-2">Decision</th>
+                <th className="py-2">Lifecycle</th>
+                <th className="py-2">Policy</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.siblings.map((sib) => (
+                <tr key={sib.id} className="border-b border-[var(--border)] last:border-0">
+                  <td className="py-2 text-[var(--muted)]">{sib.decision_at}</td>
+                  <td className="py-2">
+                    <DecisionBadge decision={sib.decision} mode={sib.mode_at_decision} />
+                  </td>
+                  <td className="py-2 text-[var(--muted)]">{sib.lifecycle}</td>
+                  <td className="py-2">
+                    <Link
+                      href={`/decisions/${sib.id}`}
+                      className="hover:underline"
+                    >
+                      {sib.policy_name}
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+
+function DefList({ rows }: { rows: Array<[string, React.ReactNode]> }) {
+  return (
+    <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1.5 text-sm">
+      {rows.map(([k, v]) => (
+        <div key={k} className="flex gap-2">
+          <dt className="w-32 shrink-0 text-[var(--muted)]">{k}</dt>
+          <dd className="font-medium break-all">{v}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+
+function TraceLink({ id }: { id: string }) {
+  return (
+    <Link
+      href={`/traces/${id}`}
+      className="font-mono text-xs hover:underline text-[var(--accent)]"
+    >
+      {id.slice(0, 8)}…{id.slice(-4)}
+    </Link>
+  );
+}

--- a/packages/dashboard/components/EnforcementTimeline.tsx
+++ b/packages/dashboard/components/EnforcementTimeline.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import Link from 'next/link';
+import useSWR from 'swr';
+
+import {
+  DecisionRow,
+  DecisionsListResponse,
+  FirewallDecisionVerb,
+  FirewallLifecycle,
+  fetchDecisions,
+} from '@/lib/api';
+import { useUrlString } from '@/lib/url-state';
+
+/**
+ * Live timeline of every decision the firewall produced — the
+ * dashboard's primary surface for "is the firewall doing anything?"
+ * and "what would have blocked yesterday?" (§8.2 of
+ * AGENT_FIREWALL_SPEC.md, task #45).
+ *
+ * Filters: decision verb, lifecycle, agent. URL-backed via
+ * useUrlString so a refresh / link share preserves the view state.
+ *
+ * Polls every 5s — decisions are bounded by retention (default 90d
+ * per §10) so the table size stays reasonable; a heavier deployment
+ * can drop refresh interval or paginate further by clicking "Load
+ * more" (offset pagination). Real-time websocket fanout for new
+ * decisions can land in a later slice.
+ */
+export default function EnforcementTimeline() {
+  const [decision, setDecision] = useUrlString('decision', '');
+  const [lifecycle, setLifecycle] = useUrlString('lifecycle', '');
+  const [agent, setAgent] = useUrlString('agent', '');
+
+  const params: Parameters<typeof fetchDecisions>[0] = {
+    limit: 100,
+    decision: (decision || undefined) as FirewallDecisionVerb | undefined,
+    lifecycle: (lifecycle || undefined) as FirewallLifecycle | undefined,
+    agent: agent || undefined,
+  };
+
+  const key = ['decisions', decision, lifecycle, agent].join('|');
+  const { data, error, isLoading } = useSWR<DecisionsListResponse>(
+    key,
+    () => fetchDecisions(params),
+    { refreshInterval: 5_000 },
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="card p-4 flex flex-wrap items-center gap-3">
+        <FilterPill
+          label="Decision"
+          value={decision}
+          options={[
+            { v: '', label: 'all' },
+            { v: 'block', label: 'block' },
+            { v: 'flag', label: 'flag' },
+            { v: 'require_approval', label: 'approval' },
+            { v: 'rewrite', label: 'rewrite' },
+            { v: 'allow', label: 'allow (rare)' },
+          ]}
+          onChange={setDecision}
+        />
+        <FilterPill
+          label="Lifecycle"
+          value={lifecycle}
+          options={[
+            { v: '', label: 'all' },
+            { v: 'before_proxy_call', label: 'before proxy' },
+            { v: 'after_proxy_call', label: 'after proxy' },
+            { v: 'before_tool_call', label: 'before tool' },
+            { v: 'after_tool_call', label: 'after tool' },
+            { v: 'post_ingest', label: 'post ingest' },
+          ]}
+          onChange={setLifecycle}
+        />
+        <input
+          type="text"
+          placeholder="Agent…"
+          value={agent}
+          onChange={(e) => setAgent(e.target.value)}
+          className="px-3 py-1.5 rounded border bg-transparent text-sm w-40
+                     border-[var(--border)] placeholder:text-[var(--muted)]"
+        />
+        <div className="ml-auto text-xs text-[var(--muted)]">
+          {data ? `${data.decisions.length} of ${data.total}` : '—'}
+        </div>
+      </div>
+
+      {error ? (
+        <div className="card p-4 text-rose-400">
+          Failed to load decisions: {String(error.message ?? error)}
+        </div>
+      ) : isLoading || !data ? (
+        <div className="card p-8 text-center text-[var(--muted)]">Loading…</div>
+      ) : data.decisions.length === 0 ? (
+        <div className="card p-8 text-center text-[var(--muted)]">
+          No decisions match these filters.
+        </div>
+      ) : (
+        <div className="card overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wide text-[var(--muted)] border-b border-[var(--border)]">
+                <th className="px-3 py-2">When</th>
+                <th className="px-3 py-2">Decision</th>
+                <th className="px-3 py-2">Mode</th>
+                <th className="px-3 py-2">Lifecycle</th>
+                <th className="px-3 py-2">Policy</th>
+                <th className="px-3 py-2">Agent / Tool</th>
+                <th className="px-3 py-2">Trace</th>
+                <th className="px-3 py-2 text-right">Latency</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.decisions.map((d) => (
+                <DecisionRowView key={d.id} d={d} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+
+function DecisionRowView({ d }: { d: DecisionRow }) {
+  return (
+    <tr className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--surface-hover)]">
+      <td className="px-3 py-2 whitespace-nowrap text-[var(--muted)]">
+        <Link href={`/decisions/${d.id}`} className="hover:underline">
+          {formatRelative(d.decision_at)}
+        </Link>
+      </td>
+      <td className="px-3 py-2">
+        <DecisionBadge decision={d.decision} mode={d.mode_at_decision} />
+      </td>
+      <td className="px-3 py-2 text-[var(--muted)]">{d.mode_at_decision}</td>
+      <td className="px-3 py-2 text-[var(--muted)]">{d.lifecycle}</td>
+      <td className="px-3 py-2">
+        <Link
+          href={`/policies/${encodeURIComponent(d.policy_name)}`}
+          className="hover:underline font-medium"
+        >
+          {d.policy_name}
+        </Link>
+      </td>
+      <td className="px-3 py-2 text-[var(--muted)]">
+        {d.agent || '—'}
+        {d.tool_name ? <span className="ml-1 text-xs">/{d.tool_name}</span> : null}
+      </td>
+      <td className="px-3 py-2 font-mono text-xs">
+        {d.trace_id ? (
+          <Link href={`/traces/${d.trace_id}`} className="hover:underline">
+            {d.trace_id.slice(0, 8)}…
+          </Link>
+        ) : (
+          '—'
+        )}
+      </td>
+      <td className="px-3 py-2 text-right text-[var(--muted)]">{d.duration_ms}ms</td>
+    </tr>
+  );
+}
+
+
+export function DecisionBadge({
+  decision,
+  mode,
+}: {
+  decision: FirewallDecisionVerb;
+  mode: string;
+}) {
+  // Color map: block = red, require_approval = amber, flag = yellow,
+  // rewrite = blue, allow = green. Shadow mode dims everything to a
+  // muted variant so an operator scanning the timeline can pick out
+  // the rules that actually fired vs. those that only would have.
+  const isShadow = mode === 'shadow';
+  const styles = (() => {
+    switch (decision) {
+      case 'block':
+        return isShadow
+          ? 'bg-rose-500/10 text-rose-300 border-rose-500/30'
+          : 'bg-rose-500/20 text-rose-200 border-rose-500/50';
+      case 'require_approval':
+        return isShadow
+          ? 'bg-amber-500/10 text-amber-300 border-amber-500/30'
+          : 'bg-amber-500/20 text-amber-200 border-amber-500/50';
+      case 'flag':
+        return 'bg-yellow-500/10 text-yellow-300 border-yellow-500/30';
+      case 'rewrite':
+        return isShadow
+          ? 'bg-sky-500/10 text-sky-300 border-sky-500/30'
+          : 'bg-sky-500/20 text-sky-200 border-sky-500/50';
+      case 'allow':
+      default:
+        return 'bg-emerald-500/10 text-emerald-300 border-emerald-500/30';
+    }
+  })();
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded border text-xs font-medium ${styles}`}
+    >
+      {decision}
+      {isShadow && <span className="opacity-70">(shadow)</span>}
+    </span>
+  );
+}
+
+
+function FilterPill({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: Array<{ v: string; label: string }>;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="inline-flex items-center gap-2 text-xs text-[var(--muted)]">
+      <span>{label}</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="px-2 py-1 rounded border bg-transparent text-sm
+                   border-[var(--border)] [&>option]:bg-[var(--surface)]"
+      >
+        {options.map((o) => (
+          <option key={o.v} value={o.v}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+
+function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  // Ensure UTC interpretation when the timestamp lacks an explicit
+  // offset (DuckDB returns naive timestamps, so the API's ISO string
+  // is naive too).
+  const d = new Date(iso.includes('Z') || iso.includes('+') ? iso : `${iso}Z`);
+  const sec = Math.floor((Date.now() - d.getTime()) / 1000);
+  if (sec < 0) return d.toLocaleTimeString();
+  if (sec < 60) return `${sec}s ago`;
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`;
+  return d.toLocaleDateString();
+}

--- a/packages/dashboard/components/ModeToggle.tsx
+++ b/packages/dashboard/components/ModeToggle.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+
+import {
+  FirewallMode,
+  ModeChangeForecast,
+  setPolicyMode,
+} from '@/lib/api';
+
+/**
+ * Mode toggle with confirmation + back-test forecast (§5.4 / §8.2).
+ *
+ * Operators flip a policy from shadow → enforce only after seeing
+ * what it would have blocked. The toggle calls the API which runs
+ * the forecast synchronously (back-tests the rule against the last
+ * 30 days of decisions) and returns the count + a few example
+ * trace_ids; we render that in a confirmation step before applying.
+ *
+ * The pattern:
+ *   1. User clicks a non-current mode chip
+ *   2. We call /v1/policies/{name}/mode — it runs the forecast AND
+ *      flips immediately (the API doesn't have a "preview" endpoint
+ *      separate from "apply" yet; that's a §11 enhancement)
+ *   3. We show a toast with the forecast count
+ *
+ * For the dashboard slice this is good enough — operators can flip
+ * back to shadow any time, and the forecast is informational. A
+ * future preview-then-apply step can land on top.
+ */
+export default function ModeToggle({
+  policyName,
+  currentMode,
+  onChange,
+}: {
+  policyName: string;
+  currentMode: FirewallMode | string;
+  onChange?: (newMode: FirewallMode, forecast: ModeChangeForecast) => void;
+}) {
+  const [busy, setBusy] = useState<FirewallMode | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [lastForecast, setLastForecast] = useState<{
+    mode: FirewallMode;
+    forecast: ModeChangeForecast;
+  } | null>(null);
+
+  async function flip(target: FirewallMode) {
+    if (busy || target === currentMode) return;
+    setBusy(target);
+    setError(null);
+    try {
+      const out = await setPolicyMode(policyName, target);
+      setLastForecast({ mode: target, forecast: out.forecast });
+      onChange?.(target, out.forecast);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="inline-flex items-center rounded-md border border-[var(--border)] overflow-hidden text-sm">
+        {(['shadow', 'flag', 'enforce'] as FirewallMode[]).map((m) => (
+          <button
+            key={m}
+            onClick={() => flip(m)}
+            disabled={busy !== null}
+            className={
+              'px-3 py-1.5 transition-colors ' +
+              (m === currentMode
+                ? 'bg-[var(--accent)] text-[var(--accent-foreground)] font-medium'
+                : 'text-[var(--muted)] hover:bg-[var(--surface-hover)]') +
+              (busy === m ? ' opacity-60' : '') +
+              (busy && busy !== m ? ' opacity-40' : '')
+            }
+            title={modeHelp(m)}
+          >
+            {m}
+            {busy === m && <span className="ml-1 animate-pulse">…</span>}
+          </button>
+        ))}
+      </div>
+
+      {error && <div className="text-xs text-rose-400">{error}</div>}
+
+      {lastForecast && (
+        <div className="text-xs space-y-1">
+          <div className="text-[var(--foreground-soft)]">
+            Switched to{' '}
+            <span className="font-medium">{lastForecast.mode}</span>. Over the
+            last 30 days this policy fired{' '}
+            <span className="font-medium">
+              {lastForecast.forecast.would_have_blocked}
+            </span>{' '}
+            time(s).
+          </div>
+          {lastForecast.forecast.examples.length > 0 && (
+            <div className="text-[var(--muted)]">
+              Recent traces:{' '}
+              {lastForecast.forecast.examples.map((tid, i) => (
+                <span key={tid}>
+                  <a
+                    href={`/traces/${tid}`}
+                    className="font-mono hover:underline text-[var(--accent)]"
+                  >
+                    {tid.slice(0, 8)}…
+                  </a>
+                  {i < lastForecast.forecast.examples.length - 1 ? ', ' : ''}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+
+function modeHelp(m: FirewallMode): string {
+  switch (m) {
+    case 'shadow':
+      return 'Record decisions but never block live traffic.';
+    case 'flag':
+      return 'Record + return decision=flag (does not cancel the action).';
+    case 'enforce':
+      return 'Take the configured action (block / require approval / rewrite).';
+  }
+}

--- a/packages/dashboard/components/PanicBanner.tsx
+++ b/packages/dashboard/components/PanicBanner.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import useSWR from 'swr';
+
+import { fetchPanicState, setPanicDisabled, PanicState } from '@/lib/api';
+
+/**
+ * Top-of-app banner that warns when the firewall kill-switch is
+ * engaged (§10.2). Only rendered when ``disabled === true`` so a
+ * normal operator sees nothing. The "Re-enable" button POSTs to
+ * /v1/firewall/panic_disable with disabled=false and revalidates
+ * the SWR cache.
+ *
+ * Polls every 10s — when an oncall engineer flips the switch, every
+ * other dashboard tab learns about it within one polling interval
+ * without needing a websocket. Decisions returned during a panic
+ * window already include reason="panic_disabled" so the timeline
+ * also surfaces the state at decision granularity.
+ */
+export default function PanicBanner() {
+  const { data, mutate } = useSWR<PanicState>(
+    '/panic',
+    fetchPanicState,
+    { refreshInterval: 10_000 },
+  );
+
+  if (!data?.disabled) return null;
+
+  async function reenable() {
+    try {
+      await setPanicDisabled(false, undefined, 'dashboard');
+      await mutate();
+    } catch {
+      // The next poll cycle will surface any persistent failure;
+      // silent here so we don't shout at the operator twice.
+    }
+  }
+
+  return (
+    <div className="bg-rose-500/10 border-b border-rose-500/40 text-rose-200 text-sm px-6 py-2 flex items-center justify-between gap-4">
+      <div>
+        <span className="font-semibold">Firewall disabled.</span>{' '}
+        Every <code className="text-xs">/v1/policy/decide</code> call is
+        returning <code className="text-xs">allow</code> while this kill-switch
+        is engaged. Decisions are not being recorded.
+      </div>
+      <button
+        onClick={reenable}
+        className="px-3 py-1 rounded bg-rose-500/20 hover:bg-rose-500/30 border border-rose-500/50 text-xs font-medium"
+      >
+        Re-enable firewall
+      </button>
+    </div>
+  );
+}

--- a/packages/dashboard/components/PolicyEditPage.tsx
+++ b/packages/dashboard/components/PolicyEditPage.tsx
@@ -8,6 +8,7 @@ import {
   PolicyAuditEntry,
   formatStartedAt,
 } from '@/lib/api';
+import ModeToggle from '@/components/ModeToggle';
 import PolicyEditor from '@/components/PolicyEditor';
 
 /**
@@ -78,6 +79,24 @@ export default function PolicyEditPage({ name }: { name: string }) {
           </p>
         ) : null}
       </div>
+
+      {/* Firewall mode toggle (§5.4 / §10.1). Only render when the
+          API surfaced a mode value — avoids showing it for legacy
+          installs whose backend hasn't run the firewall migration
+          yet. */}
+      {policy.mode ? (
+        <section className="mb-8 card p-4 space-y-3">
+          <div>
+            <h2 className="text-sm font-semibold">Enforcement mode</h2>
+            <p className="text-xs text-[var(--muted)] mt-1">
+              Shadow records decisions without blocking. Flag returns
+              decision=&apos;flag&apos; (does not cancel the action). Enforce
+              applies the configured action.
+            </p>
+          </div>
+          <ModeToggle policyName={policy.name} currentMode={policy.mode} />
+        </section>
+      ) : null}
 
       <PolicyEditor mode="edit" initial={policy} />
 

--- a/packages/dashboard/components/PolicyEditor.tsx
+++ b/packages/dashboard/components/PolicyEditor.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { API_BASE, Policy, PolicySeverity } from '@/lib/api';
+import { API_BASE, Policy, PolicyAction, PolicySeverity } from '@/lib/api';
 
 /**
  * Form for creating or editing a policy. The same component handles
@@ -30,7 +30,14 @@ export default function PolicyEditor({
     initial?.trigger ?? 'span_end',
   );
   const [condition, setCondition] = useState(initial?.condition ?? '');
-  const [action, setAction] = useState<'flag' | 'alert'>(initial?.action ?? 'flag');
+  // The Policy.action union now includes the firewall verbs (allow,
+  // block, require_approval, rewrite) alongside the legacy
+  // post_ingest verbs (flag, alert). The editor doesn't yet expose
+  // the firewall verbs (separate slice — operators set them via
+  // YAML or the API for now), but the local state has to accept the
+  // wider union so loading an existing firewall rule doesn't trip
+  // the type checker.
+  const [action, setAction] = useState<PolicyAction>(initial?.action ?? 'flag');
   const [severity, setSeverity] = useState<PolicySeverity>(
     initial?.severity ?? 'medium',
   );

--- a/packages/dashboard/lib/api.ts
+++ b/packages/dashboard/lib/api.ts
@@ -127,7 +127,32 @@ export type SessionDetail = Session & {
 // ---- Policies (Phase 3 read, Phase 4 write) -----------------------------
 
 export type PolicyTrigger = 'span_end' | 'trace_end';
-export type PolicyAction = 'flag' | 'alert';
+// Action vocabulary covers both layers: legacy post-ingest (flag,
+// alert) + Agent Firewall (allow, block, require_approval, rewrite).
+// Editor and decision-row renderers branch on this union.
+export type PolicyAction =
+  | 'flag'
+  | 'alert'
+  | 'allow'
+  | 'block'
+  | 'require_approval'
+  | 'rewrite';
+
+export type FirewallLifecycle =
+  | 'post_ingest'
+  | 'before_proxy_call'
+  | 'after_proxy_call'
+  | 'before_tool_call'
+  | 'after_tool_call';
+
+export type FirewallMode = 'shadow' | 'flag' | 'enforce';
+
+export type FirewallDecisionVerb =
+  | 'allow'
+  | 'block'
+  | 'flag'
+  | 'require_approval'
+  | 'rewrite';
 
 export type Policy = {
   name: string;
@@ -141,6 +166,15 @@ export type Policy = {
   enabled: boolean;
   source: 'yaml' | 'db' | 'none';
   version: number;
+  // Agent Firewall fields. Optional on the wire — the API only emits
+  // them when the firewall migration has run; treat absence as the
+  // safe default ("post_ingest" / "enforce" for legacy rows, "shadow"
+  // for newly-authored ones).
+  lifecycle?: FirewallLifecycle;
+  mode?: FirewallMode;
+  priority?: number;
+  on_timeout?: 'allow' | 'deny';
+  on_internal_error?: 'allow' | 'deny' | 'flag';
 };
 
 export type PolicyListResponse = {
@@ -190,6 +224,146 @@ export const fetcher = async (path: string) => {
   }
   return res.json();
 };
+
+
+// ---- Agent Firewall — decisions + approvals + panic ---------------------
+
+export type DecisionRow = {
+  id: string;
+  policy_id: string;
+  policy_name: string;
+  lifecycle: FirewallLifecycle;
+  decision: FirewallDecisionVerb;
+  mode_at_decision: FirewallMode | string;
+  reason: string | null;
+  trace_id: string | null;
+  span_id: string | null;
+  session_id: string | null;
+  agent: string | null;
+  project: string | null;
+  tool_name: string | null;
+  matched_field: string | null;
+  matched_value_truncated: string | null;
+  decision_at: string;
+  duration_ms: number;
+  metadata: unknown;
+};
+
+export type DecisionsListResponse = {
+  decisions: DecisionRow[];
+  total: number;
+  has_more: boolean;
+};
+
+export type DecisionDetailResponse = {
+  decision: DecisionRow;
+  policy: {
+    name: string;
+    description: string | null;
+    lifecycle: FirewallLifecycle;
+    mode: FirewallMode;
+    action: PolicyAction;
+    severity: PolicySeverity;
+    condition: string;
+    priority: number;
+  } | null;
+  siblings: DecisionRow[];
+};
+
+export type ModeChangeForecast = {
+  would_have_blocked: number;
+  examples: string[];
+};
+
+export type ModeChangeResponse = {
+  id: string;
+  mode: FirewallMode;
+  previous_mode: FirewallMode | string;
+  forecast: ModeChangeForecast;
+};
+
+export type ApprovalRow = {
+  id: string;
+  decision_id: string;
+  policy_id: string;
+  trace_id: string | null;
+  agent: string | null;
+  tool_name: string | null;
+  params_truncated: unknown;
+  state: 'pending' | 'allowed' | 'denied' | 'timed_out';
+  requested_at: string;
+  resolved_at: string | null;
+  resolved_by: string | null;
+  resolution_reason: string | null;
+  timeout_at: string;
+  on_timeout: 'allow' | 'deny';
+};
+
+export type ApprovalsListResponse = {
+  approvals: ApprovalRow[];
+  total: number;
+};
+
+export type PanicState = {
+  disabled: boolean;
+};
+
+
+export async function fetchDecisions(params: {
+  decision?: FirewallDecisionVerb;
+  lifecycle?: FirewallLifecycle;
+  agent?: string;
+  trace_id?: string;
+  session_id?: string;
+  since?: string;
+  until?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<DecisionsListResponse> {
+  const q = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== null && v !== '') q.set(k, String(v));
+  }
+  const path = `/v1/decisions${q.toString() ? `?${q}` : ''}`;
+  return fetcher(path);
+}
+
+export async function fetchDecisionDetail(id: string): Promise<DecisionDetailResponse> {
+  return fetcher(`/v1/decisions/${encodeURIComponent(id)}`);
+}
+
+export async function setPolicyMode(
+  name: string, mode: FirewallMode,
+): Promise<ModeChangeResponse> {
+  const res = await fetch(`${API_BASE}/v1/policies/${encodeURIComponent(name)}/mode`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ mode }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Mode change failed: HTTP ${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+export async function fetchPanicState(): Promise<PanicState> {
+  return fetcher(`/v1/firewall/panic_disable`);
+}
+
+export async function setPanicDisabled(
+  disabled: boolean, reason?: string, actor?: string,
+): Promise<{ disabled: boolean; reason: string | null; updated_at: string; updated_by: string | null }> {
+  const res = await fetch(`${API_BASE}/v1/firewall/panic_disable`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ disabled, reason, actor }),
+  });
+  if (!res.ok) {
+    throw new Error(`Panic toggle failed: HTTP ${res.status}`);
+  }
+  return res.json();
+}
 
 export function formatCost(usd: number | null | undefined): string {
   if (usd === null || usd === undefined) return '—';


### PR DESCRIPTION
Adds the operator-facing surfaces for the Agent Firewall: a real-time decisions timeline, a per-decision detail view, a shadow→flag→enforce mode toggle with back-test forecast, and a top-of-app panic banner when the kill-switch is engaged.

**Depends on:** #45 (decide API + decisions endpoint + mode endpoint + panic endpoint). The dashboard builds cleanly against the current main, but it'll show empty timeline + missing badges until #45 merges.

## Routes

- \`/decisions\` — paginated timeline with verb / lifecycle / agent filters (URL-backed via \`useUrlString\` — share-link works, refresh preserves state)
- \`/decisions/{id}\` — detail: matched policy snapshot, sibling decisions on the same trace, offending value (truncated server-side)

## Components

| Component | Purpose |
|---|---|
| \`EnforcementTimeline\` | Table view of recent decisions, 5s polling, color-coded \`DecisionBadge\`, shadow firings dimmed |
| \`DecisionDetailPanel\` | "Why was this blocked?" view — policy snapshot + siblings + offending value |
| \`ModeToggle\` | shadow / flag / enforce chip group, flips policy mode, renders 30d back-test forecast |
| \`PanicBanner\` | Top-of-app red banner when \`/v1/firewall/panic_disable\` returns \`disabled=true\`, with re-enable button |

## Wiring

- Layout: \`PanicBanner\` above the header; "Decisions" nav link next to "Policies"
- PolicyEditPage: \`ModeToggle\` rendered above the editor when the policy carries a mode value (i.e. firewall-aware backend); old installs without the migration see no change
- PolicyEditor: state type widened from \`{flag|alert}\` to \`PolicyAction\` union so loading firewall rules doesn't trip the type checker

## Test plan

- [x] \`next build\` — clean compile, both new routes (\`/decisions\`, \`/decisions/[id]\`) registered in the build manifest
- [x] Type-check passes across all components
- [ ] Manual smoke against #45's API stack (do after #45 merges):
  - [ ] \`/decisions\` polls and renders rows
  - [ ] Filter by verb persists in URL
  - [ ] Click row → detail loads policy snapshot
  - [ ] ModeToggle on a policy: flip shadow→enforce, confirm forecast number matches \`SELECT COUNT FROM decisions WHERE policy_name=...\`
  - [ ] POST panic_disable; confirm banner appears within 10s; click "Re-enable"; banner disappears
- [ ] e2e Playwright fixtures for the new routes (later — needs the API stack live in CI)

## What's NOT in this PR

- E2E tests (need live API stack, will land in the wrap-up PR)
- Custom firewall verb authoring in PolicyEditor (operators set firewall rules via YAML / API today; UI exposure is a follow-up)
- WebSocket fanout for new decisions (currently 5s polling — fine for OSS launch, websocket can land alongside the rest of the trace fanout work)

## Spec references

- §5.2 GET /v1/decisions
- §5.3 GET /v1/decisions/{id}
- §5.4 POST /v1/policies/{name}/mode
- §8.2 components
- §10.1 shadow as default
- §10.2 panic disable
- §10.3 circuit breaker (state surfaced via \`mode_at_decision\` column)