### PR TITLE
feat(dashboard): ApprovalsInbox — admin surface for pending firewall approvals (Slice 2 Tier 3.4)

### DIFF
--- a/packages/dashboard/app/approvals/page.tsx
+++ b/packages/dashboard/app/approvals/page.tsx
@@ -1,0 +1,24 @@
+import ApprovalsInbox from '@/components/ApprovalsInbox';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Approvals',
+};
+
+export default function ApprovalsPage() {
+  return (
+    <div className="max-w-5xl mx-auto">
+      <div className="mb-5">
+        <h1 className="text-lg font-semibold">Pending approvals</h1>
+        <p className="text-sm text-[var(--muted)] mt-1">
+          Tool calls that fired a <code className="text-xs">require_approval</code>{' '}
+          rule and are waiting for an operator decision. Click Allow or Deny
+          to resolve. Denied calls are cached per session — the agent can't
+          immediately retry the same action.
+        </p>
+      </div>
+      <ApprovalsInbox />
+    </div>
+  );
+}

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import Logo from '@/components/Logo';
+import ApprovalsNavLink from '@/components/ApprovalsNavLink';
 import ViolationsNavLink from '@/components/ViolationsNavLink';
 import NavLink from '@/components/NavLink';
 import PanicBanner from '@/components/PanicBanner';
