### PR TITLE
feat(firewall): decision actions + POST /v1/labels endpoint (Slice 3 PR C)

### DIFF
--- a/packages/api/routers/firewall.py
+++ b/packages/api/routers/firewall.py
@@ -593,3 +593,58 @@ def instantiate_template(
         "description": saved.description,
         "template_id": template_id,
     }
+
+
+# ---- labels  (§5.8 — Slice 3 PR C foundation) ---------------------------
+
+
+class LabelRequest(BaseModel):
+    """Body for POST /v1/labels — operator marks a trace/span as bad/good
+    for downstream classifier training and false-positive review."""
+    trace_id: Optional[str] = None
+    span_id: Optional[str] = None
+    decision_id: Optional[str] = None
+    field: str = Field(..., description="One of: input, output, tool_params, tool_result")
+    label: str = Field(..., description="One of: bad, good, neutral")
+    category: Optional[str] = None
+    notes: Optional[str] = None
+    labeled_by: Optional[str] = "dashboard"
+
+
+@router.post("/v1/labels")
+def post_label(payload: LabelRequest, db: Database = Depends(get_db)) -> Dict[str, Any]:
+    """Insert a label row. Used by the dashboard's 'Mark as false
+    positive' button on /decisions/{id}, and as the substrate for
+    the local classifier trainer (Slice 4)."""
+    if payload.label not in ("bad", "good", "neutral"):
+        raise HTTPException(status_code=400, detail="label must be bad/good/neutral")
+    if payload.field not in ("input", "output", "tool_params", "tool_result"):
+        raise HTTPException(
+            status_code=400,
+            detail="field must be one of: input, output, tool_params, tool_result",
+        )
+    import uuid as _uuid
+    label_id = "lbl_" + _uuid.uuid4().hex[:24]
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    try:
+        db.execute(
+            """
+            INSERT INTO labels (
+                id, trace_id, span_id, field, label, category, notes,
+                labeled_by, labeled_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                label_id, payload.trace_id, payload.span_id,
+                payload.field, payload.label, payload.category,
+                payload.notes, payload.labeled_by or "dashboard", now,
+            ],
+        )
+    except Exception:
+        logger.exception("firewall: failed to insert label row")
+        raise HTTPException(status_code=500, detail="label insert failed")
+    return {
+        "id": label_id,
+        "label": payload.label,
+        "labeled_at": now.isoformat(),
+    }

--- a/packages/api/tests/firewall/test_labels.py
+++ b/packages/api/tests/firewall/test_labels.py
@@ -1,0 +1,55 @@
+"""Tests for POST /v1/labels (Slice 3 PR C — labels endpoint)."""
+
+from __future__ import annotations
+
+
+def test_post_label_inserts_row(client, db):
+    r = client.post(
+        "/v1/labels",
+        json={
+            "trace_id": "trace-x",
+            "span_id": "span-y",
+            "field": "tool_params",
+            "label": "good",
+            "category": "false_positive",
+            "notes": "rule fired but the action was actually fine",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["label"] == "good"
+    assert body["id"].startswith("lbl_")
+
+    # Row in DB
+    rows = db.fetchall_dict("SELECT * FROM labels WHERE id = ?", [body["id"]])
+    assert len(rows) == 1
+    assert rows[0]["label"] == "good"
+    assert rows[0]["category"] == "false_positive"
+    assert rows[0]["labeled_by"] == "dashboard"
+
+
+def test_post_label_rejects_bad_label(client):
+    r = client.post(
+        "/v1/labels",
+        json={"trace_id": "t", "field": "input", "label": "purple"},
+    )
+    assert r.status_code == 400
+
+
+def test_post_label_rejects_bad_field(client):
+    r = client.post(
+        "/v1/labels",
+        json={"trace_id": "t", "field": "garbage_field", "label": "bad"},
+    )
+    assert r.status_code == 400
+
+
+def test_post_label_with_minimal_body(client, db):
+    """All fields except label and field are optional."""
+    r = client.post(
+        "/v1/labels",
+        json={"field": "input", "label": "bad"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["label"] == "bad"

--- a/packages/dashboard/components/DecisionDetailPanel.tsx
+++ b/packages/dashboard/components/DecisionDetailPanel.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import Link from 'next/link';
+import { useState } from 'react';
 import useSWR from 'swr';
 
 import {
   DecisionDetailResponse,
+  DecisionRow,
   fetchDecisionDetail,
+  postLabel,
 } from '@/lib/api';
 
 import { DecisionBadge } from './EnforcementTimeline';
@@ -79,6 +82,12 @@ export default function DecisionDetailPanel({ decisionId }: { decisionId: string
             </pre>
           </div>
         )}
+
+        {/* Slice 3 PR C — operator actions on the decision. False
+            positive marking feeds the local-classifier trainer
+            (Slice 4); "Use a template" is the recommended path for
+            authoring a new rule from observed bad behavior. */}
+        <DecisionActions decision={d} />
       </div>
 
       {data.policy && (
@@ -178,5 +187,72 @@ function TraceLink({ id }: { id: string }) {
     >
       {id.slice(0, 8)}…{id.slice(-4)}
     </Link>
+  );
+}
+
+
+function DecisionActions({ decision }: { decision: DecisionRow }) {
+  const [labeling, setLabeling] = useState(false);
+  const [labeled, setLabeled] = useState(false);
+  const [labelError, setLabelError] = useState<string | null>(null);
+
+  async function markFalsePositive() {
+    if (!decision.trace_id) {
+      setLabelError('No trace_id on this decision — cannot label');
+      return;
+    }
+    setLabeling(true);
+    setLabelError(null);
+    try {
+      await postLabel({
+        trace_id: decision.trace_id,
+        span_id: decision.span_id ?? undefined,
+        decision_id: decision.id,
+        field:
+          decision.lifecycle === 'before_tool_call' ||
+          decision.lifecycle === 'after_tool_call'
+            ? 'tool_params'
+            : 'output',
+        label: 'good',
+        category: 'false_positive',
+        notes: `Marked false-positive for policy ${decision.policy_name} from /decisions/${decision.id}`,
+      });
+      setLabeled(true);
+    } catch (e) {
+      setLabelError((e as Error).message);
+    } finally {
+      setLabeling(false);
+    }
+  }
+
+  return (
+    <div className="border-t border-[var(--border)] pt-4 flex items-center gap-2 flex-wrap">
+      <Link
+        href="/templates"
+        className="px-3 py-1.5 rounded text-xs border border-[var(--border)] hover:bg-[var(--surface-hover)] transition-colors"
+        title="Author a new rule from a pre-built template"
+      >
+        + New rule from template
+      </Link>
+
+      {labeled ? (
+        <span className="text-xs text-emerald-400 px-3 py-1.5">
+          ✓ Marked as false positive
+        </span>
+      ) : (
+        <button
+          onClick={markFalsePositive}
+          disabled={labeling}
+          className="px-3 py-1.5 rounded text-xs border border-[var(--border)] hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-50"
+          title="Records a 'good' label so this trace doesn't trip the rule next time the local classifier retrains"
+        >
+          {labeling ? 'Marking…' : 'Mark as false positive'}
+        </button>
+      )}
+
+      {labelError ? (
+        <span className="text-xs text-rose-400">{labelError}</span>
+      ) : null}
+    </div>
   );
 }

--- a/packages/dashboard/lib/api.ts
+++ b/packages/dashboard/lib/api.ts
@@ -226,6 +226,36 @@ export const fetcher = async (path: string) => {
 };
 
 
+// ---- Agent Firewall — labels (Slice 3 PR C) -----------------------------
+
+export type LabelRequest = {
+  trace_id?: string;
+  span_id?: string;
+  decision_id?: string;
+  field: 'input' | 'output' | 'tool_params' | 'tool_result';
+  label: 'bad' | 'good' | 'neutral';
+  category?: string;
+  notes?: string;
+};
+
+export async function postLabel(body: LabelRequest): Promise<{
+  id: string;
+  label: string;
+  labeled_at: string;
+}> {
+  const res = await fetch(`${API_BASE}/v1/labels`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`HTTP ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+
 // ---- Agent Firewall — decisions + approvals + panic ---------------------
 
 export type DecisionRow = {


### PR DESCRIPTION
Closes Tier 3.3 (decision detail enhancements) + Tier 3.5 (label widget) from the Slice 2 plan in one PR. Operators can now (a) navigate from a fired decision to authoring a new rule via the template gallery, and (b) mark the decision as a false positive — feeding the labels table that sits empty since Slice 1 schema migrations.

## What's in this PR
- **Server**: POST /v1/labels (§5.8) with LabelRequest Pydantic model. Inserts into the existing labels table.
- **Dashboard**: DecisionDetailPanel grows a DecisionActions toolbar with two buttons:
  - `+ New rule from template` → /templates
  - `Mark as false positive` → POST /v1/labels with category=false_positive
- **Client**: postLabel fetcher + LabelRequest type in lib/api.ts

## Tests
- 4 new in tests/firewall/test_labels.py
- 391/391 suite green
- Dashboard build clean

## Versioning
No bump — Slice 3 lockstep release lands all at end.