### PR TITLE
feat(api): firewall — Presidio detector + auto circuit breaker (Slice 2 Tier 2.1 + 4.1)

### DIFF
--- a/packages/api/firewall/builtins.py
+++ b/packages/api/firewall/builtins.py
@@ -38,6 +38,7 @@ from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlparse
 
 from firewall.detectors import regex_pack as rp
+from firewall.detectors import presidio as presidio_det
 
 logger = logging.getLogger("lumin.api.firewall.builtins")
 
@@ -137,6 +138,23 @@ def looks_like_secret(s: Optional[str]) -> bool:
 
 def has_pii(s: Optional[str]) -> bool:
     return rp.has_pii(s)
+
+
+def presidio_pii_score(s: Optional[str]) -> float:
+    """Semantic PII confidence score (0.0–1.0) via Microsoft Presidio.
+
+    Returns 0.0 when presidio isn't installed — that's the expected
+    state for operators who don't opt into the heavier ML deps.
+    See ``firewall.detectors.presidio`` for the entity allow-list.
+    """
+    return presidio_det.presidio_pii_score(s)
+
+
+def presidio_pii_entities(s: Optional[str]) -> list:
+    """List of ``{entity_type, score, start, end}`` dicts for every
+    PII entity Presidio detected. Empty list when presidio isn't
+    installed or no entity matched."""
+    return presidio_det.presidio_pii_entities(s)
 
 
 def has_image_markdown_exfil(s: Optional[str]) -> bool:
@@ -472,6 +490,9 @@ STATELESS_BUILTINS: Dict[str, Callable] = {
     "has_pii": has_pii,
     "has_image_markdown_exfil": has_image_markdown_exfil,
     "has_ascii_smuggling": has_ascii_smuggling,
+    # Detectors (presidio — optional, returns 0.0 / [] when not installed)
+    "presidio_pii_score": presidio_pii_score,
+    "presidio_pii_entities": presidio_pii_entities,
     # Sanitisation
     "redact_pii": redact_pii,
 }

--- a/packages/api/firewall/decide.py
+++ b/packages/api/firewall/decide.py
@@ -34,10 +34,12 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 import uuid
+from collections import deque
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Deque, Dict, List, Optional, Tuple
 
 from lumin.policy import Policy
 
@@ -109,6 +111,119 @@ def refresh_panic_state(db: Database) -> None:
         # Table may not exist yet (pre-migration), or row missing.
         # Either way: leave the flag as-is.
         pass
