### PR TITLE
feat(firewall): rule template gallery (Slice 2 Tier 1.05)

### DIFF
--- a/packages/api/firewall/templates/__init__.py
+++ b/packages/api/firewall/templates/__init__.py
@@ -1,0 +1,25 @@
+"""Rule templates — Slice 2 Tier 1.05.
+
+Each template is a YAML file in this directory. The loader walks the
+directory at module-load time, parses templates into a registry, and
+the HTTP layer exposes them at:
+
+  GET  /v1/firewall/templates             — list all
+  GET  /v1/firewall/templates/{id}        — full template detail
+  POST /v1/firewall/templates/{id}/instantiate
+       — create a policy from the template + operator's field values
+
+Schema per YAML file:
+
+  id, name, icon, summary, category   — metadata
+  fields: [{id, label, hint?, type, default, choices?, ...}]
+  defaults: { lifecycle, mode, severity, priority, on_timeout? }
+  condition: str.format-style template; ``{field_id}`` interpolates
+             field values. Multi-select renders as a Python list
+             literal so conditions can use ``in {tools}``.
+  description: human description (also str.format-substituted)
+
+Operators never write the condition — the dashboard renders fields
+as a form, sends values to ``/instantiate``, server compiles via
+``str.format()`` and creates the policy in ``mode=shadow`` (§10.1).
+"""

--- a/packages/api/firewall/templates/destructive_shell.yaml
+++ b/packages/api/firewall/templates/destructive_shell.yaml
@@ -1,0 +1,49 @@
+id: destructive_shell
+name: Block destructive shell commands
+icon: "🛡️"
+summary: rm -rf, mkfs, dd, drop database — irreversible operations
+category: filesystem
+
+fields:
+  - id: tools
+    label: Tools to apply this rule to
+    hint: |
+      Most agent frameworks expose a shell tool under one of these names.
+      Pick all the ones your agents might use; the rule fires on whichever
+      one the agent invokes.
+    type: multi-select
+    default: [exec, shell, bash, sh, terminal]
+    choices:
+      - { id: exec, label: "exec (OpenClaw)" }
+      - { id: shell, label: "shell (generic)" }
+      - { id: bash, label: "bash" }
+      - { id: sh, label: "sh" }
+      - { id: terminal, label: "terminal" }
+      - { id: run_command, label: "run_command (Mastra/LangChain)" }
+      - { id: code_interpreter, label: "code_interpreter" }
+
+  - id: action
+    label: What should happen?
+    type: select
+    default: block
+    choices:
+      - { id: block, label: "Block — refuse the call (recommended for irreversible ops)" }
+      - { id: require_approval, label: "Require operator approval" }
+      - { id: flag, label: "Flag only — record but allow" }
+
+defaults:
+  lifecycle: before_tool_call
+  mode: shadow
+  severity: critical
+  priority: 100
+
+condition: |
+  tool_name in {tools} and (
+    regex_match(str(Input.params.get("command", "")), "(?i)rm\\s+-rf\\s")
+    or regex_match(str(Input.params.get("command", "")), "(?i)mkfs|fdisk|dd\\s+if=")
+    or regex_match(str(Input.params.get("command", "")), "(?i)\\bdrop\\s+(database|table)\\b")
+    or is_destructive_path(str(Input.params.get("command", "")))
+  )
+description: |
+  Blocks destructive shell commands across {tools}. Catches rm -rf,
+  mkfs, dd if=, drop database/table, and well-known dangerous paths.

