### PR TITLE
chore: lockstep-bump all packages + embedded versions to 0.3.0

### DIFF
--- a/packages/api/main.py
+++ b/packages/api/main.py
@@ -222,7 +222,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     title="Lumin API",
     description="Local-first AI agent observability — ingest and query API",
-    version="0.1.0",
+    version="0.3.0",
     lifespan=lifespan,
 )
 

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
   ],
 };
 
-const VERSION = '0.1.0';
+const VERSION = '0.3.0';
 
 export default function RootLayout({
   children,

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumin-dashboard",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/integrations/mastra/package.json
+++ b/packages/integrations/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/mastra",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Lumin exporter for Mastra agents \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/integrations/openclaw-diagnostics/.gitignore
+++ b/packages/integrations/openclaw-diagnostics/.gitignore
@@ -1,0 +1,4 @@
+
+
+# npm pack output — local-only, never commit
+*.tgz

--- a/packages/integrations/openclaw-diagnostics/package.json
+++ b/packages/integrations/openclaw-diagnostics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/openclaw-diagnostics",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Lumin observability + Agent Firewall for OpenClaw \u2014 captures prompts, responses, tool I/O, and synchronously enforces firewall policies on every tool call.",
   "homepage": "https://github.com/amitbidlan/zistica-lumin/tree/main/packages/integrations/openclaw-diagnostics",
   "repository": {

--- a/packages/integrations/openclaw/package.json
+++ b/packages/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/openclaw",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Lumin exporter for OpenClaw agents \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/integrations/voltagent/package.json
+++ b/packages/integrations/voltagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/voltagent",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Lumin exporter for VoltAgent \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lumin"
-version = "0.1.0"
+version = "0.3.0"
 description = "Local-first AI agent observability SDK"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/sdk",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Local-first AI agent observability SDK (TypeScript)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Why

The Slice 1 firewall release shipped the Docker image as v0.3.0 (via the v* git-tag workflow), but the rest of the monorepo stayed scattered:

| Component | Was | Should be |
|---|---|---|
| Lumin API (Docker) | v0.3.0 | v0.3.0 ✓ |
| OpenClaw plugin (npm) | 0.2.0 | 0.3.0 |
| SDK Python | 0.1.0 | 0.3.0 |
| SDK TypeScript | 0.1.0 | 0.3.0 |
| Dashboard | 0.1.0 | 0.3.0 |
| OpenClaw integration | 0.1.0 | 0.3.0 |
| Mastra integration | 0.1.0 | 0.3.0 |
| VoltAgent integration | 0.1.0 | 0.3.0 |

Going forward, lockstep monorepo versioning: every release bumps **all** packages + embedded VERSION constants together. *"What version of Lumin am I running?"* gets a single answer.

## Changes

Touches the 9 version locations + adds `*.tgz` to the OpenClaw plugin's `.gitignore` so `npm pack` artifacts don't sneak in:

- \`packages/api/main.py\` — `FastAPI(version=)`
- \`packages/sdk-python/pyproject.toml\`
- \`packages/sdk-typescript/package.json\`
- \`packages/dashboard/package.json\`
- \`packages/dashboard/app/layout.tsx\` — `VERSION` footer pill
- \`packages/integrations/openclaw-diagnostics/package.json\`
- \`packages/integrations/openclaw/package.json\`
- \`packages/integrations/mastra/package.json\`
- \`packages/integrations/voltagent/package.json\`
- \`packages/integrations/openclaw-diagnostics/.gitignore\` (new — tarball ignore)

## Test plan

- [x] 335 / 335 tests pass — pure version bump, no functional change
- [x] Smoke check on `FastAPI(version=)` — dashboard footer reads from `VERSION` const, both updated together

## After merge — publish steps

1. **Republish @lumin-io/openclaw-diagnostics 0.3.0 to npm + ClawHub.** Currently published at 0.2.0; need a fresh publish at 0.3.0 to align with the rest. (One extra publish, accepted cost for version uniformity per @amitbidlan.)
2. **Other 5 packages: skip publish.** No functional change this slice; they'll go out at their next real change as 0.3.x or 0.4.x.
3. **Docker image already at v0.3.0** from the earlier tag — no action.

## Going forward

Memory note saved (`version_lockstep.md`): every future release bumps all 9 entries above + the git tag in the same PR. New packages added to the monorepo go on this list.