### PR TITLE
fix(api): policy validator allows firewall builtins + .get(...) on namespaces

### DIFF
--- a/packages/api/routers/policy.py
+++ b/packages/api/routers/policy.py
@@ -511,8 +511,33 @@ def _build_policy_from_create(body: PolicyCreate) -> Policy:
     )
 
 
-_ALLOWED_NAMES = frozenset({"span", "trace"})
-_ALLOWED_FUNCTIONS = frozenset({"len", "str", "int", "float", "abs"})
+_ALLOWED_NAMES = frozenset({
+    "span", "trace",
+    # Agent Firewall lifecycle namespaces — exposed by firewall.decide
+    # to condition expressions for synchronous lifecycles. Validating
+    # here keeps the editor's "save" path strict but accepts the
+    # firewall vocab.
+    "Input", "Output",
+    "tool_name", "params", "text",
+})
+_ALLOWED_FUNCTIONS = frozenset({
+    "len", "str", "int", "float", "abs",
+    # Agent Firewall builtins — see firewall/builtins.py. These are
+    # available to firewall-lifecycle conditions; allowing them in
+    # the validator means operators can author rules through the
+    # dashboard editor without hitting "function not defined" 400s.
+    "regex_match", "regex_extract", "contains_any",
+    "url_host", "url_in_allowlist", "is_internal_url", "is_destructive_path",
+    "entropy", "len_chars",
+    "looks_like_secret", "has_pii",
+    "has_image_markdown_exfil", "has_ascii_smuggling",
+    "redact_pii",
+    # History-backed (registered per-request via build_history_builtins)
+    "session_total_tokens", "session_total_cost",
+    "trace_total_cost", "tool_calls_in_trace",
+    "agent_calls_per_minute", "agent_calls_today",
+    "pii_violations_in_project_last_24h",
+})
 
 
 def _validate_condition_parses(condition: str) -> None:
@@ -566,8 +591,26 @@ def _validate_condition_parses(condition: str) -> None:
                 if node.func.id not in _ALLOWED_FUNCTIONS:
                     bad_func_names.append(node.func.id)
             elif isinstance(node.func, _ast.Attribute):
-                # Method calls (x.startswith(...), __import__(...).system(...))
-                # are not exposed by the engine — reject at write time.
+                # Method calls are mostly disallowed (x.startswith(...),
+                # __import__(...).system(...)) — reject at write time.
+                # Exception: `.get(key, default)` on the Agent Firewall
+                # namespaces (Input/Output/params). The decide engine
+                # exposes these via _NS wrappers that translate the
+                # attribute access into a real dict.get; validating
+                # this AST shape here lets operators author firewall
+                # rules with `Input.params.get("command", "")` without
+                # tripping the method-call guard.
+                if (
+                    node.func.attr == "get"
+                    and len(node.args) <= 2
+                ):
+                    # Walk leftmost name to confirm it's an allowed
+                    # base. `Input.params.get(...)` → base is `Input`.
+                    base = node.func.value
+                    while isinstance(base, _ast.Attribute):
+                        base = base.value
+                    if isinstance(base, _ast.Name) and base.id in _ALLOWED_NAMES:
+                        continue
                 method_call_nodes.append(node)
 
     if bad_func_names:


### PR DESCRIPTION
## Why

Caught dogfooding OWASP starter pack against a real Telegram → OpenClaw → exec tool call. Two validator rejections forced workarounds (direct DB writes) before the firewall actually fired:

1. **Firewall builtins rejected as \"disallowed function\".** Only \`len/str/int/float/abs\` were allowed. \`regex_match\`, \`has_pii\`, \`looks_like_secret\`, \`url_in_allowlist\` etc. all 400'd at \`POST/PUT /v1/policies\`.

2. **\`Input.params.get(\"command\", \"\")\` rejected as \"method call\".** The decide engine's \`_NS\` wrapper exposes \`.get()\` at runtime, but the AST validator didn't know.

Result: any rule that used firewall vocab couldn't be authored through the dashboard editor or the public CRUD API. Operators had to edit the DB directly (we did exactly that during the dogfood, twice).

## Fix

\`_ALLOWED_FUNCTIONS\` extended with the full firewall builtin set. \`_ALLOWED_NAMES\` extended with \`Input/Output/tool_name/params/text\`. AST walker grants one targeted exception to the method-call guard: \`.get(key, default)\` (≤2 args) on allowed-name bases is permitted; other method calls still rejected.

Concrete result — this rule now saves cleanly via PUT /v1/policies:

\`\`\`yaml
condition: |
  (tool_name == \"shell\" or tool_name == \"exec\") and
  regex_match(str(Input.params.get(\"command\", \"\")), \"(?i)rm\\s+-rf\")
\`\`\`

## Test plan

- [x] 335 / 335 tests pass — no regressions
- [x] Manual: PUT updated condition through API; firewall correctly fires \`require_approval\` on real OpenClaw exec tool call (verified end-to-end)
- [x] AST exception is conservative — only allows \`.get(...)\` and only on bases that are already in \`_ALLOWED_NAMES\`. Methods like \`.startswith\`, \`.__class__\` still rejected

## Related

This is one of the Tier 1 fix items from the Slice 2 plan (1.4 Validator allows firewall idioms). Lays groundwork for the dashboard PolicyEditor UI to expose firewall verb authoring (Tier 1.6).