@@ -74,6 +75,7 @@ export default function RootLayout({
               <NavLink href="/sessions">Sessions</NavLink>
               <NavLink href="/policies">Policies</NavLink>
               <NavLink href="/decisions">Decisions</NavLink>
+              <ApprovalsNavLink />
               <ViolationsNavLink />
               <span className="opacity-30 mx-1">·</span>
               <a

--- a/packages/dashboard/components/ApprovalsInbox.tsx
+++ b/packages/dashboard/components/ApprovalsInbox.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import useSWR from 'swr';
+
+import {
+  ApprovalRow,
+  ApprovalsListResponse,
+  fetchApprovals,
+  resolveApproval,
+} from '@/lib/api';
+
+/**
+ * Admin-facing inbox for pending firewall approvals (§5.6 / §5.7,
+ * task 3.4). When a `require_approval` rule fires, the agent is
+ * blocked until an operator says allow or deny — this is where they
+ * say it.
+ *
+ * Cluster C separation: when admin senders are excluded from
+ * chat-side approval prompts (so end users never see "approve this
+ * `rm -rf`?"), this dashboard surface is the operator's path. The
+ * agent that's long-polling /v1/approvals/{id} unblocks the moment
+ * we resolve here.
+ *
+ * Polls every 3s — faster than the decisions timeline (5s) because
+ * an agent is literally waiting on each row, and operator decision
+ * latency is the user-visible metric. Empty state is a calm "all
+ * clear" rather than a loading spinner — most of the time the
+ * inbox should be empty.
+ */
+export default function ApprovalsInbox() {
+  const { data, error, isLoading, mutate } = useSWR<ApprovalsListResponse>(
+    'approvals:pending',
+    () => fetchApprovals({ state: 'pending', limit: 50 }),
+    { refreshInterval: 3_000 },
+  );
+
+  if (error) {
+    return (
+      <div className="card p-6 text-rose-400">
+        Failed to load approvals: {String(error.message ?? error)}
+      </div>
+    );
+  }
+
+  if (isLoading || !data) {
+    return (
+      <div className="card p-8 text-center text-[var(--muted)]">Loading…</div>
+    );
+  }
+
+  if (data.approvals.length === 0) {
+    return (
+      <div className="card p-10 text-center">
+        <div className="text-2xl mb-2" aria-hidden>
+          {'\u{1F389}'}
+        </div>
+        <div className="text-sm text-[var(--muted)]">
+          No pending approvals.
+        </div>
+        <div className="text-xs text-[var(--muted)] mt-1 opacity-70">
+          The dashboard is polling every 3s — new requests will appear
+          automatically.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card overflow-hidden">
+      <div className="px-4 py-3 border-b border-[var(--border)] flex items-center justify-between">
+        <span className="text-sm font-medium">Pending approvals</span>
+        <span
+          className="inline-flex items-center justify-center min-w-[1.5rem] px-2 py-0.5 rounded-full
+                     text-xs font-semibold bg-amber-500/20 text-amber-300 border border-amber-500/40"
+        >
+          {data.approvals.length}
+        </span>
+      </div>
+      <ul className="divide-y divide-[var(--border)]">
+        {data.approvals.map((a) => (
+          <ApprovalListItem
+            key={a.id}
+            approval={a}
+            onResolved={async () => {
+              await mutate();
+            }}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+
+type Mode = { kind: 'idle' } | { kind: 'confirm'; resolution: 'allow' | 'deny' };
+
+function ApprovalListItem({
+  approval,
+  onResolved,
+}: {
+  approval: ApprovalRow;
+  onResolved: () => void | Promise<void>;
+}) {
+  const [mode, setMode] = useState<Mode>({ kind: 'idle' });
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [errorText, setErrorText] = useState<string | null>(null);
+
+  async function submit(resolution: 'allow' | 'deny') {
+    setSubmitting(true);
+    setErrorText(null);
+    try {
+      await resolveApproval(
+        approval.id,
+        resolution,
+        reason.trim() || undefined,
+        'dashboard',
+      );
+      // Re-fetch — row should disappear from `state=pending`.
+      await onResolved();
+    } catch (e) {
+      setErrorText(e instanceof Error ? e.message : String(e));
+      setSubmitting(false);
+    }
+  }
+
+  // Format JSON params, max ~200 chars on a single line of code.
+  const paramsText = formatParams(approval.params_truncated);
+
+  return (
+    <li className="px-4 py-3 hover:bg-[var(--surface-hover)]">
+      <div className="flex items-start gap-3">
+        <span
+          className="mt-0.5 text-amber-400 select-none"
+          aria-hidden
+          title="awaiting approval"
+        >
+          {'⚠'}
+        </span>
+        <div className="flex-1 min-w-0">
+          <div className="font-medium text-sm break-all">
+            {approval.policy_id}
+          </div>
+
+          <div className="text-xs text-[var(--muted)] mt-0.5 flex items-center gap-2 flex-wrap">
+            {approval.tool_name && (
+              <span>
+                tool: <span className="font-mono">{approval.tool_name}</span>
+              </span>
+            )}
+            {approval.tool_name && approval.agent && <span aria-hidden>·</span>}
+            {approval.agent && (
+              <span>
+                agent: <span className="font-mono">{approval.agent}</span>
+              </span>
+            )}
+          </div>
+
+          {paramsText && (
+            <pre
+              className="mt-2 text-xs bg-[var(--surface-elev)] p-2 rounded
+                         border border-[var(--border)] overflow-x-auto
+                         whitespace-pre-wrap break-all"
+            >
+              {paramsText}
+            </pre>
+          )}
+
+          <div className="text-xs text-[var(--muted)] mt-2 flex items-center gap-2 flex-wrap">
+            {approval.trace_id && (
+              <>
+                <Link
+                  href={`/traces/${approval.trace_id}`}
+                  className="font-mono hover:underline text-[var(--accent)]"
+                >
+                  trace {approval.trace_id.slice(0, 8)}…
+                </Link>
+                <span aria-hidden>·</span>
+              </>
+            )}
+            <span>{formatRelative(approval.requested_at)}</span>
+            {approval.timeout_at && (
+              <>
+                <span aria-hidden>·</span>
+                <span title={`auto-${approval.on_timeout} at ${approval.timeout_at}`}>
+                  times out {formatRelative(approval.timeout_at)} (
+                  {approval.on_timeout})
+                </span>
+              </>
+            )}
+          </div>
+
+          {/* Action row */}
+          <div className="mt-3">
+            {mode.kind === 'idle' ? (
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() =>
+                    setMode({ kind: 'confirm', resolution: 'allow' })
+                  }
+                  className="px-3 py-1 rounded text-xs font-medium border
+                             bg-emerald-500/10 hover:bg-emerald-500/20
+                             text-emerald-300 border-emerald-500/40"
+                >
+                  Allow
+                </button>
+                <button
+                  onClick={() =>
+                    setMode({ kind: 'confirm', resolution: 'deny' })
+                  }
+                  className="px-3 py-1 rounded text-xs font-medium border
+                             bg-rose-500/10 hover:bg-rose-500/20
+                             text-rose-300 border-rose-500/40"
+                >
+                  Deny
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <input
+                  type="text"
+                  placeholder="Reason (optional)"
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  disabled={submitting}
+                  autoFocus
+                  className="w-full px-2 py-1 rounded border bg-transparent
+                             text-xs border-[var(--border)]
+                             placeholder:text-[var(--muted)]
+                             focus:outline-none focus:border-[var(--accent)]"
+                />
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-[var(--muted)] mr-1">
+                    {mode.resolution === 'allow' ? 'Allow this?' : 'Deny this?'}
+                  </span>
+                  <button
+                    onClick={() => submit(mode.resolution)}
+                    disabled={submitting}
+                    className={
+                      'px-3 py-1 rounded text-xs font-medium border ' +
+                      (mode.resolution === 'allow'
+                        ? 'bg-emerald-500/20 hover:bg-emerald-500/30 text-emerald-200 border-emerald-500/50'
+                        : 'bg-rose-500/20 hover:bg-rose-500/30 text-rose-200 border-rose-500/50') +
+                      ' disabled:opacity-50'
+                    }
+                  >
+                    {submitting ? 'Submitting…' : 'Confirm'}
+                  </button>
+                  <button
+                    onClick={() => {
+                      setMode({ kind: 'idle' });
+                      setReason('');
+                      setErrorText(null);
+                    }}
+                    disabled={submitting}
+                    className="px-3 py-1 rounded text-xs font-medium border
+                               border-[var(--border)] text-[var(--muted)]
+                               hover:text-[var(--foreground)] disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                {errorText && (
+                  <div className="text-xs text-rose-400">{errorText}</div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+
+function formatParams(params: unknown): string | null {
+  if (params === null || params === undefined) return null;
+  let text: string;
+  try {
+    text = typeof params === 'string' ? params : JSON.stringify(params, null, 2);
+  } catch {
+    text = String(params);
+  }
+  if (!text) return null;
+  if (text.length > 400) {
+    return text.slice(0, 400) + '…';
+  }
+  return text;
+}
+
+
+function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  // Naive timestamps from DuckDB → treat as UTC.
+  const d = new Date(iso.includes('Z') || iso.includes('+') ? iso : `${iso}Z`);
+  const sec = Math.floor((Date.now() - d.getTime()) / 1000);
+  if (sec >= 0) {
+    if (sec < 60) return `${sec}s ago`;
+    if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
+    if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`;
+    return d.toLocaleDateString();
+  }
+  // Future timestamp (e.g. timeout_at) → "in X".
+  const future = -sec;
+  if (future < 60) return `in ${future}s`;
+  if (future < 3600) return `in ${Math.floor(future / 60)}m`;
+  if (future < 86400) return `in ${Math.floor(future / 3600)}h`;
+  return d.toLocaleString();
+}

--- a/packages/dashboard/components/ApprovalsNavLink.tsx
+++ b/packages/dashboard/components/ApprovalsNavLink.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import useSWR from 'swr';
+import { ApprovalsListResponse, fetchApprovals } from '@/lib/api';
+
+/**
+ * Top-nav link for /approvals with a live pending-count badge. Polls
+ * every 5s — fast enough that operators see new approvals appear in
+ * the header without needing to be on the inbox page, slow enough not
+ * to hammer the API. Mirrors ViolationsNavLink's pattern.
+ *
+ * Failures are silent — the link still renders without the badge if
+ * the API is unreachable. Per Rule 7 the dashboard never crashes
+ * because of policy data.
+ */
+export default function ApprovalsNavLink() {
+  const { data } = useSWR<ApprovalsListResponse>(
+    'approvals:nav-count',
+    () => fetchApprovals({ state: 'pending', limit: 1 }),
+    {
+      refreshInterval: 5_000,
+      shouldRetryOnError: false,
+      revalidateOnFocus: false,
+    },
+  );
+
+  const pending = data?.total ?? 0;
+  const pathname = usePathname();
+  const isActive =
+    pathname === '/approvals' || pathname?.startsWith('/approvals/');
+
+  return (
+    <Link
+      href="/approvals"
+      className={
+        'px-2 py-1 rounded transition-colors inline-flex items-center gap-1.5 ' +
+        (isActive
+          ? 'text-[var(--foreground)] bg-[var(--background-hover)]'
+          : 'text-[var(--muted)] hover:text-[var(--foreground)] hover:bg-[var(--background-hover)]')
+      }
+    >
+      Approvals
+      {pending > 0 ? (
+        <span
+          className="inline-flex items-center justify-center min-w-[1.25rem]
+                     px-1.5 rounded-full text-[10px] font-semibold
+                     bg-amber-500/20 text-amber-300 border border-amber-500/40"
+          title={`${pending} pending approval${pending === 1 ? '' : 's'}`}
+        >
+          {pending > 99 ? '99+' : pending}
+        </span>
+      ) : null}
+    </Link>
+  );
+}

--- a/packages/dashboard/lib/api.ts
+++ b/packages/dashboard/lib/api.ts
@@ -351,6 +351,49 @@ export async function fetchPanicState(): Promise<PanicState> {
   return fetcher(`/v1/firewall/panic_disable`);
 }
 
+
+// ---- Approvals (§5.6 / §5.7) ---------------------------------------------
+
+export async function fetchApprovals(params: {
+  state?: string;
+  project?: string;
+  agent?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<ApprovalsListResponse> {
+  const q = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== null && v !== '') q.set(k, String(v));
+  }
+  const path = `/v1/approvals${q.toString() ? `?${q}` : ''}`;
+  return fetcher(path);
+}
+
+export async function fetchApproval(id: string): Promise<ApprovalRow> {
+  return fetcher(`/v1/approvals/${encodeURIComponent(id)}`);
+}
+
+export async function resolveApproval(
+  id: string,
+  resolution: 'allow' | 'deny',
+  reason?: string,
+  resolver?: string,
+): Promise<{ id: string; state: string; resolved_at: string }> {
+  const res = await fetch(
+    `${API_BASE}/v1/approvals/${encodeURIComponent(id)}/resolve`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ resolution, reason, resolver }),
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Resolve failed: HTTP ${res.status} ${text}`);
+  }
+  return res.json();
+}
+
 export async function setPanicDisabled(
   disabled: boolean, reason?: string, actor?: string,
 ): Promise<{ disabled: boolean; reason: string | null; updated_at: string; updated_by: string | null }> {


### PR DESCRIPTION
## Summary

Slice 2 Tier 3.4 — the admin surface for resolving pending firewall approvals.

When a `require_approval` policy fires, the agent is blocked (long-polling `GET /v1/approvals/{id}`) until an operator says allow or deny. Slice 1 shipped the API + decision logging; this PR ships the operator UI.

This also completes the admin-separation story from Cluster C: when `adminSenders` excludes end users from chat-side approval prompts (so end users never see _\"approve this `rm -rf`?\"_), the Lumin dashboard `/approvals` page is where operators actually resolve them.

## What's in here

- **`packages/dashboard/components/ApprovalsInbox.tsx`** — live-polling list of pending approvals
  - Polls `fetchApprovals({state: 'pending'})` every **3s** (vs. 5s for decisions — operator decision latency is the user-visible metric here, since an agent is literally waiting on each row)
  - Each row shows policy id, tool, agent, formatted JSON params (truncated to ~400 chars), trace link, relative requested-at, and a timeout countdown (`times out in 4m (deny)`)
  - **Allow / Deny** inline → confirm step with optional `reason` text input → POST to `/v1/approvals/{id}/resolve`, mutate SWR cache, row disappears
  - Inline error banner if resolve fails (409 already-resolved, network, etc.); user can retry or cancel
  - Empty state: \"No pending approvals.\" — most of the time the inbox should be empty, so we lean calm rather than spinner
- **`packages/dashboard/app/approvals/page.tsx`** — page wrapper with explanatory header copy
- **`packages/dashboard/components/ApprovalsNavLink.tsx`** — top-nav link with a live amber pending-count badge (polls every 5s; mirrors `ViolationsNavLink`'s pattern)
- **`packages/dashboard/lib/api.ts`** — three new fetchers: `fetchApprovals`, `fetchApproval`, `resolveApproval`. Types `ApprovalRow` / `ApprovalsListResponse` already existed from Slice 1.

## UX decisions

- **3s poll interval** for the inbox; **5s** for the nav-link badge. Inbox is the active workspace; nav is ambient.
- **Amber/yellow** accent for pending count + the warning glyph row prefix — matches `require_approval` colour in `DecisionBadge`.
- **Allow** = emerald, **Deny** = rose, both at low-opacity by default and high-opacity in confirm step (so a fat-finger first click never resolves; second click does).
- Reason is **optional** but the input is `autoFocus` in confirm mode, so an operator who wants to leave a note doesn't have to mouse over.
- **`resolver: 'dashboard'`** is sent on every resolve so the audit trail distinguishes dashboard-resolved vs. CLI-resolved vs. webhook-resolved approvals.

## API contract — no changes

This PR consumes existing endpoints only:
- `GET /v1/approvals?state=pending&limit=50`
- `POST /v1/approvals/{id}/resolve` with `{resolution, reason?, resolver?}`

No version bump. No backend modification.

## Build status

Clean — `npm run build` passes type-check and lint. New `/approvals` route compiles to 2.96 kB.

## Test plan

- [ ] Trigger a `require_approval` decision (e.g. via OpenClaw `exec` rule); confirm row appears in `/approvals` within 3s
- [ ] Click **Allow** → **Confirm** → row disappears, agent unblocks
- [ ] Click **Deny** with a reason → row disappears, agent receives blocked response, deny cached for the session
- [ ] Network failure mid-resolve → inline error banner, row stays, retryable
- [ ] Two operators race to resolve same row → second sees `approval already allowed/denied` 409 surfaced cleanly
- [ ] Empty state renders when there are zero pending approvals
- [ ] Nav badge appears within 5s of a new pending approval and clears within 5s of resolution
- [ ] Light + dark theme both render correctly