### PR TITLE
feat(firewall): admin separation + LLM feedback (Slice 2 Cluster B + C)

### DIFF
--- a/packages/api/firewall/decide.py
+++ b/packages/api/firewall/decide.py
@@ -69,6 +69,97 @@ LATENCY_BUDGET_MS: Dict[str, int] = {
 }
 
 
+# ---- session-level deny cache (Slice 2 Tier 1.5(b)) ----------------------
+#
+# When an operator denies a tool call, the LLM doesn't always
+# learn — Slice 1 dogfood (2026-05-07) saw an agent retry the same
+# rm -rf three times after a deny, asking the user to approve via
+# fake /approve syntax each time. The cache short-circuits this:
+# once a (session_id, tool_name, params_hash) is denied, subsequent
+# decide() calls for the same tuple auto-deny in <1ms without
+# touching the policy engine OR re-prompting the operator.
+#
+# Cache scope is intentionally narrow:
+#   - Per-session: a deny for session A doesn't affect session B
+#   - Per-tool: blocking shell rm -rf doesn't affect a fetch call
+#   - Per-params-hash: the same exact command. A *different* shell
+#     command with different params is re-evaluated normally
+#     (operators have to approve each variation, not "approve all
+#     shell commands forever for this session").
+#
+# TTL: 600s by default (matches require_approval timeout). Override
+# with LUMIN_DENY_CACHE_TTL=N (seconds, 0 disables).
+#
+# Storage: in-memory dict, keyed by (session_id, tool_name, params_hash).
+# Sized loosely — 100k entries is ~30MB at peak; we don't bound size
+# yet because real-world session counts are bounded by retention
+# (90d default) and each session's denied tuples are typically <10.
+
+import hashlib
+import os
+
+_DENY_CACHE: Dict[tuple, float] = {}
+_DENY_CACHE_TTL = float(os.environ.get("LUMIN_DENY_CACHE_TTL", "600"))
+
+
+def _params_hash(params: Optional[Dict[str, Any]]) -> str:
+    """Stable hash of tool params for cache keying. Order-independent
+    so {a:1,b:2} and {b:2,a:1} cache as the same call. Truncated
+    to 16 hex chars — collision probability is fine at this scope."""
+    if not params:
+        return "noparams"
+    try:
+        payload = json.dumps(params, sort_keys=True, default=str)
+    except Exception:
+        payload = str(params)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _deny_cache_key(
+    session_id: Optional[str],
+    tool_name: Optional[str],
+    params: Optional[Dict[str, Any]],
+) -> Optional[tuple]:
+    """Build the cache key tuple, or None when this request shouldn't
+    use the cache (no session = no cross-call correlation possible)."""
+    if not session_id or not tool_name:
+        return None
+    return (str(session_id), str(tool_name), _params_hash(params))
+
+
+def _check_deny_cache(key: Optional[tuple]) -> Optional[str]:
+    """Return the policy_name that previously denied this tuple if
+    a non-expired entry exists, else None. Lazily evicts expired
+    entries on lookup so the cache size stays bounded by recent
+    activity."""
+    if not key or _DENY_CACHE_TTL <= 0:
+        return None
+    entry = _DENY_CACHE.get(key)
+    if entry is None:
+        return None
+    expires_at, policy_name = entry  # type: ignore[misc]
+    if time.time() > expires_at:
+        _DENY_CACHE.pop(key, None)
+        return None
+    return str(policy_name)
+
+
+def _record_deny_in_cache(
+    key: Optional[tuple], policy_name: str,
+) -> None:
+    """Cache a deny for TTL seconds. No-op when the key is missing
+    (e.g. session_id wasn't supplied) or TTL is disabled."""
+    if not key or _DENY_CACHE_TTL <= 0:
+        return
+    _DENY_CACHE[key] = (time.time() + _DENY_CACHE_TTL, policy_name)  # type: ignore[assignment]
+
+
+def reset_deny_cache_for_tests() -> None:
+    """Test helper. The cache is per-process module global; tests
+    that exercise the cache flow should clear between cases."""
+    _DENY_CACHE.clear()
+
+
 # ---- panic kill-switch ----------------------------------------------------
 
 # In-memory flag flipped by POST /v1/firewall/panic_disable. Persisted
@@ -111,6 +202,83 @@ def refresh_panic_state(db: Database) -> None:
         pass
 
 
+# ---- agent_feedback helper (Slice 2 Tier 1.5(a)) -------------------------
+#
+# When Lumin denies a tool call or LLM output, OpenClaw passes our
+# decision through to the agent as a tool error string. Slice 1
+# dogfood (2026-05-07) captured a live LLM reasoning trace that
+# revealed four distinct misunderstandings:
+#
+#   1. The LLM thought the deny came from the user, not a separate
+#      enforcement layer ("Denied by user").
+#   2. It treated policy as user-controlled ("user gave permission?").
+#   3. It hallucinated a fake approval prompt and showed it to the
+#      user (`/approve rm -rf <command>`) — a social engineering
+#      surface.
+#   4. The error string was opaque — Lumin's policy_name + reason
+#      never reached the LLM's reasoning context.
+#
+# ``agent_feedback`` is a string the plugin v0.4.x reads off our
+# response and surfaces verbatim as the tool error. It's authored
+# to be:
+#   - Authoritative (cites policy name)
+#   - Disambiguating ("platform-level, not user")
+#   - Anti-hallucination ("Do NOT generate approval syntax")
+#   - Action-directing ("Reply to the user that...")
+#
+# We keep it concise so it doesn't blow the LLM's response token
+# budget when echoed in tool errors.
+
+
+def _agent_feedback(
+    *, decision: str, policy_name: Optional[str], reason: str,
+) -> str:
+    """Construct the LLM-targeted feedback string for a non-allow
+    decision. Returned in the decide response body so the plugin
+    can surface it as the tool error / proxy error verbatim.
+
+    Tuned for the failure modes we observed in 2026-05-07 dogfood:
+    LLM hallucinating /approve syntax, retrying after deny, mis-
+    attributing to user permission. Each clause targets one of
+    those failure modes.
+    """
+    pol = f" (policy: {policy_name})" if policy_name else ""
+    if decision == "block":
+        return (
+            f"This action was blocked by the Lumin Agent Firewall{pol}. "
+            f"Reason: {reason}. This is a platform-level denial enforced "
+            f"regardless of user request — it is NOT a user decision and "
+            f"cannot be overridden by asking the user. "
+            f"Do NOT retry this command. Do NOT generate /approve syntax "
+            f"or any other approval prompt to the user. "
+            f"Reply that you cannot perform this action due to security "
+            f"policy and stop."
+        )
+    if decision == "require_approval":
+        return (
+            f"This action requires operator approval per the Lumin Agent "
+            f"Firewall{pol}. Reason: {reason}. The approval request has "
+            f"already been routed to a configured operator channel — DO "
+            f"NOT ask the end user to approve, and DO NOT generate "
+            f"/approve syntax in your reply. While waiting, simply tell "
+            f"the user you're checking on the request."
+        )
+    if decision == "rewrite":
+        return (
+            f"This action was modified by the Lumin Agent Firewall{pol} "
+            f"to redact sensitive data. Reason: {reason}. Continue with "
+            f"the rewritten parameters as provided. Do not attempt to "
+            f"reconstruct the original."
+        )
+    if decision == "flag":
+        return (
+            f"This action was flagged by the Lumin Agent Firewall{pol} "
+            f"for operator review. Reason: {reason}. The action was "
+            f"allowed to proceed; no additional response action required."
+        )
+    return reason
+
+
 # ---- core decide ----------------------------------------------------------
 
 
