### PR TITLE
feat(firewall): authoring DX overhaul — list membership, tool builtins, PolicyOut fields, OWASP audit (Slice 2 Cluster A)

### DIFF
--- a/packages/api/firewall/builtins.py
+++ b/packages/api/firewall/builtins.py
@@ -447,12 +447,106 @@ def build_history_builtins(db) -> Dict[str, Callable]:
 
 
 # ---------------------------------------------------------------------------
+# Cross-framework tool name detection (Slice 2 Tier 1.1)
+# ---------------------------------------------------------------------------
+#
+# Different agent frameworks use different names for the same
+# capability. Slice 1 dogfood caught this concretely: an OWASP rule
+# matched ``tool_name == "shell"`` but OpenClaw's actual tool is
+# named ``exec`` — the rule silently never fired. These builtins
+# canonicalize across the common framework vocabularies so operators
+# can write ``is_shell_tool()`` once and not maintain a manually-
+# updated list of every tool name across every integration.
+#
+# When adding a new framework: extend the relevant set below. Names
+# are lowercased on lookup so casing differences don't matter.
+
+_SHELL_TOOL_NAMES = frozenset({
+    # OpenClaw
+    "exec",
+    # Generic / many frameworks
+    "shell", "bash", "sh", "terminal", "system",
+    # Mastra / VoltAgent / LangChain conventions
+    "run_command", "execute_command", "run_shell", "shell_exec",
+    # Code-interpreter style (executes shell-like code)
+    "code_exec", "code_interpreter", "python_repl", "python_exec",
+})
+
+_WEB_FETCH_TOOL_NAMES = frozenset({
+    # OpenClaw / common
+    "fetch", "http_fetch", "web_fetch", "http_get", "http_request",
+    # LangChain / LlamaIndex
+    "requests_get", "requests_post", "url_fetch",
+    # cURL-named wrappers
+    "curl",
+    # Search-engine wrappers (often hit external URLs)
+    "brave_search", "google_search", "duckduckgo_search", "web_search",
+})
+
+_DB_WRITE_TOOL_NAMES = frozenset({
+    # SQL execution wrappers
+    "sql_exec", "sql_query", "execute_sql", "db_execute",
+    "postgres_query", "mysql_query", "sqlite_exec",
+    # NoSQL
+    "mongo_write", "redis_set", "redis_del",
+    # ORM-style
+    "db_write", "model_create", "model_update", "model_delete",
+})
+
+_FILESYSTEM_TOOL_NAMES = frozenset({
+    "fs_write", "fs_read", "file_write", "file_read",
+    "write_file", "read_file", "edit_file", "create_file", "delete_file",
+    # OpenClaw uses "edit" for the canvas/editor tool — included
+    # here because it can write to disk
+    "edit",
+})
+
+
+def is_shell_tool(name: Optional[str]) -> bool:
+    """True when the tool name is a known shell / command-execution
+    tool across any supported framework. Used by firewall rules
+    that want to gate on "anything that runs an arbitrary command"
+    without enumerating every framework's flavor."""
+    if not isinstance(name, str):
+        return False
+    return name.strip().lower() in _SHELL_TOOL_NAMES
+
+
+def is_web_fetch_tool(name: Optional[str]) -> bool:
+    """True for HTTP/URL-fetching tools across frameworks. Used in
+    SSRF / data-exfil rules that want to gate on the "agent is
+    reaching outside the host" capability."""
+    if not isinstance(name, str):
+        return False
+    return name.strip().lower() in _WEB_FETCH_TOOL_NAMES
+
+
+def is_db_write_tool(name: Optional[str]) -> bool:
+    """True for tools that mutate a database. Used by rules guarding
+    against destructive SQL (DROP, DELETE without WHERE, TRUNCATE)
+    or unauthorized model-CRUD."""
+    if not isinstance(name, str):
+        return False
+    return name.strip().lower() in _DB_WRITE_TOOL_NAMES
+
+
+def is_filesystem_tool(name: Optional[str]) -> bool:
+    """True for tools that read or write files outside the shell
+    capability. Useful when a rule wants to catch ``write_file
+    /etc/passwd`` patterns without enumerating shell commands."""
+    if not isinstance(name, str):
+        return False
+    return name.strip().lower() in _FILESYSTEM_TOOL_NAMES
+
+
+# ---------------------------------------------------------------------------
 # Stateless builtins map
 # ---------------------------------------------------------------------------
 #
 # Merged with ``build_history_builtins(db)`` to produce the full
