### PR TITLE
chore: lockstep-bump all packages + embedded versions to 0.4.0

### DIFF
--- a/packages/api/main.py
+++ b/packages/api/main.py
@@ -222,7 +222,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     title="Lumin API",
     description="Local-first AI agent observability — ingest and query API",
-    version="0.3.0",
+    version="0.4.0",
     lifespan=lifespan,
 )
 

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -36,7 +36,7 @@ export const metadata: Metadata = {
   ],
 };
 
-const VERSION = '0.3.0';
+const VERSION = '0.4.0';
 
 export default function RootLayout({
   children,

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumin-dashboard",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/integrations/mastra/package.json
+++ b/packages/integrations/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/mastra",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Lumin exporter for Mastra agents \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/integrations/openclaw-diagnostics/package.json
+++ b/packages/integrations/openclaw-diagnostics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/openclaw-diagnostics",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Lumin observability + Agent Firewall for OpenClaw \u2014 captures prompts, responses, tool I/O, and synchronously enforces firewall policies on every tool call.",
   "homepage": "https://github.com/amitbidlan/zistica-lumin/tree/main/packages/integrations/openclaw-diagnostics",
   "repository": {

--- a/packages/integrations/openclaw/package.json
+++ b/packages/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/openclaw",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Lumin exporter for OpenClaw agents \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/integrations/voltagent/package.json
+++ b/packages/integrations/voltagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/voltagent",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Lumin exporter for VoltAgent \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lumin"
-version = "0.3.0"
+version = "0.4.0"
 description = "Local-first AI agent observability SDK"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Local-first AI agent observability SDK (TypeScript)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Slice 2 lockstep release per the lockstep memory: every release bumps all packages + embedded VERSION constants to the same number.

## Slice 2 changes shipping with v0.4.0

| PR | What |
|---|---|
| #52 | Authoring DX — list membership, cross-framework tool builtins, PolicyOut firewall fields, OWASP audit |
| #53 | LLM feedback + admin separation — agent_feedback, session deny cache, adminSenders, before_message_write suppression |
| #54 | ApprovalsInbox dashboard — admin surface for pending approvals |
| #55 | Presidio (optional dep) + auto circuit breaker |
| #56 | Rule template gallery (server-side) |

## Bumped (9 locations)

- \`packages/api/main.py\` — \`FastAPI(version=)\`
- \`packages/sdk-python/pyproject.toml\`
- \`packages/sdk-typescript/package.json\`
- \`packages/dashboard/package.json\`
- \`packages/dashboard/app/layout.tsx\` — VERSION footer pill
- \`packages/integrations/openclaw-diagnostics/package.json\`
- \`packages/integrations/openclaw/package.json\`
- \`packages/integrations/mastra/package.json\`
- \`packages/integrations/voltagent/package.json\`

## Test plan

- [x] 387/387 tests pass — pure version bump, no functional change

## After merge — publish steps

1. **Republish @lumin-io/openclaw-diagnostics 0.4.0 to npm + ClawHub** — the admin separation work in #53 is the user-visible plugin change (new \`adminSenders\`, \`userBlockedMessage\`, \`adminSeesFullResponse\` config keys + \`before_message_write\` hook). Operators with v0.3.0 installed will not get the LLM-suppression security fix until they upgrade.
2. **Tag \`v0.4.0\`** and push — Docker Hub workflow fires, \`zistica/lumin:0.4.0\` + \`:latest\` published.
3. **Other 5 packages: skip publish** — no functional change this slice; they'll go out at 0.5.0 when something user-visible touches them.