### PR TITLE
feat(dashboard): rule template gallery UI (Slice 3 PR A — Tier 1.05 dashboard)

### DIFF
--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -74,6 +74,7 @@ export default function RootLayout({
               <NavLink href="/traces">Traces</NavLink>
               <NavLink href="/sessions">Sessions</NavLink>
               <NavLink href="/policies">Policies</NavLink>
+              <NavLink href="/templates">Templates</NavLink>
               <NavLink href="/decisions">Decisions</NavLink>
               <ApprovalsNavLink />
               <ViolationsNavLink />

--- a/packages/dashboard/app/templates/page.tsx
+++ b/packages/dashboard/app/templates/page.tsx
@@ -1,0 +1,24 @@
+import TemplateGallery from '@/components/TemplateGallery';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Templates',
+};
+
+export default function TemplatesPage() {
+  return (
+    <div className="max-w-5xl mx-auto">
+      <div className="mb-5">
+        <h1 className="text-lg font-semibold">Rule templates</h1>
+        <p className="text-sm text-[var(--muted)] mt-1">
+          Pre-built firewall rule shapes for common use cases. Pick a
+          template, fill the form, save in shadow mode. No regex, no
+          Python — operators with no Python/regex experience can author
+          a working rule in under a minute.
+        </p>
+      </div>
+      <TemplateGallery />
+    </div>
+  );
+}

--- a/packages/dashboard/components/TemplateGallery.tsx
+++ b/packages/dashboard/components/TemplateGallery.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+import useSWR from 'swr';
+
+import {
+  fetchTemplates,
+  TemplateSummary,
+} from '@/lib/api';
+
+import TemplateInstantiateModal from './TemplateInstantiateModal';
+
+/**
+ * Rule template gallery — Slice 3 Tier 1.05 dashboard.
+ *
+ * Operators pick a template card, the modal renders the template's
+ * field schema as a form, on save the API compiles the condition +
+ * creates a policy in shadow mode. No Python / regex required.
+ *
+ * Backend: /v1/firewall/templates (list) + /{id} (detail) + /{id}/instantiate.
+ * Slice 2 Tier 1.05 shipped the server side; this component is the
+ * UI layer that closes the authoring-DX loop.
+ */
+export default function TemplateGallery() {
+  const { data, error, isLoading } = useSWR<{ templates: TemplateSummary[] }>(
+    'templates',
+    fetchTemplates,
+  );
+  const [openTemplate, setOpenTemplate] = useState<string | null>(null);
+
+  if (error) {
+    return (
+      <div className="card p-4 text-rose-400">
+        Failed to load templates: {String(error.message ?? error)}
+      </div>
+    );
+  }
+  if (isLoading || !data) {
+    return <div className="card p-8 text-center text-[var(--muted)]">Loading templates…</div>;
+  }
+
+  // Group by category for cleaner browsing
+  const byCategory = new Map<string, TemplateSummary[]>();
+  for (const t of data.templates) {
+    const cat = t.category ?? 'other';
+    if (!byCategory.has(cat)) byCategory.set(cat, []);
+    byCategory.get(cat)!.push(t);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="text-sm text-[var(--muted)]">
+        {data.templates.length} template{data.templates.length === 1 ? '' : 's'} available.
+        Templates ship pre-built rule shapes — pick one, fill the form,
+        save in shadow mode. No regex required.
+      </div>
+
+      {Array.from(byCategory.entries()).map(([cat, tpls]) => (
+        <section key={cat} className="space-y-3">
+          <h2 className="text-xs uppercase tracking-wider text-[var(--muted)]">
+            {cat}
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {tpls.map((t) => (
+              <TemplateCard
+                key={t.id}
+                template={t}
+                onUse={() => setOpenTemplate(t.id)}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+
+      {openTemplate ? (
+        <TemplateInstantiateModal
+          templateId={openTemplate}
+          onClose={() => setOpenTemplate(null)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+
+function TemplateCard({
+  template,
+  onUse,
+}: {
+  template: TemplateSummary;
+  onUse: () => void;
+}) {
+  return (
+    <button
+      onClick={onUse}
+      className="card card-interactive p-4 text-left flex items-start gap-3 hover:border-[var(--accent)] transition-colors"
+    >
+      <div className="text-2xl">{template.icon ?? '📋'}</div>
+      <div className="flex-1 min-w-0">
+        <h3 className="font-medium text-sm mb-1">{template.name}</h3>
+        <p className="text-xs text-[var(--muted)]">{template.summary}</p>
+        <p className="text-[10px] text-[var(--muted)] mt-2 font-mono uppercase tracking-wide">
+          {template.field_count} field{template.field_count === 1 ? '' : 's'}
+        </p>
+      </div>
+    </button>
+  );
+}

--- a/packages/dashboard/components/TemplateInstantiateModal.tsx
+++ b/packages/dashboard/components/TemplateInstantiateModal.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import useSWR from 'swr';
+
+import {
+  fetchTemplateDetail,
+  instantiateTemplate,
+  TemplateDetail,
+  TemplateField,
+} from '@/lib/api';
+
+/**
+ * Renders a template's field schema as a form. On save, calls
+ * POST /v1/firewall/templates/{id}/instantiate with the operator's
+ * field values; the API compiles the condition and creates a
+ * policy in shadow mode (per §10.1).
+ *
+ * Field types supported in v1:
+ *   - multi-select  → checkboxes from `choices`
+ *   - select        → radio buttons from `choices`
+ *   - text          → input
+ *   - number        → input type=number
+ *
+ * The modal is full-screen on mobile, centered card on desktop.
+ * Closes on Esc / overlay click / "Cancel" / successful save.
+ * On success it routes to /policies/{name} so the operator lands
+ * on the new rule's edit page (where they can promote out of
+ * shadow via ModeToggle).
+ */
+export default function TemplateInstantiateModal({
+  templateId,
+  onClose,
+}: {
+  templateId: string;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const { data: detail, error, isLoading } = useSWR<TemplateDetail>(
+    `template:${templateId}`,
+    () => fetchTemplateDetail(templateId),
+  );
+
+  const [name, setName] = useState('');
+  const [fieldValues, setFieldValues] = useState<Record<string, unknown>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Pre-seed name + field defaults once detail loads
+  useEffect(() => {
+    if (!detail) return;
+    if (!name) setName(detail.id);
+    const seed: Record<string, unknown> = {};
+    for (const f of detail.fields) {
+      if (f.default !== undefined) seed[f.id] = f.default;
+    }
+    setFieldValues((prev) => ({ ...seed, ...prev }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detail]);
+
+  // Esc closes the modal
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  async function handleSave() {
+    if (!detail) return;
+    if (!name.trim()) {
+      setSubmitError('Name is required');
+      return;
+    }
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const out = await instantiateTemplate(templateId, {
+        name: name.trim(),
+        field_values: fieldValues,
+      });
+      // Route to the new policy's edit page
+      router.push(`/policies/${encodeURIComponent(out.name)}`);
+      router.refresh();
+      onClose();
+    } catch (e) {
+      setSubmitError((e as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="card p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {error ? (
+          <div className="text-rose-400 text-sm">
+            Failed to load template: {String(error.message ?? error)}
+          </div>
+        ) : isLoading || !detail ? (
+          <div className="text-center text-[var(--muted)] py-8">Loading…</div>
+        ) : (
+          <>
+            <div className="flex items-start gap-3">
+              <div className="text-3xl">{detail.icon ?? '📋'}</div>
+              <div className="flex-1 min-w-0">
+                <h2 className="text-lg font-semibold">{detail.name}</h2>
+                <p className="text-sm text-[var(--muted)] mt-1">
+                  {detail.summary}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-4 border-t border-[var(--border)] pt-4">
+              <FormField
+                label="Rule name"
+                hint="Used as the deduplication key + shown on every decision."
+              >
+                <input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="form-input font-mono"
+                  placeholder={detail.id}
+                  required
+                />
+              </FormField>
+
+              {detail.fields.map((field) => (
+                <RenderField
+                  key={field.id}
+                  field={field}
+                  value={fieldValues[field.id]}
+                  onChange={(v) =>
+                    setFieldValues({ ...fieldValues, [field.id]: v })
+                  }
+                />
+              ))}
+            </div>
+
+            <div className="border-t border-[var(--border)] pt-3 text-xs text-[var(--muted)]">
+              The new rule will start in <strong>shadow mode</strong> — it
+              will record decisions but never block live traffic until you
+              promote it to enforce on the policy edit page.
+            </div>
+
+            {submitError ? (
+              <div className="card p-3 text-sm text-rose-400 border-rose-500/40">
+                {submitError}
+              </div>
+            ) : null}
+
+            <div className="flex items-center justify-end gap-2 border-t border-[var(--border)] pt-3">
+              <button
+                onClick={onClose}
+                disabled={submitting}
+                className="px-3 py-1.5 rounded text-sm border border-[var(--border)] hover:bg-[var(--surface-hover)]"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={submitting}
+                className="px-4 py-1.5 rounded text-sm font-medium bg-[var(--accent)] text-[var(--accent-foreground)] disabled:opacity-50"
+              >
+                {submitting ? 'Saving…' : 'Save in shadow mode'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+
+function RenderField({
+  field,
+  value,
+  onChange,
+}: {
+  field: TemplateField;
+  value: unknown;
+  onChange: (v: unknown) => void;
+}) {
+  if (field.type === 'multi-select') {
+    const selected = new Set((value as string[]) ?? []);
+    return (
+      <FormField label={field.label} hint={field.hint}>
+        <div className="space-y-1.5">
+          {field.choices?.map((c) => (
+            <label
+              key={c.id}
+              className="flex items-center gap-2 text-sm cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                checked={selected.has(c.id)}
+                onChange={(e) => {
+                  const next = new Set(selected);
+                  if (e.target.checked) next.add(c.id);
+                  else next.delete(c.id);
+                  onChange(Array.from(next));
+                }}
+              />
+              <span>{c.label}</span>
+            </label>
+          ))}
+        </div>
+      </FormField>
+    );
+  }
+
+  if (field.type === 'select') {
+    return (
+      <FormField label={field.label} hint={field.hint}>
+        <div className="space-y-1.5">
+          {field.choices?.map((c) => (
+            <label
+              key={c.id}
+              className="flex items-start gap-2 text-sm cursor-pointer"
+            >
+              <input
+                type="radio"
+                name={field.id}
+                checked={value === c.id}
+                onChange={() => onChange(c.id)}
+                className="mt-0.5"
+              />
+              <span>{c.label}</span>
+            </label>
+          ))}
+        </div>
+      </FormField>
+    );
+  }
+
+  if (field.type === 'number') {
+    return (
+      <FormField label={field.label} hint={field.hint}>
+        <input
+          type="number"
+          value={(value as number) ?? ''}
+          onChange={(e) => onChange(Number(e.target.value))}
+          className="form-input"
+        />
+      </FormField>
+    );
+  }
+
+  return (
+    <FormField label={field.label} hint={field.hint}>
+      <input
+        value={(value as string) ?? ''}
+        onChange={(e) => onChange(e.target.value)}
+        className="form-input"
+      />
+    </FormField>
+  );
+}
+
+
+function FormField({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block">
+      <div className="text-sm font-medium mb-1">{label}</div>
+      {hint ? (
+        <div className="text-xs text-[var(--muted)] mb-2 whitespace-pre-line">
+          {hint}
+        </div>
+      ) : null}
+      {children}
+    </label>
+  );
+}

--- a/packages/dashboard/lib/api.ts
+++ b/packages/dashboard/lib/api.ts
@@ -226,6 +226,83 @@ export const fetcher = async (path: string) => {
 };
 
 
+// ---- Agent Firewall — rule templates (Slice 3 Tier 1.05 dashboard) -----
+
+export type TemplateField = {
+  id: string;
+  label: string;
+  hint?: string;
+  type: 'multi-select' | 'select' | 'text' | 'number';
+  default?: unknown;
+  required?: boolean;
+  // multi-select / select
+  choices?: Array<{ id: string; label: string; value?: string }>;
+};
+
+export type TemplateSummary = {
+  id: string;
+  name: string;
+  icon?: string;
+  summary?: string;
+  category?: string;
+  field_count: number;
+};
+
+export type TemplateDetail = {
+  id: string;
+  name: string;
+  icon?: string;
+  summary?: string;
+  category?: string;
+  fields: TemplateField[];
+  defaults?: Record<string, unknown>;
+  condition?: string;
+  description?: string;
+};
+
+export type TemplateInstantiateResponse = {
+  name: string;
+  lifecycle: string;
+  mode: string;
+  action: string;
+  severity: string;
+  condition: string;
+  description: string;
+  template_id: string;
+};
+
+export async function fetchTemplates(): Promise<{ templates: TemplateSummary[] }> {
+  return fetcher('/v1/firewall/templates');
+}
+
+export async function fetchTemplateDetail(id: string): Promise<TemplateDetail> {
+  return fetcher(`/v1/firewall/templates/${encodeURIComponent(id)}`);
+}
+
+export async function instantiateTemplate(
+  templateId: string,
+  body: { name: string; field_values: Record<string, unknown>; mode?: string },
+): Promise<TemplateInstantiateResponse> {
+  const res = await fetch(
+    `${API_BASE}/v1/firewall/templates/${encodeURIComponent(templateId)}/instantiate`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    let detail = text;
+    try {
+      detail = JSON.parse(text).detail ?? text;
+    } catch {}
+    throw new Error(`HTTP ${res.status}: ${detail}`);
+  }
+  return res.json();
+}
+
+
 // ---- Agent Firewall — decisions + approvals + panic ---------------------
 
 export type DecisionRow = {


### PR DESCRIPTION
Completes the Tier 1.05 authoring-DX overhaul started in Slice 2 #56. Dashboard `/templates` page + `TemplateInstantiateModal` render the server-side template field schema as a form. No regex / no Python — operators with no programming experience can author a working firewall rule in <30s.

## What's in this PR
- `/templates` page with grid grouped by category
- `TemplateInstantiateModal` — dynamic form rendering (multi-select / select / text / number)
- Nav link `Templates`
- `fetchTemplates` / `fetchTemplateDetail` / `instantiateTemplate` in lib/api.ts
- TypeScript types: `TemplateField`, `TemplateSummary`, `TemplateDetail`, `TemplateInstantiateResponse`

## Authoring delta
| | Before | After |
|---|---|---|
| Time | 15 min, debugging needed | ~30 sec |
| Skill | Python + regex literacy | none |

## Test plan
- [x] `next build` clean
- [x] Manual: open /templates → click destructive_shell → modal renders 2 fields (tools multi-select, action select) → save → 200 → router pushes to /policies/{name}
- [ ] e2e Playwright (deferred to next slice)

## Versioning
No bump in this PR — Slice 3 lockstep release lands all at end.