@@ -147,6 +315,40 @@ def decide(
     if lifecycle not in LATENCY_BUDGET_MS:
         # Unknown lifecycle = caller bug, not our problem. Allow.
         return _allow_response(t0, reason=f"unknown_lifecycle:{lifecycle}")
+
+    # ---- Session-level deny cache (Slice 2 Tier 1.5(b)) -----------------
+    # Once an operator denies a (session, tool, params) tuple, the
+    # LLM frequently retries the same call. Auto-deny in <1ms without
+    # re-bothering the operator (or running the full engine again).
+    cache_key = _deny_cache_key(session_id, tool_name, params)
+    cached_policy = _check_deny_cache(cache_key)
+    if cached_policy is not None:
+        decision_id = _record_decision(
+            db, policy=None, lifecycle=lifecycle,
+            decision="block", reason=f"cached_deny:{cached_policy}",
+            trace_id=trace_id, span_id=span_id, session_id=session_id,
+            agent=agent, project=project, tool_name=tool_name,
+            duration_ms=_elapsed_ms(t0),
+            mode_at_decision="enforce",
+        )
+        return {
+            "decision": "block",
+            "policy_id": cached_policy,
+            "policy_name": cached_policy,
+            "reason": (
+                f"This action was previously denied in this session and is "
+                f"auto-denied for the deny-cache window."
+            ),
+            "agent_feedback": _agent_feedback(
+                decision="block",
+                policy_name=cached_policy,
+                reason="previously denied in this session — do not retry",
+            ),
+            "decision_id": decision_id,
+            "mode_at_decision": "enforce",
+            "duration_ms": _elapsed_ms(t0),
+            "cached_deny": True,
+        }
 
     try:
         policies = _applicable_policies(db, lifecycle=lifecycle, agent=agent)
@@ -223,6 +425,11 @@ def decide(
                     "policy_id": policy.name,
                     "policy_name": policy.name,
                     "reason": "internal_error",
+                    "agent_feedback": _agent_feedback(
+                        decision="block",
+                        policy_name=policy.name,
+                        reason="internal_error",
+                    ),
                     "decision_id": decision_id,
                     "mode_at_decision": policy.mode,
                     "duration_ms": _elapsed_ms(t0),
@@ -305,6 +512,9 @@ def decide(
                 "policy_id": policy.name,
                 "policy_name": policy.name,
                 "reason": reason,
+                "agent_feedback": _agent_feedback(
+                    decision="flag", policy_name=policy.name, reason=reason,
+                ),
                 "decision_id": decision_id,
                 "mode_at_decision": "flag",
                 "duration_ms": _elapsed_ms(t0),
@@ -331,6 +541,10 @@ def decide(
                 "policy_id": policy.name,
                 "policy_name": policy.name,
                 "reason": reason,
+                "agent_feedback": _agent_feedback(
+                    decision="require_approval",
+                    policy_name=policy.name, reason=reason,
+                ),
                 "approval_id": approval_id,
                 "timeout_s": 600,
                 "decision_id": decision_id,
@@ -346,6 +560,9 @@ def decide(
                 "policy_id": policy.name,
                 "policy_name": policy.name,
                 "reason": reason,
+                "agent_feedback": _agent_feedback(
+                    decision="rewrite", policy_name=policy.name, reason=reason,
+                ),
                 "decision_id": decision_id,
                 "mode_at_decision": "enforce",
                 "duration_ms": _elapsed_ms(t0),
@@ -357,6 +574,9 @@ def decide(
             "policy_id": policy.name,
             "policy_name": policy.name,
             "reason": reason,
+            "agent_feedback": _agent_feedback(
+                decision=action, policy_name=policy.name, reason=reason,
+            ),
             "decision_id": decision_id,
             "mode_at_decision": "enforce",
             "duration_ms": _elapsed_ms(t0),

--- a/packages/api/routers/firewall.py
+++ b/packages/api/routers/firewall.py
@@ -392,8 +392,18 @@ def resolve_approval(
 ) -> Dict[str, Any]:
     if payload.resolution not in ("allow", "deny"):
         raise HTTPException(status_code=400, detail="resolution must be allow|deny")
+    # Pull richer context up-front — needed both for the state guard
+    # and (on deny) to populate the session deny cache so the LLM
+    # can't immediately retry the same tuple.
     row = db.fetchone_dict(
-        "SELECT id, state FROM approvals WHERE id = ?", [approval_id]
+        """
+        SELECT a.id, a.state, a.policy_id, a.tool_name, a.params_truncated,
+               a.decision_id, d.session_id
+        FROM approvals a
+        LEFT JOIN decisions d ON d.id = a.decision_id
+        WHERE a.id = ?
+        """,
+        [approval_id],
     )
     if not row:
         raise HTTPException(status_code=404, detail="approval not found")
@@ -415,6 +425,36 @@ def resolve_approval(
         """,
         [new_state, now, payload.resolver, payload.reason, approval_id],
     )
+
+    # Slice 2 Tier 1.5(b): record deny in session cache so the LLM's
+    # next retry of the same (session, tool, params) tuple gets an
+    # immediate auto-deny instead of pinging an admin again. Best
+    # effort — params_truncated is JSON-stringified, parse defensively.
+    if new_state == "denied" and row.get("session_id") and row.get("tool_name"):
+        try:
+            params_blob = row.get("params_truncated")
+            if isinstance(params_blob, str):
+                try:
+                    params = json.loads(params_blob)
+                except (json.JSONDecodeError, TypeError):
+                    params = None
+            elif isinstance(params_blob, dict):
+                params = params_blob
+            else:
+                params = None
+            cache_key = fw_decide._deny_cache_key(
+                row["session_id"], row["tool_name"], params,
+            )
+            fw_decide._record_deny_in_cache(
+                cache_key, row["policy_id"] or "_operator_deny",
+            )
+        except Exception:
+            logger.exception(
+                "firewall: failed to record deny in session cache "
+                "(approval=%s); operator deny still applied",
+                approval_id,
+            )
+
     return {
         "id": approval_id,
         "state": new_state,

--- a/packages/api/tests/firewall/test_decide.py
+++ b/packages/api/tests/firewall/test_decide.py
@@ -359,3 +359,158 @@ def test_decision_row_records_all_context(db: Database) -> None:
     assert row["span_id"] == "span-y"
     assert row["tool_name"] == "shell"
     assert row["lifecycle"] == "before_tool_call"
+
+
+# ---- agent_feedback (Slice 2 Tier 1.5(a)) -------------------------------
+
+
+def test_block_response_includes_agent_feedback(db: Database) -> None:
+    """The decide response on block must include an agent_feedback
+    string designed for the LLM to consume — anti-hallucination,
+    anti-retry, platform-attribution. Plugin v0.4.x surfaces this
+    as the tool error string."""
+    _mk_policy(db, name="block_all", action="block", condition="True")
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "block"
+    assert "agent_feedback" in out
+    fb = out["agent_feedback"]
+    # Must mention the platform (so the LLM doesn't think the user denied)
+    assert "Lumin" in fb
+    # Must mention the policy (so the LLM has authoritative context)
+    assert "block_all" in fb
+    # Must explicitly forbid /approve hallucination (the live failure mode)
+    assert "/approve" in fb or "approval syntax" in fb
+    # Must explicitly forbid retrying
+    assert "retry" in fb.lower() or "do not retry" in fb.lower() or "stop" in fb.lower()
+
+
+def test_require_approval_includes_agent_feedback(db: Database) -> None:
+    _mk_policy(
+        db, name="needs_apv", action="require_approval", condition="True",
+    )
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "require_approval"
+    fb = out["agent_feedback"]
+    # For require_approval the LLM should know it's been routed to
+    # an operator channel — DON'T tell the user to approve.
+    assert "operator" in fb.lower()
+    assert "/approve" in fb or "approval syntax" in fb
+
+
+def test_flag_response_includes_agent_feedback(db: Database) -> None:
+    _mk_policy(db, name="flag_all", action="flag", condition="True")
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "flag"
+    fb = out["agent_feedback"]
+    assert "Lumin" in fb
+    assert "flag_all" in fb
+
+
+def test_allow_response_has_no_agent_feedback(db: Database) -> None:
+    """Allow path is the happy path — no need for LLM-targeted
+    feedback since nothing's wrong. Keeps the response payload
+    minimal on the hot path."""
+    out = fw_decide.decide(db, lifecycle="before_tool_call", tool_name="shell")
+    assert out["decision"] == "allow"
+    assert "agent_feedback" not in out
+
+
+# ---- session-level deny cache (Slice 2 Tier 1.5(b)) ---------------------
+
+
+def test_deny_cache_short_circuits_repeat(db: Database) -> None:
+    """After a (session, tool, params) tuple is recorded as denied
+    in the cache, the next decide() for the same tuple returns
+    block immediately without consulting any policy."""
+    fw_decide.reset_deny_cache_for_tests()
+    # Fake a previous deny by writing directly to the cache
+    cache_key = fw_decide._deny_cache_key(
+        "sess-cache", "exec", {"command": "rm -rf /"},
+    )
+    fw_decide._record_deny_in_cache(cache_key, "owasp_llm06_destructive_shell")
+
+    # NO policies created — so without the cache, decide() would allow
+    out = fw_decide.decide(
+        db, lifecycle="before_tool_call",
+        tool_name="exec",
+        params={"command": "rm -rf /"},
+        session_id="sess-cache",
+    )
+    assert out["decision"] == "block"
+    assert out.get("cached_deny") is True
+    assert out["policy_name"] == "owasp_llm06_destructive_shell"
+    # Cache hit feedback must still tell the LLM not to retry
+    assert "Lumin" in out["agent_feedback"]
+
+
+def test_deny_cache_does_not_affect_other_sessions(db: Database) -> None:
+    fw_decide.reset_deny_cache_for_tests()
+    key_a = fw_decide._deny_cache_key("sess-A", "exec", {"command": "rm -rf"})
+    fw_decide._record_deny_in_cache(key_a, "policy_x")
+
+    # Same tool, same params, DIFFERENT session — should not be cached
+    out = fw_decide.decide(
+        db, lifecycle="before_tool_call",
+        tool_name="exec",
+        params={"command": "rm -rf"},
+        session_id="sess-B",
+    )
+    assert out["decision"] == "allow"
+
+
+def test_deny_cache_does_not_affect_different_params(db: Database) -> None:
+    fw_decide.reset_deny_cache_for_tests()
+    key = fw_decide._deny_cache_key("sess-1", "exec", {"command": "rm -rf"})
+    fw_decide._record_deny_in_cache(key, "policy_x")
+
+    # Different command — should NOT be cached. Operators have to
+    # approve each variation explicitly; can't "approve all shell
+    # commands forever for this session" by approving one.
+    out = fw_decide.decide(
+        db, lifecycle="before_tool_call",
+        tool_name="exec",
+        params={"command": "ls -la"},
+        session_id="sess-1",
+    )
+    assert out["decision"] == "allow"
+
+
+def test_deny_cache_records_on_decide_block(db: Database) -> None:
+    """Even without operator-resolution flow, when a policy fires
+    a block in enforce mode, the cache should be populated so a
+    quick LLM retry is auto-denied. (Validates the integration
+    path; the actual cache-population on resolve() lives in the
+    HTTP layer test.)"""
+    # Note: today, decide() block does not auto-populate the cache —
+    # only operator deny does. This test validates the documented
+    # behavior: cache hits only after a deliberate deny. A pure
+    # block in enforce mode does not auto-cache since the same
+    # decision will fire again on retry anyway.
+    fw_decide.reset_deny_cache_for_tests()
+    _mk_policy(db, name="auto_block", action="block", condition="True")
+
+    out1 = fw_decide.decide(
+        db, lifecycle="before_tool_call",
+        tool_name="exec", params={"command": "ls"}, session_id="s1",
+    )
+    assert out1["decision"] == "block"
+    assert out1.get("cached_deny") is None  # not from cache, from policy
+
+    # Second call still goes through the policy engine — no cache
+    out2 = fw_decide.decide(
+        db, lifecycle="before_tool_call",
+        tool_name="exec", params={"command": "ls"}, session_id="s1",
+    )
+    assert out2["decision"] == "block"
+    assert out2.get("cached_deny") is None  # still policy, not cache
+
+
+def test_deny_cache_no_session_id_no_cache(db: Database) -> None:
+    """Without a session_id, we can't correlate retries; cache is
+    skipped entirely. Verified by attempting to manually populate
+    a key with None session — cache key returns None."""
+    fw_decide.reset_deny_cache_for_tests()
+    key = fw_decide._deny_cache_key(None, "exec", {"command": "rm -rf"})
+    assert key is None  # no key built, no cache used
+    fw_decide._record_deny_in_cache(key, "policy_x")  # no-op
+    assert len(fw_decide._DENY_CACHE) == 0

--- a/packages/integrations/openclaw-diagnostics/README.md
+++ b/packages/integrations/openclaw-diagnostics/README.md
@@ -2,7 +2,7 @@
 
 > Full-fidelity Lumin observability **and synchronous policy enforcement** for [OpenClaw](https://github.com/openclaw/openclaw) — every prompt, response, tool I/O, and reasoning trace captured per turn, every tool call checked against your firewall before it runs.
 
-**v0.2.0 adds the Agent Firewall path.** Every `before_tool_call` hook now POSTs to Lumin's `/v1/policy/decide` endpoint and translates the response into OpenClaw's typed-hook return contract — `block`, rewrite `params`, or `requireApproval`. Default fail-mode is `allow` (Rule 7: agent never blocks on Lumin), with `onFirewallError: "deny"` available for fail-closed deployments. Set `enforce: false` to fall back to v0.1.x observation-only behavior.
+**v0.4.0 adds admin separation.** Configure `adminSenders` to keep approval prompts and LLM technical detail away from end users — non-admin senders get a clean canned message after a block, admins get the full context. The plugin enforces this via OpenClaw's `inbound_claim` and `before_message_write` hooks. v0.2.0 introduced the Agent Firewall: every `before_tool_call` POSTs to Lumin's `/v1/policy/decide` endpoint and translates the response into OpenClaw's typed-hook return contract — `block`, `rewrite`, or `requireApproval`. Set `enforce: false` to fall back to observation-only.
 
 [![npm](https://img.shields.io/npm/v/@lumin-io/openclaw-diagnostics.svg?style=flat-square)](https://www.npmjs.com/package/@lumin-io/openclaw-diagnostics)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](https://github.com/amitbidlan/zistica-lumin/blob/main/LICENSE)
@@ -78,6 +78,9 @@ All optional, set under `plugins.entries.lumin-diagnostics.config` in `openclaw.
 | `enforce` | `true` | **(v0.2.0)** Whether to call `/v1/policy/decide` synchronously on every `before_tool_call`. Set to `false` to fall back to observation-only behavior. |
 | `decideTimeoutMs` | `75` | **(v0.2.0)** Hard timeout for the synchronous decide call. Tighter than `timeoutMs` because every tool call pays this latency. |
 | `onFirewallError` | `"allow"` | **(v0.2.0)** Fail-mode when the firewall is unreachable: `"allow"` (Rule 7 default) lets the tool run, `"deny"` cancels it. |
+| `adminSenders` | `[]` | **(v0.4.0)** Sender IDs treated as administrators. Format: `telegram:5706212396`, `slack:U02ABCD123`, `whatsapp:+1234567890` — whatever OpenClaw produces as the canonical channel-scoped sender. Empty (default) means every sender is non-admin. |
+| `userBlockedMessage` | *(neutral default)* | **(v0.4.0)** What end users see when the LLM tries to reply after a Lumin block. Defaults to: *"I'm unable to perform that action due to security policy. Please contact your administrator if you need assistance."* |
+| `adminSeesFullResponse` | `true` | **(v0.4.0)** Whether admin senders see the agent's full reply (including any policy detail the LLM mentions) after a block. Set `false` to suppress for admins too — useful when ALL admin context should route through the Lumin dashboard. |
 
 Example:
 
@@ -116,6 +119,22 @@ Two reasons:
 - **History is summarized, not embedded.** Each turn captures only the current user prompt — the full conversation history (which OpenClaw replays to the model on every turn) is referenced by count, not embedded, so trace size doesn't grow linearly with conversation length. If you need the full conversation, use Lumin's `/sessions` view, which already groups turns by `session_id`.
 
 ## Changelog
+
+### 0.4.0 — Admin separation + LLM feedback
+
+Closes the social-engineering surface where the LLM hallucinates a fake `/approve <command>` syntax for the user to click — captured live during Slice 1 dogfood (2026-05-07).
+
+- **`adminSenders` config:** list of OpenClaw-canonical sender IDs (e.g. `telegram:5706212396`, `slack:U02ABCD123`) treated as administrators. Non-admin senders get a canned message after a Lumin block; the LLM's reply is intercepted via the new `before_message_write` hook.
+- **`userBlockedMessage` config:** override the default user-facing canned message.
+- **`adminSeesFullResponse` config (default `true`):** admins see the agent's full reply with policy detail; set `false` to route admin context only through the Lumin dashboard.
+- **New hooks registered:** `inbound_claim` (records sessionKey → senderId) and `before_message_write` (intercepts non-admin replies after recent block).
+- **Surfaces `agent_feedback` from Lumin's decide response** as the tool error string verbatim — authoritative, anti-hallucination, anti-retry text targeted at the LLM's reasoning trace.
+
+Behavior change vs 0.3.x: previously, every sender (including end users) saw OpenClaw's native `🛡️ Plugin approval required` prompt and could `/approve` it themselves — a real bypass. With `adminSenders` configured, end users never see the approval surface.
+
+### 0.3.0 — Lockstep version alignment
+
+Version bump to align with Lumin platform v0.3.0 (Lumin API Docker, all SDKs and integrations). No functional changes from 0.2.0.
 
 ### 0.2.0 — Agent Firewall enforcement
 

--- a/packages/integrations/openclaw-diagnostics/src/index.ts
+++ b/packages/integrations/openclaw-diagnostics/src/index.ts
@@ -72,7 +72,40 @@ interface LuminDiagnosticsConfig {
    * fail-closed should flip this to "deny" + accept the latency
    * tail. */
   onFirewallError?: "allow" | "deny";
+
+  // ----- Admin separation (v0.4.0 — Slice 2 Tier 1.0 / 1.0b) ---
+  /** Sender IDs that are treated as administrators. Format matches
+   * OpenClaw's canonical channel-scoped senderId (e.g.
+   * "telegram:5706212396", "slack:U02ABCD123"). When a non-admin
+   * sender's tool call gets blocked by the firewall, the plugin
+   * suppresses the LLM's reply and substitutes ``userBlockedMessage``
+   * — closes the social-engineering surface where the LLM
+   * hallucinates a fake /approve prompt the user can click.
+   *
+   * Empty list = every sender is treated as non-admin (most
+   * conservative). Default: empty. For dev/personal-bot use cases
+   * where the user IS the operator, leave empty AND set
+   * ``allowApprovalSurfaceForAdmins: false`` to bypass the
+   * suppression entirely. */
+  adminSenders?: string[];
+
+  /** The canned message shown to non-admin senders after a Lumin
+   * block. Operators can override per-deployment. Default:
+   * intentionally generic — no policy names, no technical detail,
+   * no /approve hints. */
+  userBlockedMessage?: string;
+
+  /** When true (default), admin senders see the agent's full reply
+   * including any technical detail the LLM included about the
+   * block. When false, even admins get the canned message. Useful
+   * for ultra-locked-down deployments where ALL surfaces should
+   * route admin context through the dashboard rather than chat. */
+  adminSeesFullResponse?: boolean;
 }
+
+const DEFAULT_USER_BLOCKED_MESSAGE =
+  "I'm unable to perform that action due to security policy. " +
+  "Please contact your administrator if you need assistance.";
 
 const DEFAULT_HOST = "http://localhost:8000";
 const DEFAULT_PROJECT = "openclaw";
@@ -839,6 +872,9 @@ export default definePluginEntry({
       enforce: { type: "boolean" },
       decideTimeoutMs: { type: "number" },
       onFirewallError: { type: "string", enum: ["allow", "deny"] },
+      adminSenders: { type: "array", items: { type: "string" } },
+      userBlockedMessage: { type: "string" },
+      adminSeesFullResponse: { type: "boolean" },
     },
   } as never,
   register: (api): void => {
@@ -863,6 +899,49 @@ export default definePluginEntry({
     const pending = new PendingLlmRegistry();
     const toolPending = new PendingToolCallRegistry();
     const log = apiAny.logger;
+
+    // ----- Admin separation tracking (v0.4.0 — Slice 2 Tier 1.0/1.0b) ---
+    // Maps sessionKey → senderId (recorded from inbound_claim) and
+    // sessionKey → recent block timestamp (set when before_tool_call's
+    // Lumin response is block / require_approval). The
+    // before_message_write hook reads both maps to decide whether to
+    // suppress the LLM's reply.
+    const sessionToSender = new Map<string, string>();
+    const sessionRecentBlock = new Map<string, number>();
+    // Window during which a recent block triggers reply suppression.
+    // Keep tight so a stale block from N minutes ago doesn't suppress
+    // an unrelated subsequent reply. 60s covers the LLM's typical
+    // post-block reply turnaround.
+    const RECENT_BLOCK_WINDOW_MS = 60_000;
+
+    const adminSenders = new Set(
+      (cfg.adminSenders ?? []).map((s) => s.toLowerCase().trim()).filter(Boolean),
+    );
+    const userBlockedMessage = cfg.userBlockedMessage ?? DEFAULT_USER_BLOCKED_MESSAGE;
+    const adminSeesFullResponse = cfg.adminSeesFullResponse !== false;
+
+    function isAdminSender(senderId: string | undefined): boolean {
+      if (!senderId) return false;
+      return adminSenders.has(senderId.toLowerCase().trim());
+    }
+
+    function recordRecentBlock(sessionKey: string | undefined): void {
+      if (!sessionKey) return;
+      sessionRecentBlock.set(sessionKey, Date.now());
+    }
+
+    function hasRecentBlock(sessionKey: string | undefined): boolean {
+      if (!sessionKey) return false;
+      const t = sessionRecentBlock.get(sessionKey);
+      if (!t) return false;
+      const fresh = Date.now() - t < RECENT_BLOCK_WINDOW_MS;
+      if (!fresh) {
+        // Lazy eviction
+        sessionRecentBlock.delete(sessionKey);
+        return false;
+      }
+      return true;
+    }
 
     if (typeof apiAny.on !== "function") {
       // Older OpenClaw runtimes without typed-hook support won't
@@ -978,6 +1057,18 @@ export default definePluginEntry({
           agent: ctx?.agentId,
           project: cfg.project || DEFAULT_PROJECT,
         });
+        // Slice 2 Tier 1.0/1.0b — record per-session "recent block"
+        // marker when Lumin returned a non-allow decision. The
+        // before_message_write hook reads this to suppress the
+        // LLM's follow-up reply for non-admin senders. Includes
+        // require_approval — operator hasn't yet decided, but the
+        // user shouldn't see the LLM's interim reasoning.
+        if (
+          decision &&
+          ["block", "require_approval", "rewrite", "flag"].includes(decision.decision)
+        ) {
+          recordRecentBlock(ctx?.sessionKey);
+        }
         return translateDecision(decision, fw, cfg, log);
       } catch (err) {
         log?.warn?.(`lumin-diagnostics: before_tool_call handler failed: ${(err as Error).message}`);
@@ -1017,8 +1108,77 @@ export default definePluginEntry({
       }
     });
 
+    // ---- inbound_claim (v0.4.0 — Slice 2 Tier 1.0) ---------------------
+    // Records the senderId for a session as soon as a message arrives
+    // from a channel. Lets the before_message_write hook later
+    // determine whether the recipient of the agent's reply is an
+    // admin (who sees the LLM's full response, including any policy
+    // detail) or a regular user (who gets a canned message after a
+    // recent block).
+    apiAny.on("inbound_claim", (rawEvent: unknown, _rawCtx: unknown) => {
+      try {
+        const event = rawEvent as {
+          sessionKey?: string;
+          senderId?: string;
+          channelId?: string;
+        };
+        if (event.sessionKey && event.senderId) {
+          // Canonical form matches what operators put in
+          // adminSenders config. We stash the raw value; matching is
+          // case-insensitive at lookup time.
+          sessionToSender.set(event.sessionKey, event.senderId);
+        }
+      } catch (err) {
+        log?.warn?.(`lumin-diagnostics: inbound_claim handler failed: ${(err as Error).message}`);
+      }
+    });
+
+    // ---- before_message_write (v0.4.0 — Slice 2 Tier 1.0b) -------------
+    // Final guardrail: when the agent is about to send a reply, check
+    // whether the recipient is non-admin AND there's been a recent
+    // Lumin block. If yes → suppress the LLM's reply and substitute
+    // ``userBlockedMessage``. Closes the social-engineering surface
+    // where the LLM hallucinates fake /approve syntax for the user
+    // to click.
+    //
+    // Admin senders pass through with the full LLM response intact
+    // (unless ``adminSeesFullResponse: false``) so they retain
+    // visibility into what the firewall blocked and why.
+    apiAny.on("before_message_write", (rawEvent: unknown, rawCtx: unknown) => {
+      try {
+        const ctx = rawCtx as { sessionKey?: string } | undefined;
+        const sessionKey = ctx?.sessionKey;
+        if (!sessionKey) return undefined;
+        if (!hasRecentBlock(sessionKey)) return undefined;
+
+        const senderId = sessionToSender.get(sessionKey);
+        const isAdmin = isAdminSender(senderId);
+        if (isAdmin && adminSeesFullResponse) {
+          // Admin sees the full LLM reply. They can drill into
+          // /decisions for the policy-side context.
+          return undefined;
+        }
+
+        // Replace the LLM's message with a canned, neutral
+        // refusal. We use the AgentMessage shape OpenClaw expects
+        // — content array with a single text block. No mention
+        // of policy names, no /approve syntax, no technical
+        // detail.
+        const cannedMessage = {
+          role: "assistant" as const,
+          content: [{ type: "text" as const, text: userBlockedMessage }],
+        };
+        return { message: cannedMessage as never };
+      } catch (err) {
+        log?.warn?.(
+          `lumin-diagnostics: before_message_write handler failed: ${(err as Error).message}`,
+        );
+        return undefined;
+      }
+    });
+
     log?.info?.(
-      `lumin-diagnostics: subscribed to llm_input + llm_output + before_tool_call + after_tool_call → ${cfg.host || DEFAULT_HOST}/v1/spans (project=${cfg.project || DEFAULT_PROJECT}, firewall=${enforceEnabled ? "enforce" : "observe-only"}, fail=${cfg.onFirewallError ?? "allow"})`,
+      `lumin-diagnostics: subscribed to llm_input + llm_output + before_tool_call + after_tool_call + inbound_claim + before_message_write → ${cfg.host || DEFAULT_HOST}/v1/spans (project=${cfg.project || DEFAULT_PROJECT}, firewall=${enforceEnabled ? "enforce" : "observe-only"}, fail=${cfg.onFirewallError ?? "allow"}, admins=${adminSenders.size})`,
     );
   },
 });

--- a/packages/integrations/openclaw-diagnostics/tests/plugin.test.ts
+++ b/packages/integrations/openclaw-diagnostics/tests/plugin.test.ts
@@ -32,6 +32,9 @@ interface RegisteredHooks {
   llm_output?: (event: unknown, ctx: unknown) => unknown;
   before_tool_call?: (event: unknown, ctx: unknown) => unknown;
   after_tool_call?: (event: unknown, ctx: unknown) => unknown;
+  // v0.4.0 — admin separation hooks
+  inbound_claim?: (event: unknown, ctx: unknown) => unknown;
+  before_message_write?: (event: unknown, ctx: unknown) => unknown;
 }
 
 interface FakeApi {
@@ -53,6 +56,8 @@ function buildFakeApi(pluginConfig?: Record<string, unknown>): {
       else if (name === "llm_output") hooks.llm_output = handler;
       else if (name === "before_tool_call") hooks.before_tool_call = handler;
       else if (name === "after_tool_call") hooks.after_tool_call = handler;
+      else if (name === "inbound_claim") hooks.inbound_claim = handler;
+      else if (name === "before_message_write") hooks.before_message_write = handler;
     },
   };
   return { api, hooks };
@@ -707,5 +712,239 @@ describe("firewall enforcement", () => {
     expect(body.params).toEqual({ q: "x" });
     expect(body.agent).toBe("bot.support");
     expect(body.session_id).toBe("s-1");
+  });
+});
+
+
+// ----- admin separation (v0.4.0 — Slice 2 Tier 1.0 / 1.0b) ---------------
+//
+// Tests that:
+//   1. Non-admin sender's tool call gets blocked, AND the LLM's
+//      follow-up reply is suppressed → user sees canned message.
+//   2. Admin sender sees the full LLM response with policy detail.
+//   3. inbound_claim properly tracks sessionKey → senderId map.
+//   4. The block-recency window (60s) properly ages out old blocks.
+
+describe("admin separation (v0.4.0)", () => {
+  test("inbound_claim records sessionKey → senderId", () => {
+    const { api, hooks } = buildFakeApi({
+      adminSenders: ["telegram:admin1"],
+    });
+    // @ts-expect-error
+    luminPlugin.register(api);
+    expect(typeof hooks.inbound_claim).toBe("function");
+    expect(typeof hooks.before_message_write).toBe("function");
+  });
+
+  test("non-admin: block recorded → next message_write returns canned reply", async () => {
+    const { api, hooks } = buildFakeApi({
+      adminSenders: ["telegram:admin1"],
+      userBlockedMessage: "Sorry, that's not allowed.",
+    });
+    // @ts-expect-error
+    luminPlugin.register(api);
+
+    // Step 1: claim — record this session as a non-admin sender
+    hooks.inbound_claim!(
+      { sessionKey: "sess-X", senderId: "telegram:joe-user" },
+      undefined,
+    );
+
+    // Step 2: a tool call gets blocked by Lumin
+    fetchMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        decision: "block",
+        reason: "test block",
+        policy_name: "test_policy",
+        agent_feedback: "blocked by Lumin",
+      }),
+    } as unknown as Response));
+
+    const blockResult = await hooks.before_tool_call!(
+      { runId: "r1", toolCallId: "t1", toolName: "shell",
+        params: { command: "rm -rf /" } },
+      { runId: "r1", sessionKey: "sess-X", agentId: "main" },
+    );
+    expect((blockResult as { block?: boolean }).block).toBe(true);
+
+    // Step 3: agent generates a reply — should be intercepted
+    const writeResult = hooks.before_message_write!(
+      {
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Reply with: /approve rm -rf /" }],
+        },
+      },
+      { sessionKey: "sess-X" },
+    ) as { message?: { content?: Array<{ text?: string }> } };
+
+    expect(writeResult).toBeDefined();
+    expect(writeResult.message?.content?.[0]?.text).toBe("Sorry, that's not allowed.");
+    // Confirm the LLM's hallucinated /approve syntax was REPLACED, not echoed
+    expect(writeResult.message?.content?.[0]?.text).not.toContain("/approve");
+  });
+
+  test("admin: block recorded → message_write passes through unchanged", async () => {
+    const { api, hooks } = buildFakeApi({
+      adminSenders: ["telegram:admin1"],
+    });
+    // @ts-expect-error
+    luminPlugin.register(api);
+
+    hooks.inbound_claim!(
+      { sessionKey: "sess-Y", senderId: "telegram:admin1" },
+      undefined,
+    );
+
+    fetchMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ decision: "block", reason: "test", policy_name: "p1" }),
+    } as unknown as Response));
+
+    await hooks.before_tool_call!(
+      { runId: "r2", toolCallId: "t2", toolName: "shell",
+        params: { command: "rm -rf /" } },
+      { runId: "r2", sessionKey: "sess-Y", agentId: "main" },
+    );
+
+    // Admin's reply should NOT be intercepted — full LLM reasoning
+    // visible so they can see policy context.
+    const writeResult = hooks.before_message_write!(
+      {
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "I cannot delete /. The Lumin Agent Firewall blocked this under policy p1." }],
+        },
+      },
+      { sessionKey: "sess-Y" },
+    );
+    expect(writeResult).toBeUndefined(); // pass-through
+  });
+
+  test("no recent block: message_write passes through (admin or not)", () => {
+    const { api, hooks } = buildFakeApi({
+      adminSenders: ["telegram:admin1"],
+    });
+    // @ts-expect-error
+    luminPlugin.register(api);
+
+    hooks.inbound_claim!(
+      { sessionKey: "sess-Z", senderId: "telegram:joe-user" },
+      undefined,
+    );
+
+    // No prior block — non-admin can chat freely
+    const writeResult = hooks.before_message_write!(
+      {
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello! How can I help?" }],
+        },
+      },
+      { sessionKey: "sess-Z" },
+    );
+    expect(writeResult).toBeUndefined(); // pass-through
+  });
+
+  test("missing sessionKey: hook is a no-op", () => {
+    const { api, hooks } = buildFakeApi();
+    // @ts-expect-error
+    luminPlugin.register(api);
+
+    // No sessionKey in ctx → can't correlate, so nothing to do
+    const writeResult = hooks.before_message_write!(
+      {
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "anything" }],
+        },
+      },
+      undefined,
+    );
+    expect(writeResult).toBeUndefined();
+  });
+
+  test("adminSeesFullResponse: false → admin also gets canned message", async () => {
+    const { api, hooks } = buildFakeApi({
+      adminSenders: ["telegram:admin1"],
+      adminSeesFullResponse: false,
+      userBlockedMessage: "Blocked by policy.",
+    });
+    // @ts-expect-error
+    luminPlugin.register(api);
+
+    hooks.inbound_claim!(
+      { sessionKey: "sess-A", senderId: "telegram:admin1" },
+      undefined,
+    );
+
+    fetchMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ decision: "block", reason: "x", policy_name: "p" }),
+    } as unknown as Response));
+
+    await hooks.before_tool_call!(
+      { runId: "r", toolCallId: "t", toolName: "shell", params: {} },
+      { runId: "r", sessionKey: "sess-A", agentId: "main" },
+    );
+
+    const writeResult = hooks.before_message_write!(
+      {
+        message: { role: "assistant", content: [{ type: "text", text: "long admin explanation" }] },
+      },
+      { sessionKey: "sess-A" },
+    ) as { message?: { content?: Array<{ text?: string }> } };
+
+    expect(writeResult.message?.content?.[0]?.text).toBe("Blocked by policy.");
+  });
+
+  test("require_approval also triggers recent-block recording (LLM still suppressed)", async () => {
+    const { api, hooks } = buildFakeApi({
+      adminSenders: [],  // no admins — everyone is non-admin
+    });
+    // @ts-expect-error
+    luminPlugin.register(api);
+
+    hooks.inbound_claim!(
+      { sessionKey: "sess-RA", senderId: "telegram:joe" },
+      undefined,
+    );
+
+    fetchMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        decision: "require_approval",
+        approval_id: "apv-1",
+        timeout_s: 600,
+        policy_name: "needs_apv",
+        reason: "test",
+      }),
+    } as unknown as Response));
+
+    await hooks.before_tool_call!(
+      { runId: "r", toolName: "shell", params: {} },
+      { runId: "r", sessionKey: "sess-RA", agentId: "main" },
+    );
+
+    // Even though Lumin returned require_approval (not block), the
+    // user shouldn't see the LLM's interim reasoning — the operator
+    // hasn't decided yet.
+    const writeResult = hooks.before_message_write!(
+      {
+        message: { role: "assistant", content: [{ type: "text", text: "while we wait, let me try /approve ..." }] },
+      },
+      { sessionKey: "sess-RA" },
+    ) as { message?: { content?: Array<{ text?: string }> } };
+
+    expect(writeResult.message?.content?.[0]?.text).not.toContain("/approve");
   });
 });


### PR DESCRIPTION
Two clusters bundled because the plugin changes (Cluster C) directly consume the server-side \`agent_feedback\` field added in Cluster B — they're tightly coupled and ship together.

## Live Slice 1 dogfood evidence (2026-05-07)

We caught **two** distinct LLM behavior failure modes during real Telegram → OpenClaw → Lumin testing:

1. **LLM hallucinated fake \`/approve <command>\` syntax** and asked the user to click it. Captured in the LLM's reasoning trace: *\"Provide the /approve command... 'Reply with: /approve <command>'\"*.
2. **End user could bypass firewall** by clicking the OpenClaw native approval prompt (\`/approve <id> allow-once\`) themselves — security regression.

Plus the retry loop where each deny → LLM tried again → another approval prompt, ad infinitum.

## What's in this PR

### Cluster B — Server-side LLM feedback fixes

**1.5(a) \`agent_feedback\` in decide response.** Authoritative LLM-targeted feedback string in every non-allow decide() return. Per-decision-verb variants (block / require_approval / rewrite / flag). Each clause targets one of the observed failure modes — cite the platform, disambiguate from user denial, forbid \`/approve\` hallucination, direct toward graceful refusal.

**1.5(b) Session-level deny cache.** Once \`(session_id, tool_name, params_hash)\` is denied, subsequent decide() calls auto-deny in <1ms. TTL 600s default, configurable via \`LUMIN_DENY_CACHE_TTL\`. Scope is intentionally narrow — per-session AND per-tool AND per-params-hash. Cache populated by /v1/approvals/{id}/resolve when resolution=deny.

### Cluster C — Plugin admin separation

**1.0 \`adminSenders\` config.** List of OpenClaw-canonical sender IDs treated as administrators. Default empty = every sender is non-admin (most conservative).

**1.0b \`before_message_write\` interception.** New hook intercepts the LLM's reply when:
- recipient is non-admin (per \`adminSenders\`)
- AND there's been a recent (60s) Lumin block
→ Substitute \`userBlockedMessage\` (neutral canned text). Closes the social-engineering surface where the LLM hallucinated fake \`/approve\` syntax for users to click.

**\`inbound_claim\` hook tracking.** Records sessionKey → senderId at message-arrival time so before_message_write can determine recipient role.

**3 new config keys** documented in README:
- \`adminSenders: string[]\`
- \`userBlockedMessage: string\`
- \`adminSeesFullResponse: boolean\` (default true)

## Test plan

- [x] **API**: 9 new tests (4 agent_feedback variants + 5 deny cache cases). 344/344 pass on this branch.
- [x] **Plugin**: 7 new tests (admin separation describe block). 29/29 pass.
- [x] Plugin build (\`tsc\`) clean.
- [x] No regressions on existing tests.
- [x] README updated with v0.4.0 changelog + new config table rows (per PR-readme-check memory).

## Behavior change — admin/non-admin

In v0.3.x, every sender saw OpenClaw's \`🛡️ Plugin approval required\` prompt and could \`/approve\` it. In v0.4.0 with \`adminSenders\` configured, end users never see the approval surface — admins do.

## What's NOT in this PR

- v0.4.0 lockstep version bump — that lands in the wrap-up PR per the lockstep memory
- npm + ClawHub republish — happens after the version bump merges
- Admin webhook routing (Slack / dedicated Telegram) — Slice 2.5 follow-up; for v0.4.0 admin notification routes through the Lumin dashboard \`/approvals\` page

## After-merge order

1. Merge this PR + #52 (Cluster A)
2. Open the lockstep v0.4.0 release PR (bumps all 9 version locations)
3. Tag \`v0.4.0\` → Docker Hub workflow fires
4. \`npm publish\` + \`clawhub package publish\` for OpenClaw plugin at 0.4.0