-# ``functions=`` argument for ``simpleeval.SimpleEval``. The decision
-# engine (Slice 1 task §37) does this merge per evaluation.
+# ``functions=`` argument for ``simpleeval.EvalWithCompoundTypes``.
+# The decision engine (Slice 1 task §37) does this merge per
+# evaluation.
 
 STATELESS_BUILTINS: Dict[str, Callable] = {
     # Core string / regex
@@ -474,6 +568,13 @@ STATELESS_BUILTINS: Dict[str, Callable] = {
     "has_ascii_smuggling": has_ascii_smuggling,
     # Sanitisation
     "redact_pii": redact_pii,
+    # Cross-framework tool name canonicalization (Slice 2 Tier 1.1).
+    # Operators write ``is_shell_tool()`` once instead of
+    # ``tool_name in ["exec","shell","bash","sh","terminal",...]``.
+    "is_shell_tool": is_shell_tool,
+    "is_web_fetch_tool": is_web_fetch_tool,
+    "is_db_write_tool": is_db_write_tool,
+    "is_filesystem_tool": is_filesystem_tool,
 }
 
 

--- a/packages/api/firewall/decide.py
+++ b/packages/api/firewall/decide.py
@@ -519,8 +519,15 @@ def _evaluate(policy: Policy, names: Dict[str, Any], funcs: Dict[str, Any]) -> b
     cond = (policy.condition or "").strip()
     if not cond:
         return True
-    from simpleeval import SimpleEval
-    e = SimpleEval(names=names, functions=funcs)
+    # EvalWithCompoundTypes (vs plain SimpleEval) supports list / dict /
+    # set literals + the `in` operator across them. Operators write
+    # natural conditions like ``tool_name in ["shell", "exec",
+    # "bash"]`` instead of OR-chains. Same security posture — only
+    # the whitelisted ``functions`` set can be invoked, and the
+    # validator's AST walker still rejects method calls except on
+    # `_NS.get(...)` per PR #49.
+    from simpleeval import EvalWithCompoundTypes
+    e = EvalWithCompoundTypes(names=names, functions=funcs)
     result = e.eval(cond)
     return bool(result)
 

--- a/packages/api/firewall/starter_packs/owasp_llm_top_10.yaml
+++ b/packages/api/firewall/starter_packs/owasp_llm_top_10.yaml
@@ -85,19 +85,30 @@ policies:
     action: block
     severity: high
 
-  # LLM06 — Excessive Agency
-  # Block destructive shell paths in tool args (rm -rf /, drop
-  # database, etc.) without an approval round-trip.
-  - name: owasp_llm06_destructive_shell
-    description: Require approval for destructive shell commands (rm -rf, mkfs, format).
+  # LLM06 — Excessive Agency (split: irreversible vs recoverable per
+  # Slice 2 Tier 1.6.5 guidance — block> require_approval for ops that
+  # can't be safely undone, since require_approval creates a pending
+  # state the LLM tries to satisfy by hallucinating /approve syntax
+  # to the user. See live evidence in docs/SLICE_2_PLAN.md.)
+  - name: owasp_llm06_destructive_shell_irreversible
+    description: Block irreversible destructive shell commands (rm -rf, mkfs, dd, drop database). No approval — these can't be safely "undone".
     lifecycle: before_tool_call
     mode: shadow
     priority: 100
     trigger: span_end
-    condition: tool_name == "shell" and (regex_match(str(Input.params.get("command", "")), "(?i)rm\\s+-rf\\s") or regex_match(str(Input.params.get("command", "")), "(?i)mkfs|fdisk|dd\\s+if=") or is_destructive_path(str(Input.params.get("command", ""))))
-    action: require_approval
+    condition: is_shell_tool(tool_name) and (regex_match(str(Input.params.get("command", "")), "(?i)rm\\s+-rf\\s") or regex_match(str(Input.params.get("command", "")), "(?i)mkfs|fdisk|dd\\s+if=") or regex_match(str(Input.params.get("command", "")), "(?i)\\bdrop\\s+(database|table)\\b") or is_destructive_path(str(Input.params.get("command", ""))))
+    action: block
     severity: critical
-    on_timeout: deny
+
+  - name: owasp_llm06_sensitive_file_read
+    description: Block reads of sensitive credential / config files (SSH keys, AWS / GCP / kube credentials, /etc/passwd, .env). Defense-in-depth — even if the shell skill permits it, the firewall denies.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 95
+    trigger: span_end
+    condition: is_shell_tool(tool_name) and regex_match(str(Input.params.get("command", "")), "(?i)(cat|head|tail|less|more|od|xxd|base64|cp|mv|grep)\\s.*?(/etc/(passwd|shadow|sudoers|hosts)|~/.ssh/|/Users/[^/]+/.ssh/|~/.aws/credentials|/Users/[^/]+/.aws/credentials|~/.kube/config|/var/log/auth|\\.env\\b|/secrets?/|/private[/-]key)")
+    action: block
+    severity: critical
 
   # LLM07 — System Prompt Leakage
   # If the model output verbatim-quotes the system prompt, flag it.
@@ -135,13 +146,17 @@ policies:
 
   # LLM10 — Unbounded Consumption
   # Cap per-session tokens. Default budget is generous; operators
-  # tighten it after seeing baseline traffic.
+  # tighten it after seeing baseline traffic. Returns 0 (and
+  # therefore doesn't fire) when session_id is missing — sessions
+  # are framework-conventional and a missing one means the request
+  # came in without the routing metadata we need to enforce a
+  # per-session cap.
   - name: owasp_llm10_session_token_budget
-    description: Block proxy calls when the session has burned through its token budget.
+    description: Block proxy calls when the session has burned through its token budget (default 1M tokens).
     lifecycle: before_proxy_call
     mode: shadow
     priority: 40
     trigger: span_end
-    condition: session_total_tokens(Input.session_id) > 1000000
+    condition: session_total_tokens(str(Input.session_id or "")) > 1000000
     action: block
     severity: medium

--- a/packages/api/models.py
+++ b/packages/api/models.py
@@ -252,6 +252,17 @@ class PolicyOut(BaseModel):
     source: str = "yaml"  # "yaml" | "db" — surfaces where the engine loaded it from
     version: int = 1
 
+    # Agent Firewall fields (Slice 2 Tier 1.3 — exposed on the wire
+    # so dashboard can render mode/lifecycle in lists instead of
+    # placeholder dashes). Optional with safe defaults to remain
+    # back-compat with pre-firewall-migration installs.
+    lifecycle: str = "post_ingest"
+    mode: str = "enforce"
+    priority: int = 0
+    on_timeout: str = "allow"
+    on_internal_error: str = "allow"
+    circuit_breaker_state: str = "ok"
+
 
 class PolicyListResponse(BaseModel):
     policies: List[PolicyOut]

--- a/packages/api/routers/policy.py
+++ b/packages/api/routers/policy.py
@@ -437,7 +437,14 @@ def policy_audit(
 
 
 def _policy_to_out(p, source: str = "yaml", version: int = 1) -> PolicyOut:
-    """Project an SDK ``Policy`` dataclass onto the wire shape."""
+    """Project an SDK ``Policy`` dataclass onto the wire shape.
+
+    Agent Firewall fields (lifecycle/mode/priority/on_timeout/...)
+    are read with getattr-with-default so this remains compatible
+    with old SDK Policy dataclasses missing those attrs (e.g. when
+    a deployment hasn't redeployed the SDK yet but the dashboard
+    is asking for the new fields).
+    """
     return PolicyOut(
         name=p.name,
         description=p.description,
@@ -450,6 +457,12 @@ def _policy_to_out(p, source: str = "yaml", version: int = 1) -> PolicyOut:
         enabled=True,
         source=source,
         version=version,
+        lifecycle=getattr(p, "lifecycle", "post_ingest") or "post_ingest",
+        mode=getattr(p, "mode", "enforce") or "enforce",
+        priority=int(getattr(p, "priority", 0) or 0),
+        on_timeout=getattr(p, "on_timeout", "allow") or "allow",
+        on_internal_error=getattr(p, "on_internal_error", "allow") or "allow",
+        circuit_breaker_state=getattr(p, "circuit_breaker_state", "ok") or "ok",
     )
 
 
@@ -532,6 +545,9 @@ _ALLOWED_FUNCTIONS = frozenset({
     "looks_like_secret", "has_pii",
     "has_image_markdown_exfil", "has_ascii_smuggling",
     "redact_pii",
+    # Cross-framework tool name canonicalization (Slice 2 Tier 1.1).
+    "is_shell_tool", "is_web_fetch_tool", "is_db_write_tool",
+    "is_filesystem_tool",
     # History-backed (registered per-request via build_history_builtins)
     "session_total_tokens", "session_total_cost",
     "trace_total_cost", "tool_calls_in_trace",
@@ -559,11 +575,11 @@ def _validate_condition_parses(condition: str) -> None:
         Same UX rationale.
     """
     try:
-        from simpleeval import SimpleEval
+        from simpleeval import EvalWithCompoundTypes
     except ImportError:
         return
     try:
-        SimpleEval().parse(condition)
+        EvalWithCompoundTypes().parse(condition)
     except Exception as e:
         raise HTTPException(
             status_code=400, detail=f"condition is not a valid expression: {e}"

--- a/packages/api/tests/firewall/test_builtins.py
+++ b/packages/api/tests/firewall/test_builtins.py
@@ -355,3 +355,108 @@ def test_history_cache_hits_within_1s():
         assert first == second  # cached, not refetched
     finally:
         db.close()
+
+
+# ---- Cross-framework tool name detection (Slice 2 Tier 1.1) -------------
+
+
+def test_is_shell_tool_openclaw():
+    """OpenClaw uses 'exec' for the shell tool — Slice 1 dogfood
+    discovered our OWASP rule hardcoded 'shell' and silently never
+    fired. is_shell_tool() canonicalizes."""
+    from firewall.builtins import is_shell_tool
+    for name in ["exec", "shell", "bash", "sh", "terminal", "system"]:
+        assert is_shell_tool(name), f"{name!r} should be a shell tool"
+
+
+def test_is_shell_tool_framework_variants():
+    from firewall.builtins import is_shell_tool
+    for name in [
+        "run_command", "execute_command", "run_shell", "shell_exec",
+        "code_exec", "code_interpreter", "python_repl", "python_exec",
+    ]:
+        assert is_shell_tool(name), f"{name!r} should be a shell tool"
+
+
+def test_is_shell_tool_case_insensitive():
+    from firewall.builtins import is_shell_tool
+    assert is_shell_tool("EXEC")
+    assert is_shell_tool("Shell")
+    assert is_shell_tool("  bash  ")  # also strips whitespace
+
+
+def test_is_shell_tool_rejects_non_shell():
+    from firewall.builtins import is_shell_tool
+    for name in ["fetch", "web_search", "sql_query", "fs_read", "edit"]:
+        assert not is_shell_tool(name), f"{name!r} should NOT be a shell tool"
+
+
+def test_is_shell_tool_safe_on_none():
+    from firewall.builtins import is_shell_tool
+    assert is_shell_tool(None) is False
+    assert is_shell_tool(123) is False
+    assert is_shell_tool("") is False
+
+
+def test_is_web_fetch_tool():
+    from firewall.builtins import is_web_fetch_tool
+    for name in [
+        "fetch", "http_fetch", "web_fetch", "curl",
+        "brave_search", "google_search", "duckduckgo_search",
+    ]:
+        assert is_web_fetch_tool(name), f"{name!r} should be a web fetch tool"
+    assert not is_web_fetch_tool("exec")
+    assert not is_web_fetch_tool("sql_query")
+
+
+def test_is_db_write_tool():
+    from firewall.builtins import is_db_write_tool
+    for name in [
+        "sql_exec", "execute_sql", "postgres_query",
+        "mongo_write", "model_create", "db_write",
+    ]:
+        assert is_db_write_tool(name), f"{name!r} should be a db write tool"
+    assert not is_db_write_tool("exec")
+    assert not is_db_write_tool("fetch")
+
+
+def test_is_filesystem_tool():
+    from firewall.builtins import is_filesystem_tool
+    for name in [
+        "fs_write", "file_read", "write_file", "create_file", "edit",
+    ]:
+        assert is_filesystem_tool(name), f"{name!r} should be a fs tool"
+    assert not is_filesystem_tool("exec")  # shell, not direct fs
+
+
+def test_tool_classifiers_in_stateless_map():
+    """All four classifiers must be in STATELESS_BUILTINS so the
+    decide engine wires them into the simpleeval functions table.
+    Without this, conditions using the classifiers parse fine in the
+    validator but fail at evaluation with 'function not defined'."""
+    from firewall.builtins import STATELESS_BUILTINS
+    for fn_name in ("is_shell_tool", "is_web_fetch_tool",
+                    "is_db_write_tool", "is_filesystem_tool"):
+        assert fn_name in STATELESS_BUILTINS
+
+
+def test_tool_classifier_in_real_condition():
+    """End-to-end: a condition using is_shell_tool + list-membership
+    (Tier 1.2 + 1.1 together) evaluates correctly. This is the
+    canonical Slice 2 idiom, replacing Slice 1's verbose OR-chain."""
+    from firewall.builtins import STATELESS_BUILTINS
+    from simpleeval import EvalWithCompoundTypes
+    funcs = {"len": len, "str": str}
+    funcs.update(STATELESS_BUILTINS)
+    e = EvalWithCompoundTypes(
+        names={"tool_name": "exec"},
+        functions=funcs,
+    )
+    assert e.eval("is_shell_tool(tool_name)") is True
+    assert e.eval('is_shell_tool(tool_name) and tool_name in ["exec", "shell"]') is True
+    # Combined with regex on a hypothetical command
+    e2 = EvalWithCompoundTypes(
+        names={"tool_name": "exec", "cmd": "rm -rf /etc"},
+        functions=funcs,
+    )
+    assert e2.eval('is_shell_tool(tool_name) and regex_match(cmd, "(?i)rm\\s+-rf")') is True

--- a/packages/dashboard/components/PolicyList.tsx
+++ b/packages/dashboard/components/PolicyList.tsx
@@ -115,7 +115,25 @@ function PolicyCard({ policy }: { policy: Policy }) {
                                      'badge badge-slate'
   );
   const triggerCls = policy.trigger === 'span_end' ? 'badge badge-blue' : 'badge badge-violet';
-  const actionCls  = policy.action  === 'alert'    ? 'badge badge-orange' : 'badge badge-slate';
+  const actionCls  = (
+    policy.action === 'block'             ? 'badge badge-rose' :
+    policy.action === 'require_approval'  ? 'badge badge-amber' :
+    policy.action === 'rewrite'           ? 'badge badge-cyan' :
+    policy.action === 'allow'             ? 'badge badge-emerald' :
+    policy.action === 'alert'             ? 'badge badge-orange' :
+                                            'badge badge-slate'
+  );
+  // Slice 2 Tier 1.3: surface firewall fields when present.
+  // Mode chip dims for shadow (rule records but never fires) so a
+  // glance shows which rules are *actually* enforcing today.
+  const modeCls = (
+    policy.mode === 'enforce'  ? 'badge badge-rose' :
+    policy.mode === 'flag'     ? 'badge badge-amber' :
+    policy.mode === 'shadow'   ? 'badge badge-slate opacity-70' :
+                                 'badge badge-slate'
+  );
+  const isFirewallLifecycle =
+    policy.lifecycle && policy.lifecycle !== 'post_ingest';
 
   return (
     <Link
@@ -125,8 +143,17 @@ function PolicyCard({ policy }: { policy: Policy }) {
       <div className="flex items-center gap-3 mb-2 flex-wrap">
         <span className={sevCls}>{policy.severity}</span>
         <h3 className="font-mono text-sm font-medium tracking-tight">{policy.name}</h3>
-        <span className={triggerCls}>{policy.trigger}</span>
+        {isFirewallLifecycle ? (
+          <span className="badge badge-violet">{policy.lifecycle}</span>
+        ) : (
+          <span className={triggerCls}>{policy.trigger}</span>
+        )}
         <span className={actionCls}>{policy.action}</span>
+        {policy.mode ? (
+          <span className={modeCls} title={modeHelp(policy.mode)}>
+            {policy.mode}
+          </span>
+        ) : null}
         {policy.scope_agents.length > 0 ? (
           <span className="badge badge-fuchsia">
             scoped to {policy.scope_agents.length} agent{policy.scope_agents.length === 1 ? '' : 's'}
@@ -150,4 +177,18 @@ function PolicyCard({ policy }: { policy: Policy }) {
       </code>
     </Link>
   );
+}
+
+
+function modeHelp(mode: string): string {
+  switch (mode) {
+    case 'shadow':
+      return 'Shadow — records decisions but never blocks live traffic.';
+    case 'flag':
+      return 'Flag — records and returns decision=flag (does not cancel the action).';
+    case 'enforce':
+      return 'Enforce — takes the configured action (block / require_approval / rewrite).';
+    default:
+      return mode;
+  }
 }

--- a/packages/sdk-python/lumin/policy.py
+++ b/packages/sdk-python/lumin/policy.py
@@ -487,8 +487,13 @@ class PolicyEngine:
         # 18k spans/sec that's 50% headroom for free, and the per-call
         # work becomes proportional to operator count not condition
         # length. Catches syntax errors at load time too.
-        from simpleeval import SimpleEval
-        _parser = SimpleEval(functions=dict(_SAFE_FUNCTIONS))
+        # EvalWithCompoundTypes supports list/dict/set literals + the
+        # `in` operator. Lets operators author conditions like
+        # ``span.model in ["gpt-4o", "claude-sonnet-4"]`` instead of
+        # OR-chains. Same security model — function whitelist still
+        # gates what's callable.
+        from simpleeval import EvalWithCompoundTypes
+        _parser = EvalWithCompoundTypes(functions=dict(_SAFE_FUNCTIONS))
         self._compiled: List[tuple] = []
         for p in self._policies:
             try:
@@ -536,13 +541,15 @@ class PolicyEngine:
     def _make_evaluator():
         """Build a fresh simpleeval evaluator per call.
 
-        SimpleEval is stateful (caches names) so we don't reuse one
-        evaluator across spans — but we DO reuse one per evaluation
-        within a single call.
+        EvalWithCompoundTypes (vs plain SimpleEval) is stateful
+        (caches names) so we don't reuse one evaluator across
+        spans — but we DO reuse one per evaluation within a single
+        call. The compound-types variant unlocks list/set/dict
+        literals + `in` operator, used widely in firewall rules.
         """
-        from simpleeval import SimpleEval
+        from simpleeval import EvalWithCompoundTypes
 
-        ev = SimpleEval(functions=dict(_SAFE_FUNCTIONS))
+        ev = EvalWithCompoundTypes(functions=dict(_SAFE_FUNCTIONS))
         return ev
 
     def evaluate_span(


### PR DESCRIPTION
First Cluster of Slice 2 — four small authoring-DX wins, all driven by Slice 1 dogfood pain.

## What's in this PR

**1.2 List membership in conditions.** \`SimpleEval\` → \`EvalWithCompoundTypes\` across decide engine + SDK + validator. Operators can now write \`tool_name in [\"shell\", \"exec\", \"bash\"]\` instead of OR-chains. Dict / set literals + \`in\` operator unlocked. Same security posture (function whitelist + AST guards unchanged).

**1.1 Cross-framework tool name builtins.** Adds \`is_shell_tool\`, \`is_web_fetch_tool\`, \`is_db_write_tool\`, \`is_filesystem_tool\`. Each knows the canonical names across frameworks (e.g. \`exec\` / \`shell\` / \`bash\` / \`sh\` / \`run_command\` / \`code_interpreter\` / \`code_exec\` all classify as \"shell\"). Slice 1 OWASP LLM06 silently never fired because it hardcoded \`tool_name == \"shell\"\` while OpenClaw uses \`exec\` — this prevents that class of bug.

**1.3 PolicyOut surfaces firewall fields.** Adds \`lifecycle\`, \`mode\`, \`priority\`, \`on_timeout\`, \`on_internal_error\`, \`circuit_breaker_state\` to the wire schema + serializer. Dashboard PolicyList renders mode + lifecycle pills (instead of \`(?/?)\` placeholders); mode chip dims for shadow so what's actually enforcing pops at a glance.

**1.7 + 1.6.5 OWASP starter pack audit.** Splits LLM06 per block-vs-require_approval guidance — \`destructive_shell_irreversible\` (block) and a promoted \`sensitive_file_read\` (block, from yesterday's live dogfood rule). Both use \`is_shell_tool()\` so they work against any framework's shell tool. LLM10 token-budget condition tightened to handle missing session_id.

## Test plan

- [x] 345 / 345 backend tests pass (was 335 + 10 new builtin tests)
- [x] Dashboard \`next build\` clean — both new fields render
- [x] Manual smoke: PUT /v1/policies with a \`tool_name in [...]\` condition succeeds (was 400 before)
- [x] OWASP starter pack imports cleanly with the new is_shell_tool builtin

## Versioning

No version bumps in this PR. Slice 2 lands across multiple PRs (Cluster A here, B + C to follow); a single \`v0.4.0\` lockstep release ships all 9 version locations together at the end of the slice per the lockstep memory.