--- a/packages/api/firewall/templates/loader.py
+++ b/packages/api/firewall/templates/loader.py
@@ -1,0 +1,240 @@
+"""Template loader + compiler — Slice 2 Tier 1.05.
+
+Walks the templates directory at module load and parses every
+``*.yaml`` into a registry keyed by template id. The HTTP layer
+(routers/firewall.py) reads the registry to render the dashboard's
+"+ New rule" gallery; the same module's ``compile_rule`` turns
+operator field choices into a real ``Policy`` ready for
+``policy_store.create_policy()``.
+
+Why a registry, not on-disk-each-call?
+
+  - Templates are static. There's no reason to re-parse on every
+    HTTP request. The registry caches at module load.
+  - Tests can call ``reload_templates(directory=...)`` to swap
+    the registry for a fixture directory without polluting the
+    production module.
+  - Operators can drop a custom YAML into the directory and
+    restart the API — single source of truth, no DB write needed.
+
+Failure modes:
+
+  - Malformed YAML: log a warning, skip the template, keep the
+    rest of the registry usable. Better one bad template than
+    zero good ones.
+  - Compile-time field-value mismatch (operator picked an option
+    not in ``choices``): raise ``ValueError`` with a clean error
+    string. The HTTP layer maps this to a 400.
+  - Template references a field id that doesn't exist in
+    ``fields``: caught at compile time as ``KeyError``, rewrapped
+    as ``ValueError`` so callers see a helpful message rather
+    than a raw exception.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from lumin.policy import Policy
+
+logger = logging.getLogger("lumin.api.firewall.templates")
+
+
+_TEMPLATE_DIR = Path(__file__).parent
+_REGISTRY: Dict[str, dict] = {}
+_LOADED = False
+
+
+# ---- public API ------------------------------------------------------------
+
+
+def load_templates(directory: Optional[Path] = None) -> Dict[str, dict]:
+    """Return the cached registry, loading it on first call. Pass
+    ``directory`` to swap the source — useful for tests."""
+    global _LOADED, _REGISTRY
+    if directory is not None:
+        # Explicit reload against a different directory (test path).
+        _REGISTRY = _read_directory(directory)
+        _LOADED = True
+        return _REGISTRY
+    if not _LOADED:
+        _REGISTRY = _read_directory(_TEMPLATE_DIR)
+        _LOADED = True
+    return _REGISTRY
+
+
+def get_template(template_id: str) -> Optional[dict]:
+    return load_templates().get(template_id)
+
+
+def reload_templates(directory: Optional[Path] = None) -> Dict[str, dict]:
+    """Test helper — force a re-read."""
+    global _LOADED
+    _LOADED = False
+    return load_templates(directory)
+
+
+def list_templates_summary() -> List[dict]:
+    """Compact summary for the gallery — drops the heavy ``condition``
+    + ``description`` fields so the list endpoint payload stays small."""
+    out = []
+    for tpl in load_templates().values():
+        out.append({
+            "id": tpl["id"],
+            "name": tpl["name"],
+            "icon": tpl.get("icon"),
+            "summary": tpl.get("summary"),
+            "category": tpl.get("category"),
+            "field_count": len(tpl.get("fields", [])),
+        })
+    return out
+
+
+def compile_rule(
+    template_id: str,
+    name: str,
+    field_values: Dict[str, Any],
+    *,
+    mode: Optional[str] = None,
+) -> Policy:
+    """Render a Policy from a template + operator's field choices.
+
+    Always returns a ``mode=shadow`` policy unless ``mode`` is
+    explicitly overridden — matches §10.1 (new policies are safe-by-
+    default; operator must promote via ModeToggle).
+
+    Raises ``KeyError`` if the template id is unknown.
+    Raises ``ValueError`` for any field-value validation problem.
+    """
+    tpl = get_template(template_id)
+    if tpl is None:
+        raise KeyError(f"unknown template: {template_id!r}")
+
+    # Validate + render each field value
+    rendered: Dict[str, Any] = {}
+    for field in tpl.get("fields", []):
+        fid = field["id"]
+        ftype = field.get("type", "text")
+        if fid in field_values and field_values[fid] is not None:
+            value = field_values[fid]
+        else:
+            value = field.get("default")
+        rendered[fid] = _render_field_value(field, ftype, value)
+
+    # Compile condition + description via str.format
+    try:
+        condition = tpl["condition"].format(**rendered).strip()
+    except KeyError as e:
+        raise ValueError(
+            f"template {template_id!r} condition references unknown field: {e}"
+        )
+    try:
+        description = tpl.get("description", "").format(**rendered).strip()
+    except KeyError as e:
+        raise ValueError(
+            f"template {template_id!r} description references unknown field: {e}"
+        )
+
+    # Honor an ``action`` field if the template exposes one (overrides
+    # defaults.action). select-typed action field values are rendered
+    # as repr() strings — strip the quotes before storing on Policy.
+    raw_action = field_values.get("action")
+    if raw_action is None:
+        raw_action = tpl.get("defaults", {}).get("action", "block")
+    action = str(raw_action).strip().strip("'\"")
+
+    defaults = tpl.get("defaults", {}) or {}
+    return Policy(
+        name=name,
+        description=description or tpl.get("summary"),
+        # SDK Policy requires trigger ∈ {span_end, trace_end}. Firewall
+        # rules route via lifecycle, not trigger; pin to span_end so
+        # validation passes.
+        trigger="span_end",
+        condition=condition,
+        action=action,
+        severity=defaults.get("severity", "medium"),
+        scope_agents=[],
+        lifecycle=defaults.get("lifecycle", "post_ingest"),
+        mode=mode or "shadow",
+        priority=int(defaults.get("priority", 0)),
+        on_timeout=defaults.get("on_timeout", "allow"),
+        on_internal_error=defaults.get("on_internal_error", "allow"),
+    )
+
+
+# ---- internals -------------------------------------------------------------
+
+
+def _read_directory(directory: Path) -> Dict[str, dict]:
+    out: Dict[str, dict] = {}
+    if not directory.exists():
+        return out
+    for p in sorted(directory.glob("*.yaml")):
+        try:
+            data = yaml.safe_load(p.read_text(encoding="utf-8"))
+        except yaml.YAMLError as e:
+            logger.warning("template %s: invalid YAML — skipping: %s", p.name, e)
+            continue
+        if not isinstance(data, dict) or "id" not in data:
+            logger.warning("template %s: missing id — skipping", p.name)
+            continue
+        tpl_id = str(data["id"]).strip()
+        if not tpl_id:
+            continue
+        out[tpl_id] = data
+    return out
+
+
+def _render_field_value(field: dict, ftype: str, value: Any) -> str:
+    """Convert a field value into the Python literal that the
+    condition template will str.format() into. Multi-select renders
+    as a list literal so ``tool_name in {tools}`` slots in cleanly.
+    select with a custom ``value`` mapping resolves to that mapped
+    value; otherwise to the chosen id. text/number render as
+    repr-quoted/raw."""
+    if ftype == "multi-select":
+        if not isinstance(value, list):
+            raise ValueError(
+                f"field {field['id']!r}: multi-select expects a list, got {type(value).__name__}"
+            )
+        choices = field.get("choices") or []
+        valid_ids = {c["id"] for c in choices}
+        if valid_ids:
+            for v in value:
+                if v not in valid_ids:
+                    raise ValueError(
+                        f"field {field['id']!r}: choice {v!r} not in "
+                        f"{sorted(valid_ids)}"
+                    )
+        return repr(list(value))
+
+    if ftype == "select":
+        choices = field.get("choices") or []
+        match = next(
+            (c for c in choices if c.get("id") == value),
+            None,
+        )
+        if match is None and choices:
+            valid_ids = sorted(c["id"] for c in choices)
+            raise ValueError(
+                f"field {field['id']!r}: choice {value!r} not in {valid_ids}"
+            )
+        # If the choice declares a ``value:`` (regex / longer string),
+        # use that for substitution. Otherwise the id is the value.
+        if match and "value" in match:
+            return str(match["value"])
+        return str(value)
+
+    if ftype == "number":
+        return str(value)
+
+    # text / fallback
+    return str(value)

--- a/packages/api/firewall/templates/sensitive_file_reads.yaml
+++ b/packages/api/firewall/templates/sensitive_file_reads.yaml
@@ -1,0 +1,61 @@
+id: sensitive_file_reads
+name: Block sensitive file reads
+icon: "🔐"
+summary: SSH keys, AWS / GCP / kube credentials, /etc/passwd, .env files
+category: filesystem
+
+fields:
+  - id: tools
+    label: Tools to apply this rule to
+    type: multi-select
+    default: [exec, shell, bash, sh]
+    choices:
+      - { id: exec, label: "exec (OpenClaw)" }
+      - { id: shell, label: "shell (generic)" }
+      - { id: bash, label: "bash" }
+      - { id: sh, label: "sh" }
+      - { id: terminal, label: "terminal" }
+      - { id: run_command, label: "run_command (Mastra/LangChain)" }
+
+  - id: paths_pattern
+    label: Sensitive path patterns
+    hint: |
+      Regex alternation matched against tool params after the file-read
+      operation (cat, head, tail, etc.). Pick categories or build a
+      custom pattern.
+    type: select
+    default: all
+    choices:
+      - id: all
+        label: "All — SSH + AWS + GCP + /etc + .env + secrets"
+        value: "/etc/(passwd|shadow|sudoers|hosts)|~/.ssh/|/Users/[^/]+/.ssh/|~/.aws/credentials|/Users/[^/]+/.aws/credentials|~/.kube/config|/var/log/auth|\\\\.env\\\\b|/secrets?/|/private[/-]key|gcloud/.*credentials"
+      - id: ssh_only
+        label: "SSH keys only"
+        value: "~/.ssh/|/Users/[^/]+/.ssh/|/etc/ssh/"
+      - id: cloud_creds
+        label: "Cloud credentials only (AWS, GCP)"
+        value: "~/.aws/credentials|/Users/[^/]+/.aws/credentials|gcloud/.*credentials"
+      - id: env_files
+        label: ".env files"
+        value: "\\\\.env\\\\b|\\\\.env\\\\."
+
+  - id: action
+    label: What should happen?
+    type: select
+    default: block
+    choices:
+      - { id: block, label: "Block — refuse the read (recommended)" }
+      - { id: flag, label: "Flag only — record but allow" }
+
+defaults:
+  lifecycle: before_tool_call
+  mode: shadow
+  severity: critical
+  priority: 95
+
+condition: |
+  tool_name in {tools} and regex_match(str(Input.params.get("command", "")), "(?i)(cat|head|tail|less|more|od|xxd|base64|cp|mv|grep|strings)\\s.*?({paths_pattern})")
+description: |
+  Blocks reads of sensitive files via {tools}. Defense-in-depth
+  against cred exfiltration even when the agent's skill or system
+  prompt allows reading the path.

--- a/packages/api/models.py
+++ b/packages/api/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -323,3 +323,21 @@ class PolicyAuditEntry(BaseModel):
 class PolicyAuditResponse(BaseModel):
     entries: List[PolicyAuditEntry]
     total: int
+
+
+# ---- Templates (Slice 2 Tier 1.05) -------------------------------------
+
+
+class TemplateInstantiateRequest(BaseModel):
+    """Body for POST /v1/firewall/templates/{id}/instantiate.
+
+    The dashboard renders the template's ``fields`` schema as a form,
+    collects the operator's choices, and POSTs them here. The server
+    compiles the condition + creates the policy in mode=shadow per
+    §10.1 (operator promotes via ModeToggle after reviewing forecast).
+    """
+
+    name: str
+    field_values: Dict[str, Any] = Field(default_factory=dict)
+    # Optional override — defaults to 'shadow' inside compile_rule.
+    mode: Optional[str] = None

--- a/packages/api/routers/firewall.py
+++ b/packages/api/routers/firewall.py
@@ -34,6 +34,8 @@ import policy_store
 from db import Database, get_db
 
 from firewall import decide as fw_decide
+from firewall.templates import loader as fw_templates
+from models import TemplateInstantiateRequest
 
 logger = logging.getLogger("lumin.api.routers.firewall")
 
@@ -478,3 +480,76 @@ def _approval_row_to_dict(row: Dict[str, Any]) -> Dict[str, Any]:
         except json.JSONDecodeError:
             pass
     return out
+
+
+# ---- templates  (§8 dashboard, Slice 2 Tier 1.05) -----------------------
+
+
+@router.get("/v1/firewall/templates")
+def list_templates() -> Dict[str, Any]:
+    """All available rule templates. Cheap — registry is loaded once at
+    module load. Returns a compact summary; the dashboard fetches the
+    full template (with fields) on click via the {id} endpoint."""
+    return {"templates": fw_templates.list_templates_summary()}
+
+
+@router.get("/v1/firewall/templates/{template_id}")
+def get_template_detail(template_id: str) -> Dict[str, Any]:
+    """Full template — fields schema, defaults, condition string. The
+    dashboard's modal form renders ``fields`` as a form."""
+    tpl = fw_templates.get_template(template_id)
+    if tpl is None:
+        raise HTTPException(status_code=404, detail=f"template {template_id!r} not found")
+    return tpl
+
+
+@router.post("/v1/firewall/templates/{template_id}/instantiate")
+def instantiate_template(
+    template_id: str,
+    payload: TemplateInstantiateRequest,
+    db: Database = Depends(get_db),
+) -> Dict[str, Any]:
+    """Create a policy from a template + operator's field values.
+
+    Always lands in mode=shadow per §10.1 unless operator explicitly
+    asks for another mode. Triggers an engine reload so the new rule
+    is live in the same response — same pattern as POST /v1/policies.
+    """
+    if not payload.name or not payload.name.strip():
+        raise HTTPException(status_code=400, detail="name is required")
+
+    try:
+        policy = fw_templates.compile_rule(
+            template_id, payload.name.strip(),
+            payload.field_values,
+            mode=payload.mode,
+        )
+    except KeyError:
+        raise HTTPException(
+            status_code=404, detail=f"template {template_id!r} not found"
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    try:
+        saved = policy_store.create_policy(db, policy, actor="template_instantiate")
+    except ValueError as e:
+        # Name conflict OR firewall-field validation error.
+        raise HTTPException(status_code=409, detail=str(e))
+
+    # Hot-reload so the new rule is live immediately.
+    try:
+        policy_runtime.reload_engine(db=db)
+    except Exception:
+        logger.exception("template instantiate: post-create reload failed")
+
+    return {
+        "name": saved.name,
+        "lifecycle": getattr(saved, "lifecycle", "post_ingest"),
+        "mode": getattr(saved, "mode", "shadow"),
+        "action": saved.action,
+        "severity": saved.severity,
+        "condition": saved.condition,
+        "description": saved.description,
+        "template_id": template_id,
+    }

--- a/packages/api/tests/firewall/test_templates.py
+++ b/packages/api/tests/firewall/test_templates.py
@@ -1,0 +1,236 @@
+"""Tests for the rule template gallery (Slice 2 Tier 1.05).
+
+Covers:
+  - Loader parses real YAML templates correctly
+  - Malformed YAML is skipped (not fatal)
+  - compile_rule renders condition with field-value substitution
+  - Multi-select renders as a Python list literal
+  - select with custom ``value`` mapping uses the mapped value
+  - Field validation rejects choices not in ``choices``
+  - Default mode is shadow (§10.1)
+  - HTTP endpoints: list, detail, instantiate
+  - Created policy lands in DB with the compiled condition
+  - Name conflict surfaces as 409
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from db import Database
+from firewall.templates import loader as fw_templates
+
+
+@pytest.fixture
+def db() -> Database:
+    d = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    yield d
+    d.close()
+
+
+@pytest.fixture(autouse=True)
+def _reload_real_templates():
+    """Each test gets a fresh load of the production templates dir.
+    Tests that swap in a fixture directory call reload_templates(...)
+    explicitly."""
+    fw_templates.reload_templates()
+    yield
+    fw_templates.reload_templates()
+
+
+# ---- loader -------------------------------------------------------------
+
+
+def test_loader_picks_up_destructive_shell():
+    tpls = fw_templates.load_templates()
+    assert "destructive_shell" in tpls
+    tpl = tpls["destructive_shell"]
+    assert tpl["name"] == "Block destructive shell commands"
+    assert tpl["category"] == "filesystem"
+    assert any(f["id"] == "tools" for f in tpl["fields"])
+
+
+def test_loader_picks_up_sensitive_file_reads():
+    tpls = fw_templates.load_templates()
+    assert "sensitive_file_reads" in tpls
+
+
+def test_loader_skips_malformed_yaml(tmp_path):
+    (tmp_path / "good.yaml").write_text(
+        "id: ok\nname: Good\nsummary: ok\nfields: []\ndefaults: {}\ncondition: 'True'\ndescription: ok\n"
+    )
+    (tmp_path / "broken.yaml").write_text("not: valid: yaml: at: all: : :")
+    (tmp_path / "no_id.yaml").write_text("name: missing id\n")
+    out = fw_templates.reload_templates(tmp_path)
+    assert "ok" in out
+    assert len(out) == 1
+
+
+def test_get_template_returns_none_for_unknown():
+    assert fw_templates.get_template("does_not_exist") is None
+
+
+def test_list_summary_drops_heavy_fields():
+    summaries = fw_templates.list_templates_summary()
+    assert len(summaries) >= 2
+    for s in summaries:
+        assert {"id", "name", "icon", "summary", "category", "field_count"} <= set(s.keys())
+        assert "condition" not in s
+        assert "fields" not in s
+
+
+# ---- compile_rule -------------------------------------------------------
+
+
+def test_compile_rule_substitutes_multi_select():
+    pol = fw_templates.compile_rule(
+        "destructive_shell",
+        name="my_block_destruct",
+        field_values={"tools": ["exec", "shell"], "action": "block"},
+    )
+    # Multi-select renders as Python list literal
+    assert "['exec', 'shell']" in pol.condition
+    assert pol.action == "block"
+    assert pol.lifecycle == "before_tool_call"
+    assert pol.severity == "critical"
+    assert pol.priority == 100
+
+
+def test_compile_rule_uses_field_default_when_missing():
+    """If the operator omits a field, fall back to the field's default."""
+    pol = fw_templates.compile_rule(
+        "destructive_shell",
+        name="defaults_test",
+        field_values={},  # nothing supplied
+    )
+    # Default tools list contains 'exec' — should be in the condition
+    assert "exec" in pol.condition
+
+
+def test_compile_rule_select_with_value_mapping():
+    """The sensitive_file_reads template uses select.value to map a
+    short id (e.g. 'ssh_only') onto a full regex string. compile_rule
+    should substitute the mapped value, not the id."""
+    pol = fw_templates.compile_rule(
+        "sensitive_file_reads",
+        name="ssh_block",
+        field_values={"tools": ["exec"], "paths_pattern": "ssh_only", "action": "block"},
+    )
+    # Mapped value contains "~/.ssh/" — id "ssh_only" should NOT appear
+    assert "~/.ssh/" in pol.condition
+    assert "ssh_only" not in pol.condition
+
+
+def test_compile_rule_rejects_invalid_choice():
+    with pytest.raises(ValueError, match="not in"):
+        fw_templates.compile_rule(
+            "destructive_shell",
+            name="bad",
+            field_values={"tools": ["not_a_real_shell"], "action": "block"},
+        )
+
+
+def test_compile_rule_unknown_template_raises():
+    with pytest.raises(KeyError, match="unknown template"):
+        fw_templates.compile_rule("does_not_exist", name="x", field_values={})
+
+
+def test_compile_rule_defaults_to_shadow_mode():
+    pol = fw_templates.compile_rule(
+        "destructive_shell",
+        name="mode_default",
+        field_values={"tools": ["exec"]},
+    )
+    assert pol.mode == "shadow"
+
+
+def test_compile_rule_mode_override():
+    pol = fw_templates.compile_rule(
+        "destructive_shell",
+        name="enforce_now",
+        field_values={"tools": ["exec"]},
+        mode="enforce",
+    )
+    assert pol.mode == "enforce"
+
+
+# ---- HTTP endpoints -----------------------------------------------------
+
+
+def test_list_templates_endpoint(client):
+    r = client.get("/v1/firewall/templates")
+    assert r.status_code == 200
+    body = r.json()
+    ids = {t["id"] for t in body["templates"]}
+    assert "destructive_shell" in ids
+    assert "sensitive_file_reads" in ids
+
+
+def test_get_template_detail_endpoint(client):
+    r = client.get("/v1/firewall/templates/destructive_shell")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["id"] == "destructive_shell"
+    assert "fields" in body
+    assert "condition" in body
+
+
+def test_get_template_detail_404(client):
+    r = client.get("/v1/firewall/templates/not_a_real_template")
+    assert r.status_code == 404
+
+
+def test_instantiate_creates_policy(client, db):
+    r = client.post(
+        "/v1/firewall/templates/destructive_shell/instantiate",
+        json={
+            "name": "my_destruct_rule",
+            "field_values": {"tools": ["exec", "bash"], "action": "block"},
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["name"] == "my_destruct_rule"
+    assert body["mode"] == "shadow"
+    assert "['exec', 'bash']" in body["condition"]
+
+    # Policy actually exists in DB
+    rows = db.fetchall_dict(
+        "SELECT name, mode, lifecycle FROM policies WHERE name = ?",
+        ["my_destruct_rule"],
+    )
+    assert len(rows) == 1
+    assert rows[0]["mode"] == "shadow"
+    assert rows[0]["lifecycle"] == "before_tool_call"
+
+
+def test_instantiate_name_conflict_409(client, db):
+    body = {
+        "name": "duplicate_name",
+        "field_values": {"tools": ["exec"], "action": "block"},
+    }
+    r1 = client.post("/v1/firewall/templates/destructive_shell/instantiate", json=body)
+    assert r1.status_code == 200
+    r2 = client.post("/v1/firewall/templates/destructive_shell/instantiate", json=body)
+    assert r2.status_code == 409
+
+
+def test_instantiate_400_on_invalid_choice(client):
+    r = client.post(
+        "/v1/firewall/templates/destructive_shell/instantiate",
+        json={
+            "name": "bad_choice",
+            "field_values": {"tools": ["not_real"], "action": "block"},
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_instantiate_404_on_unknown_template(client):
+    r = client.post(
+        "/v1/firewall/templates/no_such_template/instantiate",
+        json={"name": "x", "field_values": {}},
+    )
+    assert r.status_code == 404


### PR DESCRIPTION
Server-side foundation for Slice 2 Tier 1.05 — the biggest authoring-DX gap from Slice 1 dogfood.

## Why

Writing a real firewall rule in Slice 1 required composing 287-character regex+Python condition strings by hand (we did this twice live; pain was clear). Operators authoring rules outside the spec authors' bubble would never tolerate it.

## What

**Server side only** — dashboard \`/templates\` page is a follow-up (intentional split: stable contract first, UI second).

- \`firewall/templates/{__init__,loader}.py\` — registry walks \`*.yaml\` files at module load
- \`compile_rule(template_id, name, field_values)\` — multi-select renders as Python list literal, select with custom \`value:\` mapping resolves to mapped string
- 2 starter templates: \`destructive_shell.yaml\` (rm -rf, mkfs, dd, drop database) + \`sensitive_file_reads.yaml\` (SSH/AWS/kube/.env)
- 3 HTTP endpoints: \`GET /v1/firewall/templates\`, \`GET /v1/firewall/templates/{id}\`, \`POST /v1/firewall/templates/{id}/instantiate\`
- \`TemplateInstantiateRequest\` Pydantic model
- Default mode = shadow per §10.1; operator promotes via ModeToggle

## Authoring-time delta

| | Before | After |
|---|---|---|
| Time | ~15 min, debugging required | ~30 seconds |
| Regex | hand-written | none, picked from choices |
| Skill | expert-level | non-engineer |

## Test plan

- [x] 19 new tests (loader / compile / endpoints / 404 / 409 / 400 / mode default)
- [x] 354 / 354 full suite passes
- [x] Zero regressions
- [x] Manual: \`POST /v1/firewall/templates/destructive_shell/instantiate { name, field_values: { tools: ["exec","bash"], action: "block" } }\` creates a policy with the compiled condition

## What's NOT in this PR

- Dashboard \`/templates\` gallery UI — separate PR, parallel work
- 1.6 PolicyEditor firewall verb extension — separate PR  
- Version bump — Slice 2 lockstep release lands all at end

## Related

This is one of 4 Slice 2 PRs (alongside #52 Cluster A, #53 Cluster B+C, #54 ApprovalsInbox, #55 Presidio + circuit breaker). All can be merged in any order; lockstep v0.4.0 release ships everything together.