+
+
+# ---- auto circuit breaker (Tier 4.1) -------------------------------------
+#
+# Track per-policy fire counts in a rolling 60-second window. When a
+# single policy fires more than ``_AUTO_TRIP_FIRES_PER_MINUTE`` times
+# in 60s, flip its ``circuit_breaker_state`` to 'tripped' so subsequent
+# evaluations skip it. The trip is sticky until an operator un-trips
+# the policy via the dashboard / API — we don't auto-reset, because a
+# rule that fires 100+/min is by definition broken or under attack
+# and a human needs to look.
+#
+# Set ``LUMIN_AUTO_TRIP_FIRES_PER_MINUTE=0`` to disable the auto-trip
+# entirely (operators may want this when running a known-noisy rule
+# in shadow mode while gathering tuning data).
+
+_AUTO_TRIP_FIRES_PER_MINUTE = int(
+    os.environ.get("LUMIN_AUTO_TRIP_FIRES_PER_MINUTE", "100")
+)
+
+# In-memory tracker. Keyed by policy.name → deque of monotonic
+# timestamps (seconds). Each fire appends ``time.time()``; entries
+# older than 60s are trimmed lazily on each track / check call.
+_RULE_FIRE_RATES: Dict[str, Deque[float]] = {}
+
+
+def _now_seconds() -> float:
+    """Wall-clock time, monkeypatchable in tests."""
+    return time.time()
+
+
+def _track_fire(policy_name: str) -> None:
+    """Record that ``policy_name`` just fired. Trims the window to the
+    most recent 60 seconds.
+    """
+    if not policy_name:
+        return
+    now = _now_seconds()
+    cutoff = now - 60.0
+    dq = _RULE_FIRE_RATES.get(policy_name)
+    if dq is None:
+        dq = deque()
+        _RULE_FIRE_RATES[policy_name] = dq
+    dq.append(now)
+    # Trim old entries — pop from the left while the oldest is stale.
+    while dq and dq[0] < cutoff:
+        dq.popleft()
+
+
+def _check_circuit_breaker(policy_name: str) -> bool:
+    """Return True iff ``policy_name`` has fired more than
+    ``_AUTO_TRIP_FIRES_PER_MINUTE`` times in the last 60 seconds and
+    should be auto-tripped.
+
+    Returns False when the threshold env var is 0 (auto-trip disabled).
+    """
+    if _AUTO_TRIP_FIRES_PER_MINUTE <= 0:
+        return False
+    if not policy_name:
+        return False
+    dq = _RULE_FIRE_RATES.get(policy_name)
+    if not dq:
+        return False
+    # Trim before counting so a stale window doesn't trigger a false
+    # trip after a long quiet period.
+    cutoff = _now_seconds() - 60.0
+    while dq and dq[0] < cutoff:
+        dq.popleft()
+    return len(dq) > _AUTO_TRIP_FIRES_PER_MINUTE
+
+
+def _maybe_auto_trip(db: Database, policy_name: str) -> None:
+    """Track + check + (if breached) flip the policy's circuit_breaker_state
+    to 'tripped' in the DB. Errors are logged and swallowed — Rule 7."""
+    try:
+        _track_fire(policy_name)
+        if not _check_circuit_breaker(policy_name):
+            return
+        # Threshold breached: trip.
+        try:
+            policy_store.update_policy(
+                db, policy_name, circuit_breaker_state="tripped"
+            )
+        except Exception:
+            # Don't crash the engine if the DB write fails — log and
+            # continue. The next call will re-attempt because the
+            # rolling window still has the over-threshold count.
+            logger.exception(
+                "firewall.decide: failed to persist auto-trip for policy %r",
+                policy_name,
+            )
+            return
+        n = len(_RULE_FIRE_RATES.get(policy_name, ()))
+        logger.warning(
+            "auto-tripped policy %s — fired %d times in the last minute",
+            policy_name, n,
+        )
+        # Clear the deque so we don't re-trip on every call after the
+        # threshold (the policy is already tripped; the next decide()
+        # will skip it via _applicable_policies).
+        _RULE_FIRE_RATES.pop(policy_name, None)
+    except Exception:
+        logger.exception(
+            "firewall.decide: auto-trip bookkeeping crashed for policy %r",
+            policy_name,
+        )
+
+
+def reset_fire_rate_tracker_for_tests() -> None:
+    """Clear the per-policy fire-rate tracker. Tests must call this
+    between cases so fires from a previous test don't leak into the
+    next one's window."""
+    _RULE_FIRE_RATES.clear()
 
 
 # ---- core decide ----------------------------------------------------------
@@ -266,6 +381,13 @@ def decide(
                 policy.name, policy.action,
             )
             continue
+
+        # Auto circuit breaker — Tier 4.1. Track this fire and, if the
+        # policy has fired too often in the last 60s, flip it to
+        # 'tripped' in the DB. The trip applies to *subsequent* calls
+        # (this call's decision is honored). _applicable_policies
+        # already filters out tripped policies on the next request.
+        _maybe_auto_trip(db, policy.name)
 
         # ---- mode resolution --------------------------------------------
         # shadow → record and continue (don't return, lower-priority

