### PR TITLE
fix(api): /v1/policies always reads DB; engine fallback only on empty table

### DIFF
--- a/packages/api/routers/policy.py
+++ b/packages/api/routers/policy.py
@@ -225,19 +225,30 @@ def list_policies(
     """
     source = policy_runtime.engine_source()
 
-    if source == "db":
-        rows = db.fetchall_dict(
+    # DB is authoritative for storage of every policy regardless of
+    # which engine evaluates it. The SDK PolicyEngine handles
+    # post_ingest rules; firewall.decide handles synchronous
+    # lifecycles (before_proxy_call, before_tool_call, …). Both
+    # read from the same `policies` table. If the table has any
+    # rows (enabled OR disabled — soft-deleted ones still mean
+    # the DB is the source of truth), it's authoritative; the
+    # YAML-engine fallback only kicks in for the very-fresh case
+    # where bootstrap hasn't written anything yet.
+    has_any = bool(policy_store.has_any_policies(db))
+    if has_any:
+        db_rows = db.fetchall_dict(
             "SELECT * FROM policies WHERE enabled = true ORDER BY name"
         )
         out: list[PolicyOut] = []
-        for r in rows:
+        for r in db_rows:
             p = policy_store._row_to_policy(r)
             if agent and not p.applies_to_agent(agent):
                 continue
             out.append(_policy_to_out(p, source="db", version=int(r.get("version") or 1)))
         return PolicyListResponse(policies=out, source="db", engine_loaded=True)
 
-    # YAML source (or fallback)
+    # Empty `policies` table — fall through to the YAML-loaded
+    # engine snapshot.
     eng = policy_runtime.get_engine()
     if eng is None:
         return PolicyListResponse(policies=[], source="none", engine_loaded=False)
@@ -253,13 +264,14 @@ def list_policies(
 def get_policy(name: str, db: Database = Depends(get_db)) -> PolicyOut:
     """Single policy by name. DB row when DB-backed, else from the
     in-memory YAML engine state."""
+    # Same DB-first logic as the list endpoint: a firewall-only
+    # policy is still a real, persisted, viewable rule even though
+    # the SDK PolicyEngine source is "none".
     source = policy_runtime.engine_source()
-    if source == "db":
-        row = db.fetchone_dict(
-            "SELECT * FROM policies WHERE name = ? AND enabled = true", [name]
-        )
-        if row is None:
-            raise HTTPException(status_code=404, detail=f"policy '{name}' not found")
+    row = db.fetchone_dict(
+        "SELECT * FROM policies WHERE name = ? AND enabled = true", [name]
+    )
+    if row is not None:
         return _policy_to_out(
             policy_store._row_to_policy(row),
             source="db",
@@ -267,7 +279,7 @@ def get_policy(name: str, db: Database = Depends(get_db)) -> PolicyOut:
         )
     eng = policy_runtime.get_engine()
     if eng is None:
-        raise HTTPException(status_code=404, detail="engine not loaded")
+        raise HTTPException(status_code=404, detail=f"policy '{name}' not found")
     for p in eng.policies:
         if p.name == name:
             return _policy_to_out(p, source=source)

--- a/packages/dashboard/components/ChatView.tsx
+++ b/packages/dashboard/components/ChatView.tsx
@@ -65,8 +65,14 @@ export default function ChatView({
 
 
 function pickHeadlineSpan(spans: Span[]): Span | undefined {
-  // Prefer an llm-typed span; fall back to the first span overall.
-  return spans.find((s) => s.type === 'llm') ?? spans[0];
+  // ChatView is only meaningful when there's an actual model call —
+  // its renderer parses the input as a user prompt and the output as
+  // an assistant reply. Falling back to a tool-only span would feed
+  // tool params (raw JSON) to the user-bubble renderer, producing
+  // nonsense. Return undefined when no LLM span is present so the
+  // caller's "No LLM span on this trace" message kicks in and the
+  // trace falls back to the task-shape default panels.
+  return spans.find((s) => s.type === 'llm');
 }
 
 

--- a/packages/dashboard/lib/chat-shape.ts
+++ b/packages/dashboard/lib/chat-shape.ts
@@ -38,12 +38,18 @@ export function isChatShapedTrace(trace: Trace, spans: Span[]): boolean {
   }
   // Trace-level metadata fallback (the trace row's own metadata).
   if (looksChatShapedFromMetadata(trace.metadata)) return true;
-  // Heuristic: a spans list with an openclaw-prefixed span name and
-  // a session_id is chat-shaped even if the metadata didn't survive.
+  // Heuristic: openclaw-prefixed span + session_id, AND the trace has
+  // at least one LLM span. Without that last constraint, tool-only
+  // traces (a tool call without a model turn) get routed to ChatView,
+  // which then has no user-prompt source to render and falls back to
+  // showing tool JSON as a chat message — rubbish UX. Tool-only
+  // traces fall through to the task-shape default panels which render
+  // the tool params/result correctly.
   const hasOpenClawSpan = spans.some(
     (s) => (s.name ?? '').startsWith('openclaw'),
   );
-  if (hasOpenClawSpan && trace.session_id) return true;
+  const hasLlmSpan = spans.some((s) => s.type === 'llm');
+  if (hasOpenClawSpan && trace.session_id && hasLlmSpan) return true;
   return false;
 }
 


### PR DESCRIPTION
## Why

Caught when restarting the dev API after merging Slice 1. The OWASP starter pack auto-installed 9 firewall-lifecycle rules. The SDK PolicyEngine source resolved to \`"none"\` (correctly — it only looks at \`post_ingest\` rules per the prior CI fix). But the \`/v1/policies\` list endpoint was branching on \`engine_source == "db"\`, so with source=none it fell through to the empty in-memory engine and returned \`[]\` — hiding the 9 OWASP rules from the dashboard.

## Fix

\`/v1/policies\` and \`/v1/policies/{name}\` now treat the DB as authoritative for storage regardless of which engine evaluates a rule. Engine-fallback only applies when the \`policies\` table is literally empty (zero rows, not zero enabled rows — the prior fix tried "if no enabled rows, fall through" which broke soft-delete: a stale engine snapshot leaked through after deletion).

## Smoke

- \`curl /v1/policies\` returns all 9 OWASP rules with \`source=db\`
- \`POST /v1/policy/decide\` with \`rm -rf /tmp/cache\` returns \`decision: allow\` + \`shadow_hits[0].policy_id = owasp_llm06_destructive_shell\` (correct: shadow mode, would have required approval)
- 335/335 tests pass; \`test_delete_policy_soft_deletes\` regression caught + fixed in this commit