--- a/packages/api/firewall/detectors/presidio.py
+++ b/packages/api/firewall/detectors/presidio.py
@@ -1,0 +1,198 @@
+"""Microsoft Presidio integration — Tier 2.1 of SLICE_2_PLAN.md.
+
+Semantic PII detection that complements the regex-pack shape detection
+in ``regex_pack.py``. Presidio is heavier (it loads a spaCy NLP model
+on first use, ~500MB resident) but catches semantic PII that pure
+regex misses — most importantly **person names and addresses**, which
+have no useful regex shape.
+
+Design constraints:
+
+  - **Optional dep.** Presidio brings spaCy + language models that
+    inflate the install footprint substantially. Operators who don't
+    want it shouldn't have to install it. If the import fails at
+    module load time, ``available = False`` and the public functions
+    return safe defaults — score 0.0, empty entity list. Rule 7: a
+    missing classifier never blocks an agent.
+  - **Lazy init.** ``AnalyzerEngine()`` instantiation is the slow
+    step (~2s on a fresh process loading the spaCy model). Defer
+    until first call so a server import that never evaluates a
+    presidio-using policy doesn't pay the cost.
+  - **Single shared engine.** Engine is thread-safe per Presidio
+    docs and cheap to call repeatedly. We cache it module-locally.
+  - **Conservative entity types.** PERSON, EMAIL_ADDRESS, PHONE_NUMBER,
+    US_SSN, CREDIT_CARD, IP_ADDRESS, US_PASSPORT, US_DRIVER_LICENSE.
+    We deliberately skip URL, DATE_TIME, NRP — those have high false-
+    positive rates on agent traffic (most agent outputs include URLs
+    and dates legitimately).
+  - **Errors swallowed.** Bad input or analyzer failure → 0.0 / [].
+    The detector must never raise into the policy engine.
+
+Public API:
+
+  - ``available: bool`` — module-level flag, False when import failed.
+  - ``presidio_pii_score(text) -> float`` — max confidence across
+    detected entities, 0.0 when none / empty / unavailable.
+  - ``presidio_pii_entities(text) -> list[dict]`` — entities with
+    ``{entity_type, score, start, end}`` for the dashboard view.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, List, Optional
+
+logger = logging.getLogger("lumin.api.firewall.detectors.presidio")
+
+
+# ---------------------------------------------------------------------------
+# Optional import — module compiles even when presidio isn't installed.
+# ---------------------------------------------------------------------------
+
+try:
+    from presidio_analyzer import AnalyzerEngine  # type: ignore
+    available = True
+except Exception:  # pragma: no cover — exercised at install time
+    AnalyzerEngine = None  # type: ignore
+    available = False
+
+
+# Allow- and skip-lists. The allow list is what we expose; anything
+# returned by Presidio that isn't in here is dropped before the score
+# is computed.
+_ALLOWED_ENTITIES = frozenset({
+    "PERSON",
+    "EMAIL_ADDRESS",
+    "PHONE_NUMBER",
+    "US_SSN",
+    "CREDIT_CARD",
+    "IP_ADDRESS",
+    "US_PASSPORT",
+    "US_DRIVER_LICENSE",
+})
+
+
+# Lazy-init machinery. We only construct the AnalyzerEngine on first
+# call because instantiation loads spaCy models and is slow.
+_engine: Optional[Any] = None
+_engine_lock = threading.Lock()
+_engine_init_failed = False
+
+
+def _get_engine() -> Optional[Any]:
+    """Return the singleton AnalyzerEngine, instantiating it on first
+    call. Returns None when presidio isn't installed or init fails.
+    """
+    global _engine, _engine_init_failed
+    if not available:
+        return None
+    if _engine_init_failed:
+        return None
+    if _engine is not None:
+        return _engine
+    with _engine_lock:
+        if _engine is not None:
+            return _engine
+        if _engine_init_failed:
+            return None
+        try:
+            _engine = AnalyzerEngine()
+        except Exception:
+            # Most likely cause: missing spaCy model. Mark init as
+            # failed so subsequent calls don't keep retrying — they
+            # all fall back to safe defaults. Rule 7.
+            logger.warning(
+                "presidio AnalyzerEngine init failed — semantic PII "
+                "detection disabled for this process",
+                exc_info=True,
+            )
+            _engine_init_failed = True
+            _engine = None
+    return _engine
+
+
+def presidio_pii_score(text: Optional[str]) -> float:
+    """Max-confidence score (0.0 - 1.0) across detected PII entities.
+
+    Returns 0.0 when:
+      - text is None or empty
+      - presidio is not installed (``available == False``)
+      - the analyzer engine fails to initialize
+      - the analyze call raises
+      - no entity in the allow-list is detected
+    """
+    if not text or not isinstance(text, str):
+        return 0.0
+    engine = _get_engine()
+    if engine is None:
+        return 0.0
+    try:
+        results = engine.analyze(
+            text=text,
+            language="en",
+            entities=list(_ALLOWED_ENTITIES),
+        )
+    except Exception:
+        logger.debug("presidio analyze failed", exc_info=True)
+        return 0.0
+    if not results:
+        return 0.0
+    try:
+        scores = [
+            float(getattr(r, "score", 0.0))
+            for r in results
+            if getattr(r, "entity_type", None) in _ALLOWED_ENTITIES
+        ]
+    except Exception:
+        return 0.0
+    if not scores:
+        return 0.0
+    return max(scores)
+
+
+def presidio_pii_entities(text: Optional[str]) -> List[dict]:
+    """List of detected entities, each ``{entity_type, score, start,
+    end}``. Used by the dashboard's "what was detected" panel.
+
+    Returns ``[]`` on the same conditions ``presidio_pii_score`` returns
+    0.0 (no input / not installed / init failed / engine error).
+    """
+    if not text or not isinstance(text, str):
+        return []
+    engine = _get_engine()
+    if engine is None:
+        return []
+    try:
+        results = engine.analyze(
+            text=text,
+            language="en",
+            entities=list(_ALLOWED_ENTITIES),
+        )
+    except Exception:
+        logger.debug("presidio analyze failed", exc_info=True)
+        return []
+    out: List[dict] = []
+    try:
+        for r in results:
+            etype = getattr(r, "entity_type", None)
+            if etype not in _ALLOWED_ENTITIES:
+                continue
+            out.append({
+                "entity_type": etype,
+                "score": float(getattr(r, "score", 0.0)),
+                "start": int(getattr(r, "start", 0)),
+                "end": int(getattr(r, "end", 0)),
+            })
+    except Exception:
+        return []
+    return out
+
+
+def _reset_engine_for_tests() -> None:
+    """Drop the cached engine and any init-failure flag. Used by the
+    test suite to exercise the lazy-init path repeatedly."""
+    global _engine, _engine_init_failed
+    with _engine_lock:
+        _engine = None
+        _engine_init_failed = False

--- a/packages/api/requirements.txt
+++ b/packages/api/requirements.txt
@@ -20,3 +20,12 @@ pyyaml>=6.0
 # OpenLLMetry, etc.) without requiring the Lumin SDK. Stable since
 # 1.30; pinned to a recent minor to keep proto bindings consistent.
 opentelemetry-proto>=1.30
+# OPTIONAL — Microsoft Presidio for semantic PII detection (Tier 2.1
+# of the firewall slice plan). Brings spaCy + a language model
+# (~500MB resident on first use). Operators who don't need semantic
+# PII (or are happy with the regex_pack shape detection) can leave
+# this uninstalled — the firewall.detectors.presidio module degrades
+# gracefully (``available = False``, score → 0.0). Activate by:
+#     pip install 'presidio-analyzer>=2.2.0'
+#     python -m spacy download en_core_web_lg
+# presidio-analyzer>=2.2.0

--- a/packages/api/routers/policy.py
+++ b/packages/api/routers/policy.py
@@ -532,6 +532,8 @@ _ALLOWED_FUNCTIONS = frozenset({
     "looks_like_secret", "has_pii",
     "has_image_markdown_exfil", "has_ascii_smuggling",
     "redact_pii",
+    # Presidio (optional dep; gracefully returns 0.0 / [] when missing)
+    "presidio_pii_score", "presidio_pii_entities",
     # History-backed (registered per-request via build_history_builtins)
     "session_total_tokens", "session_total_cost",
     "trace_total_cost", "tool_calls_in_trace",

--- a/packages/api/tests/firewall/test_circuit_breaker.py
+++ b/packages/api/tests/firewall/test_circuit_breaker.py
@@ -1,0 +1,191 @@
+"""Tests for the auto circuit breaker — Tier 4.1 of SLICE_2_PLAN.md.
+
+The breaker watches each policy's fire rate and, when a single rule
+exceeds ``LUMIN_AUTO_TRIP_FIRES_PER_MINUTE`` fires in 60s, flips the
+policy's ``circuit_breaker_state`` to 'tripped'. ``_applicable_policies``
+already excludes tripped policies, so subsequent decide() calls skip
+the offending rule.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from db import Database
+from firewall import decide as fw_decide
+from lumin.policy import Policy
+import policy_store
+
+
+# ---- fixtures -------------------------------------------------------------
+
+
+@pytest.fixture
+def db() -> Database:
+    d = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    fw_decide.set_panic_disabled(False)
+    fw_decide.reset_fire_rate_tracker_for_tests()
+    yield d
+    fw_decide.set_panic_disabled(False)
+    fw_decide.reset_fire_rate_tracker_for_tests()
+    d.close()
+
+
+def _mk_policy(
+    db: Database,
+    *,
+    name: str,
+    lifecycle: str = "before_tool_call",
+    mode: str = "enforce",
+    priority: int = 0,
+    action: str = "block",
+    condition: str = "True",
+) -> Policy:
+    p = Policy(
+        name=name,
+        description=f"test policy {name}",
+        trigger="span_end",
+        condition=condition,
+        action=action,
+        severity="medium",
+        scope_agents=[],
+        lifecycle=lifecycle,
+        mode=mode,
+        priority=priority,
+    )
+    return policy_store.create_policy(db, p, actor="test")
+
+
+# ---- _check_circuit_breaker / _track_fire ---------------------------------
+
+
+def test_check_returns_false_for_low_fire_rate() -> None:
+    fw_decide.reset_fire_rate_tracker_for_tests()
+    for _ in range(5):
+        fw_decide._track_fire("policy_a")
+    assert fw_decide._check_circuit_breaker("policy_a") is False
+
+
+def test_check_returns_true_after_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fire one more time than the threshold and the breaker trips."""
+    monkeypatch.setattr(fw_decide, "_AUTO_TRIP_FIRES_PER_MINUTE", 10)
+    fw_decide.reset_fire_rate_tracker_for_tests()
+    # 10 is the threshold — must exceed it (>) to trip per spec.
+    for _ in range(11):
+        fw_decide._track_fire("noisy_rule")
+    assert fw_decide._check_circuit_breaker("noisy_rule") is True
+
+
+def test_window_rolls_off_after_60s(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Timestamps older than 60s must drop out of the window so a
+    quiet recovery period clears the count."""
+    monkeypatch.setattr(fw_decide, "_AUTO_TRIP_FIRES_PER_MINUTE", 5)
+    fw_decide.reset_fire_rate_tracker_for_tests()
+
+    # Pretend it's t=1000 and fire 6 times.
+    fake_t = {"now": 1000.0}
+    monkeypatch.setattr(fw_decide, "_now_seconds", lambda: fake_t["now"])
+    for _ in range(6):
+        fw_decide._track_fire("rule_x")
+    assert fw_decide._check_circuit_breaker("rule_x") is True
+
+    # Advance 61s — every old timestamp is now stale.
+    fake_t["now"] = 1061.0
+    assert fw_decide._check_circuit_breaker("rule_x") is False
+
+
+def test_disabled_when_threshold_is_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LUMIN_AUTO_TRIP_FIRES_PER_MINUTE=0 disables the breaker — a
+    rule firing 1000+ times per minute still won't auto-trip."""
+    monkeypatch.setattr(fw_decide, "_AUTO_TRIP_FIRES_PER_MINUTE", 0)
+    fw_decide.reset_fire_rate_tracker_for_tests()
+    for _ in range(1000):
+        fw_decide._track_fire("anything")
+    assert fw_decide._check_circuit_breaker("anything") is False
+
+
+# ---- _maybe_auto_trip ----------------------------------------------------
+
+
+def test_auto_trip_updates_db_state(
+    db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Once the threshold is exceeded, _maybe_auto_trip must write
+    'tripped' to the policy row."""
+    monkeypatch.setattr(fw_decide, "_AUTO_TRIP_FIRES_PER_MINUTE", 3)
+    _mk_policy(db, name="will_trip")
+    fw_decide.reset_fire_rate_tracker_for_tests()
+    for _ in range(5):
+        fw_decide._maybe_auto_trip(db, "will_trip")
+    row = db.fetchone(
+        "SELECT circuit_breaker_state FROM policies WHERE name = ?",
+        ["will_trip"],
+    )
+    assert row is not None
+    assert row[0] == "tripped"
+
+
+# ---- end-to-end via decide() ---------------------------------------------
+
+
+def test_decide_auto_trips_after_repeated_fires(
+    db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive the full decide() path past the threshold; the policy's
+    DB row must flip to 'tripped' and subsequent calls must skip it."""
+    monkeypatch.setattr(fw_decide, "_AUTO_TRIP_FIRES_PER_MINUTE", 5)
+    _mk_policy(db, name="hot_rule", action="block", condition="True")
+
+    decisions: List[str] = []
+    for _ in range(7):
+        out = fw_decide.decide(
+            db, lifecycle="before_tool_call", tool_name="shell"
+        )
+        decisions.append(out["decision"])
+
+    # First 6 fired (block), the 7th sees the policy tripped and
+    # falls through to allow.
+    assert "block" in decisions
+    assert decisions[-1] == "allow"
+
+    row = db.fetchone(
+        "SELECT circuit_breaker_state FROM policies WHERE name = ?",
+        ["hot_rule"],
+    )
+    assert row is not None
+    assert row[0] == "tripped"
+
+    # And one more decide() call confirms the policy stays skipped —
+    # _applicable_policies filters it out at the SQL layer.
+    out = fw_decide.decide(
+        db, lifecycle="before_tool_call", tool_name="shell"
+    )
+    assert out["decision"] == "allow"
+
+
+def test_decide_respects_disabled_auto_trip(
+    db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With LUMIN_AUTO_TRIP_FIRES_PER_MINUTE=0, repeated fires never
+    flip the policy state."""
+    monkeypatch.setattr(fw_decide, "_AUTO_TRIP_FIRES_PER_MINUTE", 0)
+    _mk_policy(db, name="immortal", action="block", condition="True")
+
+    for _ in range(150):
+        out = fw_decide.decide(
+            db, lifecycle="before_tool_call", tool_name="shell"
+        )
+        assert out["decision"] == "block"
+
+    row = db.fetchone(
+        "SELECT circuit_breaker_state FROM policies WHERE name = ?",
+        ["immortal"],
+    )
+    assert row is not None
+    assert row[0] == "ok"

--- a/packages/api/tests/firewall/test_presidio.py
+++ b/packages/api/tests/firewall/test_presidio.py
@@ -1,0 +1,113 @@
+"""Tests for the Presidio detector — Tier 2.1.
+
+Most tests are skipped when presidio isn't installed; the always-passing
+``test_unavailable_returns_zero`` exercises the graceful-degradation
+path that matters when operators don't opt in to the heavier ML deps.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from firewall.detectors import presidio
+
+
+pytestmark = pytest.mark.filterwarnings("ignore")
+
+
+@pytest.mark.skipif(
+    not presidio.available,
+    reason="presidio-analyzer not installed in this environment",
+)
+def test_score_for_personal_address_string() -> None:
+    """A canonical PII-laden string should clear the 0.5 threshold —
+    Presidio detects PERSON + (likely) US locations."""
+    score = presidio.presidio_pii_score(
+        "John Smith lives in 123 Main St, Springfield"
+    )
+    assert score > 0.5, f"expected score > 0.5 for PII string, got {score}"
+
+
+@pytest.mark.skipif(
+    not presidio.available,
+    reason="presidio-analyzer not installed in this environment",
+)
+def test_score_for_neutral_text_is_zero() -> None:
+    """Plain prose with no PII should not register any allow-listed
+    entity — score is 0.0 (no detections from the curated set)."""
+    score = presidio.presidio_pii_score("this is just text")
+    assert score == 0.0
+
+
+def test_score_for_none_or_empty() -> None:
+    """None / empty / non-str input → 0.0 unconditionally; this path
+    runs without requiring presidio to be installed."""
+    assert presidio.presidio_pii_score(None) == 0.0
+    assert presidio.presidio_pii_score("") == 0.0
+    assert presidio.presidio_pii_score(123) == 0.0  # type: ignore[arg-type]
+
+
+@pytest.mark.skipif(
+    not presidio.available,
+    reason="presidio-analyzer not installed in this environment",
+)
+def test_entities_for_ssn_string_includes_us_ssn() -> None:
+    """An SSN-laden string should produce at least one US_SSN entity in
+    the structured output the dashboard reads. Use a recognized SSN
+    shape — Presidio's recognizer rejects 9-digit groups whose area
+    number violates SSA allocation rules (so "123-45-6789" is dropped
+    despite matching the visual pattern)."""
+    entities = presidio.presidio_pii_entities(
+        "Patient SSN is 451-66-2342, please file"
+    )
+    assert any(e["entity_type"] == "US_SSN" for e in entities), (
+        f"expected US_SSN in entities, got {entities}"
+    )
+
+
+@pytest.mark.skipif(
+    not presidio.available,
+    reason="presidio-analyzer not installed in this environment",
+)
+def test_entities_for_empty_input_is_empty_list() -> None:
+    assert presidio.presidio_pii_entities("") == []
+    assert presidio.presidio_pii_entities(None) == []
+
+
+def test_unavailable_returns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When presidio's import is simulated as failed, score is always
+    0.0 and entities is always [] — the documented fallback. Always
+    runs, regardless of whether presidio is actually installed."""
+    monkeypatch.setattr(presidio, "available", False)
+    presidio._reset_engine_for_tests()
+    try:
+        assert presidio.presidio_pii_score(
+            "John Smith lives in 123 Main St"
+        ) == 0.0
+        assert presidio.presidio_pii_entities(
+            "Patient SSN is 123-45-6789"
+        ) == []
+    finally:
+        presidio._reset_engine_for_tests()
+
+
+def test_score_swallows_engine_init_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When AnalyzerEngine() raises (e.g. spaCy model missing), the
+    detector falls back to 0.0 / [] without bubbling the exception
+    up into the policy engine. Rule 7."""
+    presidio._reset_engine_for_tests()
+
+    class _BoomEngine:
+        def __init__(self, *a, **kw):
+            raise RuntimeError("simulated init failure")
+
+    # Force the lazy-init code path even if presidio isn't installed.
+    monkeypatch.setattr(presidio, "available", True)
+    monkeypatch.setattr(presidio, "AnalyzerEngine", _BoomEngine)
+    try:
+        assert presidio.presidio_pii_score("John Smith") == 0.0
+        assert presidio.presidio_pii_entities("John Smith") == []
+    finally:
+        presidio._reset_engine_for_tests()


### PR DESCRIPTION
## Summary

Two server-side additions to the Lumin Agent Firewall (Slice 2 plan, Tier 2.1 and Tier 4.1).

### Tier 2.1 — Microsoft Presidio integration

- New `packages/api/firewall/detectors/presidio.py` module with two builtins exposed to policy expressions:
  - `presidio_pii_score(text) -> float` — max confidence (0.0-1.0) across detected PII
  - `presidio_pii_entities(text) -> list[dict]` — `{entity_type, score, start, end}` for the dashboard's "what was detected" view
- Curated entity allow-list (PERSON, EMAIL_ADDRESS, PHONE_NUMBER, US_SSN, CREDIT_CARD, IP_ADDRESS, US_PASSPORT, US_DRIVER_LICENSE). Skips noisy types (URL, DATE_TIME, NRP).
- Lazy `AnalyzerEngine` instantiation — server startup pays no cost when no policy uses the detector.
- Wired into `STATELESS_BUILTINS` and the policy router's `_ALLOWED_FUNCTIONS`.

**Presidio is OPTIONAL.** Activate by:

```
pip install 'presidio-analyzer>=2.2.0'
python -m spacy download en_core_web_lg
```

When uninstalled, `firewall.detectors.presidio.available == False` and both builtins return safe defaults (`0.0` / `[]`) — rule conditions using `presidio_pii_score(...) > 0.5` simply never fire (Rule 7: a missing classifier never blocks an agent).

### Tier 4.1 — Auto circuit breaker

- New rolling 60s fire-rate tracker per policy in `firewall.decide`.
- `decide()` calls `_maybe_auto_trip(db, policy.name)` after a rule fires with a non-allow action. When a single policy exceeds `LUMIN_AUTO_TRIP_FIRES_PER_MINUTE` (default 100) fires in 60s, its `circuit_breaker_state` flips to `'tripped'` in the DB. The current decision is honored; subsequent calls skip the policy via the existing `_applicable_policies` SQL filter (no further changes there needed).
- Trip is sticky — operators must un-trip via the dashboard / API. A rule firing 100+/min is broken or under attack and a human should look.
- All bookkeeping wrapped in try/except (Rule 7).

**Auto-trip is OPT-OUT.** Set `LUMIN_AUTO_TRIP_FIRES_PER_MINUTE=0` to disable entirely (useful when running a known-noisy rule in shadow while gathering tuning data).

## Test plan

- [x] `tests/firewall/test_presidio.py` — 7 cases: positive PII string, neutral text, None/empty inputs, US_SSN structured detection, fallback behaviour when `available=False`, swallowed `AnalyzerEngine.__init__` failure. PII-detection tests skip when presidio isn't installed; fallback tests always run.
- [x] `tests/firewall/test_circuit_breaker.py` — 7 cases: low fire rate doesn't trip, threshold breach trips, 60s rolloff, `=0` disables, DB row flips to tripped, end-to-end through `decide()`, disabled-via-env stays at `'ok'`.
- [x] Full suite: `349 passed in 9.39s` on this branch.
- [ ] Manual smoke: install presidio, define a rule with `condition: presidio_pii_score(text) > 0.7`, send a request containing a person's name, verify decision and dashboard surface.