### PR TITLE
feat(firewall): pattern suggester + Block-this-pattern UX (Slice 3 PR D — §5.5 / §11)

### DIFF
--- a/packages/api/firewall/suggester.py
+++ b/packages/api/firewall/suggester.py
@@ -1,0 +1,342 @@
+"""Pattern suggester — Slice 3 PR D / spec §5.5 / §11.
+
+Operator clicks "Block this pattern" on a fired decision in the
+dashboard; this module extracts a regex from the matched value,
+drafts a Policy YAML around it, runs a 30-day back-test against
+the decisions table, and returns everything the dashboard needs to
+let the operator review before saving.
+
+The "compounding loop" the spec keeps talking about: every observed
+violation can be promoted into a rule with one click. No regex
+authoring, no Python — just review the draft, check the forecast,
+save in shadow.
+
+Design notes:
+
+  - Pattern extraction is deliberately conservative. We escape the
+    matched value as a literal regex rather than trying to
+    generalize. Operators who want broader patterns edit the rule
+    after promotion.
+
+  - The back-test counts decisions where the same policy_name fired
+    in the last 30 days, NOT a re-evaluation of the new condition
+    against historical traces. The latter would require running
+    the new rule across thousands of stored spans and is deferred
+    to Slice 4 (where we have the trace replay infrastructure).
+
+  - Suggestions are persisted in the ``pattern_suggestions`` table
+    so the dashboard can list pending suggestions, an operator can
+    revisit a draft they didn't immediately promote, and the
+    frequent-pattern miner (PR E) can reuse the same storage.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from lumin.policy import Policy
+
+import policy_store
+from db import Database
+
+logger = logging.getLogger("lumin.api.firewall.suggester")
+
+
+# ---- public API ------------------------------------------------------------
+
+
+def suggest_from_decision(db: Database, decision_id: str) -> Dict[str, Any]:
+    """Build a draft Policy from a fired decision + persist it.
+
+    Returns the suggestion dict (id, draft_yaml, rationale, forecast).
+    Raises ``KeyError`` when decision_id doesn't exist.
+    """
+    decision = db.fetchone_dict(
+        "SELECT * FROM decisions WHERE id = ?", [decision_id]
+    )
+    if decision is None:
+        raise KeyError(f"decision not found: {decision_id}")
+
+    draft = _draft_policy_from_decision(decision)
+    rationale = _rationale(decision, draft)
+    forecast = _forecast(db, decision)
+
+    suggestion_id = "sug_" + uuid.uuid4().hex[:24]
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    try:
+        db.execute(
+            """
+            INSERT INTO pattern_suggestions (
+                id, source_violation_id, template, draft_yaml, suggested_at,
+                forecast_fp_count, forecast_fp_examples
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                suggestion_id, decision_id, "from_decision",
+                _policy_to_yaml(draft), now,
+                int(forecast["count"]),
+                json.dumps(forecast["examples"]),
+            ],
+        )
+    except Exception:
+        # Persistence is best-effort — caller still gets the draft
+        # even if we couldn't save the row (e.g. table missing on
+        # an old install).
+        logger.exception("suggester: failed to persist suggestion")
+
+    return {
+        "id": suggestion_id,
+        "decision_id": decision_id,
+        "template": "from_decision",
+        "draft": _policy_to_dict(draft),
+        "draft_yaml": _policy_to_yaml(draft),
+        "rationale": rationale,
+        "forecast": forecast,
+    }
+
+
+def get_suggestion(db: Database, suggestion_id: str) -> Optional[Dict[str, Any]]:
+    """Re-fetch an existing suggestion from the table."""
+    row = db.fetchone_dict(
+        "SELECT * FROM pattern_suggestions WHERE id = ?", [suggestion_id]
+    )
+    if row is None:
+        return None
+    return {
+        "id": row["id"],
+        "decision_id": row.get("source_violation_id"),
+        "template": row.get("template"),
+        "draft_yaml": row.get("draft_yaml"),
+        "promoted_to_policy_id": row.get("promoted_to_policy_id"),
+        "dismissed_at": row.get("dismissed_at").isoformat() if row.get("dismissed_at") else None,
+        "forecast": {
+            "count": int(row.get("forecast_fp_count") or 0),
+            "examples": _parse_examples(row.get("forecast_fp_examples")),
+        },
+    }
+
+
+def promote_suggestion(
+    db: Database, suggestion_id: str, name: str,
+) -> Policy:
+    """Turn a suggestion into a real Policy. Always lands in
+    mode=shadow (§10.1). Marks the suggestion as promoted."""
+    row = db.fetchone_dict(
+        "SELECT * FROM pattern_suggestions WHERE id = ?", [suggestion_id]
+    )
+    if row is None:
+        raise KeyError(f"suggestion not found: {suggestion_id}")
+    if row.get("dismissed_at") is not None:
+        raise ValueError("suggestion was dismissed — cannot promote")
+    if row.get("promoted_to_policy_id"):
+        raise ValueError(
+            f"suggestion already promoted to {row['promoted_to_policy_id']!r}"
+        )
+
+    draft_yaml = row["draft_yaml"]
+    policy = _policy_from_yaml(draft_yaml, override_name=name)
+    saved = policy_store.create_policy(db, policy, actor="suggester")
+
+    db.execute(
+        "UPDATE pattern_suggestions SET promoted_to_policy_id = ? WHERE id = ?",
+        [saved.name, suggestion_id],
+    )
+    return saved
+
+
+def dismiss_suggestion(db: Database, suggestion_id: str) -> None:
+    """Mark a suggestion as dismissed. Idempotent."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    db.execute(
+        "UPDATE pattern_suggestions SET dismissed_at = ? WHERE id = ? AND dismissed_at IS NULL",
+        [now, suggestion_id],
+    )
+
+
+# ---- internals -------------------------------------------------------------
+
+
+def _draft_policy_from_decision(decision: Dict[str, Any]) -> Policy:
+    """Synthesize a Policy from a fired decision row."""
+    lifecycle = str(decision.get("lifecycle") or "before_tool_call")
+    tool_name = decision.get("tool_name")
+    matched_value = (decision.get("matched_value_truncated") or "").strip()
+
+    name = (
+        f"suggested_block_{(tool_name or 'pattern')}_"
+        f"{uuid.uuid4().hex[:6]}"
+    )
+
+    # Pattern: literal-escape the matched value so we don't get
+    # unintended regex semantics. Operators broaden after promotion.
+    if matched_value:
+        # Truncate to keep the regex sane — first 80 chars are usually
+        # the discriminating prefix.
+        snippet = matched_value[:80]
+        pattern = re.escape(snippet)
+    else:
+        pattern = "<no-matched-value>"
+
+    # Build a condition that mirrors how the original decision fired.
+    # For tool lifecycles we look at Input.params.command; for proxy
+    # lifecycles we look at Output.text or Input.last_user_msg.
+    if lifecycle in ("before_tool_call", "after_tool_call"):
+        if tool_name:
+            tool_clause = f'tool_name == "{tool_name}"'
+        else:
+            tool_clause = "True"
+        condition = (
+            f'{tool_clause} and regex_match('
+            f'str(Input.params.get("command", "")), "{pattern}")'
+        )
+    elif lifecycle == "after_proxy_call":
+        condition = f'regex_match(Output.text, "{pattern}")'
+    elif lifecycle == "before_proxy_call":
+        condition = f'regex_match(Input.last_user_msg, "{pattern}")'
+    else:
+        condition = f'regex_match(str(Input.text), "{pattern}")'
+
+    return Policy(
+        name=name,
+        description=(
+            f"Auto-generated from decision {decision['id'][:12]} — "
+            f"blocks the literal pattern that fired the original "
+            f"{decision.get('policy_name', 'rule')}."
+        ),
+        trigger="span_end",
+        condition=condition,
+        action="block",
+        severity="medium",
+        scope_agents=[],
+        lifecycle=lifecycle,  # type: ignore[arg-type]
+        mode="shadow",
+        priority=50,
+    )
+
+
+def _rationale(decision: Dict[str, Any], draft: Policy) -> str:
+    """Human-readable explanation shown above the draft in the modal."""
+    return (
+        f"Detected literal pattern from decision {decision['id'][:12]} "
+        f"(originally fired by '{decision.get('policy_name', 'unknown')}'). "
+        f"Drafting a {draft.action}-action rule on lifecycle "
+        f"{draft.lifecycle} that re-fires on the same input shape."
+    )
+
+
+def _forecast(db: Database, decision: Dict[str, Any]) -> Dict[str, Any]:
+    """Cheap back-test: count past decisions from the same policy in
+    last 30d. Real "would-have-fired against new condition" replay
+    is Slice 4. Operators see this number as 'this is how often
+    this pattern is showing up' rather than 'how many traces match
+    your draft'.
+    """
+    pol = decision.get("policy_name")
+    if not pol:
+        return {"count": 0, "examples": []}
+    try:
+        cnt_row = db.fetchone(
+            """
+            SELECT COUNT(*) FROM decisions
+            WHERE policy_name = ?
+              AND decision_at >= NOW() - INTERVAL '30 days'
+            """,
+            [pol],
+        )
+        ex_rows = db.fetchall_dict(
+            """
+            SELECT trace_id FROM decisions
+            WHERE policy_name = ?
+              AND trace_id IS NOT NULL
+              AND decision_at >= NOW() - INTERVAL '30 days'
+            ORDER BY decision_at DESC
+            LIMIT 5
+            """,
+            [pol],
+        )
+    except Exception:
+        logger.exception("suggester: forecast query failed")
+        return {"count": 0, "examples": []}
+    return {
+        "count": int(cnt_row[0]) if cnt_row else 0,
+        "examples": [r["trace_id"] for r in ex_rows if r.get("trace_id")],
+    }
+
+
+def _policy_to_dict(p: Policy) -> Dict[str, Any]:
+    return {
+        "name": p.name,
+        "description": p.description,
+        "trigger": p.trigger,
+        "condition": p.condition,
+        "action": p.action,
+        "severity": p.severity,
+        "lifecycle": p.lifecycle,
+        "mode": p.mode,
+        "priority": p.priority,
+    }
+
+
+def _policy_to_yaml(p: Policy) -> str:
+    """Serialize a Policy to a human-readable YAML string. We hand-
+    write rather than yaml.safe_dump so the output stays compact +
+    the field order is predictable for diffs."""
+    lines = [
+        f"name: {p.name}",
+        f"description: {json.dumps(p.description or '')}",
+        f"lifecycle: {p.lifecycle}",
+        f"mode: {p.mode}",
+        f"priority: {p.priority}",
+        f"trigger: {p.trigger}",
+        f"action: {p.action}",
+        f"severity: {p.severity}",
+        "condition: |",
+    ]
+    for ln in (p.condition or "").splitlines() or [""]:
+        lines.append(f"  {ln}")
+    return "\n".join(lines) + "\n"
+
+
+def _policy_from_yaml(text: str, *, override_name: str) -> Policy:
+    """Parse the text we wrote with _policy_to_yaml back into a
+    Policy. Tolerates the description field being a JSON string."""
+    import yaml as _yaml
+    raw = _yaml.safe_load(text) or {}
+    desc = raw.get("description")
+    if isinstance(desc, str) and desc.startswith('"') and desc.endswith('"'):
+        try:
+            desc = json.loads(desc)
+        except json.JSONDecodeError:
+            pass
+    return Policy(
+        name=override_name,
+        description=desc,
+        trigger=raw.get("trigger", "span_end"),
+        condition=raw.get("condition", ""),
+        action=raw.get("action", "block"),
+        severity=raw.get("severity", "medium"),
+        scope_agents=[],
+        lifecycle=raw.get("lifecycle", "post_ingest"),
+        mode=raw.get("mode", "shadow"),
+        priority=int(raw.get("priority", 0)),
+    )
+
+
+def _parse_examples(blob: Any) -> List[str]:
+    if blob is None:
+        return []
+    if isinstance(blob, list):
+        return [str(x) for x in blob if x]
+    if isinstance(blob, str):
+        try:
+            v = json.loads(blob)
+            if isinstance(v, list):
+                return [str(x) for x in v if x]
+        except json.JSONDecodeError:
+            return []
+    return []

--- a/packages/api/routers/firewall.py
+++ b/packages/api/routers/firewall.py
@@ -34,6 +34,7 @@ import policy_store
 from db import Database, get_db
 
 from firewall import decide as fw_decide
+from firewall import suggester as fw_suggester
 from firewall.templates import loader as fw_templates
 from models import TemplateInstantiateRequest
 
@@ -593,3 +594,75 @@ def instantiate_template(
         "description": saved.description,
         "template_id": template_id,
     }
+
+
+# ---- pattern suggester (§5.5 — Slice 3 PR D) ----------------------------
+
+
+class SuggestRequest(BaseModel):
+    """Body for POST /v1/policies/suggest. Operator clicks "Block this
+    pattern" on a fired decision; we synthesize a draft policy."""
+    decision_id: str
+
+
+class PromoteSuggestionRequest(BaseModel):
+    """Body for POST /v1/policies/suggest/{id}/promote. The operator
+    can rename the policy at promotion time — the auto-generated name
+    is fine but operators usually want something descriptive."""
+    name: str
+
+
+@router.post("/v1/policies/suggest")
+def suggest_policy(payload: SuggestRequest, db: Database = Depends(get_db)) -> Dict[str, Any]:
+    """Generate a draft policy from a fired decision. Persists the
+    suggestion in the pattern_suggestions table so operators can
+    revisit / dismiss / promote later."""
+    try:
+        return fw_suggester.suggest_from_decision(db, payload.decision_id)
+    except KeyError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.get("/v1/policies/suggest/{suggestion_id}")
+def get_suggestion(suggestion_id: str, db: Database = Depends(get_db)) -> Dict[str, Any]:
+    out = fw_suggester.get_suggestion(db, suggestion_id)
+    if out is None:
+        raise HTTPException(status_code=404, detail=f"suggestion {suggestion_id!r} not found")
+    return out
+
+
+@router.post("/v1/policies/suggest/{suggestion_id}/promote")
+def promote_suggestion(
+    suggestion_id: str,
+    payload: PromoteSuggestionRequest,
+    db: Database = Depends(get_db),
+) -> Dict[str, Any]:
+    """Promote a suggestion into a real policy. Lands in mode=shadow."""
+    try:
+        saved = fw_suggester.promote_suggestion(db, suggestion_id, payload.name.strip())
+    except KeyError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
+    # Reload engine so the new rule is live.
+    try:
+        policy_runtime.reload_engine(db=db)
+    except Exception:
+        logger.exception("suggester: post-promote reload failed")
+
+    return {
+        "name": saved.name,
+        "lifecycle": getattr(saved, "lifecycle", "post_ingest"),
+        "mode": getattr(saved, "mode", "shadow"),
+        "action": saved.action,
+        "severity": saved.severity,
+        "condition": saved.condition,
+        "suggestion_id": suggestion_id,
+    }
+
+
+@router.post("/v1/policies/suggest/{suggestion_id}/dismiss")
+def dismiss_suggestion(suggestion_id: str, db: Database = Depends(get_db)) -> Dict[str, Any]:
+    fw_suggester.dismiss_suggestion(db, suggestion_id)
+    return {"id": suggestion_id, "dismissed": True}

--- a/packages/api/tests/firewall/test_suggester.py
+++ b/packages/api/tests/firewall/test_suggester.py
@@ -1,0 +1,203 @@
+"""Tests for the pattern suggester (Slice 3 PR D, spec §5.5 / §11)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from db import Database
+from firewall import decide as fw_decide
+from firewall import suggester
+import policy_store
+from lumin.policy import Policy
+
+
+@pytest.fixture
+def db() -> Database:
+    d = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    fw_decide.set_panic_disabled(False)
+    yield d
+    d.close()
+
+
+def _seed_decision(db: Database, **overrides) -> str:
+    import uuid
+    decision_id = "dec_" + uuid.uuid4().hex[:24]
+    row = {
+        "id": decision_id,
+        "policy_id": "test_policy",
+        "policy_name": "test_policy",
+        "lifecycle": "before_tool_call",
+        "decision": "block",
+        "mode_at_decision": "enforce",
+        "reason": "matched bad pattern",
+        "trace_id": "trace-x",
+        "span_id": "span-y",
+        "session_id": "sess-1",
+        "agent": "openclaw",
+        "project": "test",
+        "tool_name": "exec",
+        "matched_field": "command",
+        "matched_value_truncated": "rm -rf /tmp/sensitive",
+        "decision_at": datetime.now(timezone.utc).replace(tzinfo=None),
+        "duration_ms": 3,
+        "metadata": None,
+    }
+    row.update(overrides)
+    db.execute(
+        """
+        INSERT INTO decisions (
+            id, policy_id, policy_name, lifecycle, decision,
+            mode_at_decision, reason, trace_id, span_id,
+            session_id, agent, project, tool_name,
+            matched_field, matched_value_truncated,
+            decision_at, duration_ms, metadata
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            row[k] for k in (
+                "id", "policy_id", "policy_name", "lifecycle", "decision",
+                "mode_at_decision", "reason", "trace_id", "span_id",
+                "session_id", "agent", "project", "tool_name",
+                "matched_field", "matched_value_truncated",
+                "decision_at", "duration_ms", "metadata",
+            )
+        ],
+    )
+    return decision_id
+
+
+# ---- module-level functions ----------------------------------------------
+
+
+def test_suggest_from_decision_returns_draft(db: Database):
+    did = _seed_decision(db)
+    out = suggester.suggest_from_decision(db, did)
+    assert out["id"].startswith("sug_")
+    assert out["decision_id"] == did
+    assert out["template"] == "from_decision"
+    draft = out["draft"]
+    assert draft["mode"] == "shadow"  # §10.1
+    assert draft["action"] == "block"
+    assert draft["lifecycle"] == "before_tool_call"
+    # Pattern from matched_value should appear in condition (escaped)
+    assert "rm" in draft["condition"]
+
+
+def test_suggest_unknown_decision_raises():
+    db = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    try:
+        with pytest.raises(KeyError):
+            suggester.suggest_from_decision(db, "dec_does_not_exist")
+    finally:
+        db.close()
+
+
+def test_suggest_persists_to_pattern_suggestions_table(db: Database):
+    did = _seed_decision(db)
+    out = suggester.suggest_from_decision(db, did)
+    rows = db.fetchall_dict(
+        "SELECT * FROM pattern_suggestions WHERE id = ?", [out["id"]]
+    )
+    assert len(rows) == 1
+    assert rows[0]["source_violation_id"] == did
+    assert rows[0]["template"] == "from_decision"
+    assert rows[0]["draft_yaml"]
+
+
+def test_get_suggestion_round_trip(db: Database):
+    did = _seed_decision(db)
+    out1 = suggester.suggest_from_decision(db, did)
+    out2 = suggester.get_suggestion(db, out1["id"])
+    assert out2 is not None
+    assert out2["id"] == out1["id"]
+    assert out2["decision_id"] == did
+
+
+def test_promote_creates_real_policy(db: Database):
+    did = _seed_decision(db)
+    out = suggester.suggest_from_decision(db, did)
+    saved = suggester.promote_suggestion(db, out["id"], name="my_promoted_rule")
+    assert saved.name == "my_promoted_rule"
+    assert saved.mode == "shadow"
+    assert saved.action == "block"
+    # Suggestion is marked promoted
+    row = db.fetchone_dict(
+        "SELECT promoted_to_policy_id FROM pattern_suggestions WHERE id = ?",
+        [out["id"]],
+    )
+    assert row["promoted_to_policy_id"] == "my_promoted_rule"
+
+
+def test_promote_twice_raises(db: Database):
+    did = _seed_decision(db)
+    out = suggester.suggest_from_decision(db, did)
+    suggester.promote_suggestion(db, out["id"], name="first")
+    with pytest.raises(ValueError, match="already promoted"):
+        suggester.promote_suggestion(db, out["id"], name="second")
+
+
+def test_dismiss_then_promote_raises(db: Database):
+    did = _seed_decision(db)
+    out = suggester.suggest_from_decision(db, did)
+    suggester.dismiss_suggestion(db, out["id"])
+    with pytest.raises(ValueError, match="dismissed"):
+        suggester.promote_suggestion(db, out["id"], name="should_fail")
+
+
+# ---- HTTP endpoints ------------------------------------------------------
+
+
+def test_suggest_endpoint(client, db):
+    did = _seed_decision(db)
+    r = client.post("/v1/policies/suggest", json={"decision_id": did})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["decision_id"] == did
+    assert "draft_yaml" in body
+    assert body["forecast"]["count"] >= 1  # the seeded decision counts
+
+
+def test_suggest_endpoint_404(client):
+    r = client.post("/v1/policies/suggest", json={"decision_id": "nope"})
+    assert r.status_code == 404
+
+
+def test_promote_endpoint(client, db):
+    did = _seed_decision(db)
+    r1 = client.post("/v1/policies/suggest", json={"decision_id": did})
+    sid = r1.json()["id"]
+
+    r2 = client.post(
+        f"/v1/policies/suggest/{sid}/promote",
+        json={"name": "promoted_via_api"},
+    )
+    assert r2.status_code == 200
+    body = r2.json()
+    assert body["name"] == "promoted_via_api"
+    assert body["mode"] == "shadow"
+
+    # Real policy in DB
+    rows = db.fetchall_dict(
+        "SELECT name FROM policies WHERE name = ?", ["promoted_via_api"]
+    )
+    assert len(rows) == 1
+
+
+def test_dismiss_endpoint(client, db):
+    did = _seed_decision(db)
+    r1 = client.post("/v1/policies/suggest", json={"decision_id": did})
+    sid = r1.json()["id"]
+    r2 = client.post(f"/v1/policies/suggest/{sid}/dismiss")
+    assert r2.status_code == 200
+    assert r2.json()["dismissed"] is True
+
+
+def test_promote_after_dismiss_409(client, db):
+    did = _seed_decision(db)
+    r1 = client.post("/v1/policies/suggest", json={"decision_id": did})
+    sid = r1.json()["id"]
+    client.post(f"/v1/policies/suggest/{sid}/dismiss")
+    r3 = client.post(f"/v1/policies/suggest/{sid}/promote", json={"name": "x"})
+    assert r3.status_code == 409

--- a/packages/dashboard/components/BlockThisPatternModal.tsx
+++ b/packages/dashboard/components/BlockThisPatternModal.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import useSWR from 'swr';
+
+import {
+  createSuggestion,
+  dismissSuggestion,
+  promoteSuggestion,
+  SuggestionResponse,
+} from '@/lib/api';
+
+/**
+ * "Block this pattern" modal — Slice 3 PR D.
+ *
+ * Operator clicks the button on a fired decision row in the
+ * EnforcementTimeline; this component:
+ *
+ *   1. POSTs /v1/policies/suggest with the decision_id → server
+ *      synthesizes a draft Policy + 30-day forecast.
+ *   2. Renders the draft (name, lifecycle, action, condition) +
+ *      forecast count + a few example trace_ids the operator can
+ *      drill into.
+ *   3. On Save → POST /promote → router.push to the policy edit
+ *      page where ModeToggle lets operator promote shadow → enforce
+ *      after watching the timeline.
+ *   4. On Dismiss → POST /dismiss; the suggestion sticks around in
+ *      pattern_suggestions with dismissed_at set so we can train
+ *      the suggester later on operator preferences.
+ */
+export default function BlockThisPatternModal({
+  decisionId,
+  onClose,
+}: {
+  decisionId: string;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const { data: suggestion, error, isLoading } = useSWR<SuggestionResponse>(
+    `suggest:${decisionId}`,
+    () => createSuggestion(decisionId),
+    { revalidateOnFocus: false, revalidateOnReconnect: false },
+  );
+
+  const [name, setName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Pre-seed name from the draft once it loads. Operator can rename
+  // before saving — auto-generated names are uniquely-suffixed but
+  // not descriptive.
+  useEffect(() => {
+    if (suggestion && !name) {
+      setName(suggestion.draft.name);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [suggestion]);
+
+  // Esc closes
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  async function handleSave() {
+    if (!suggestion) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const out = await promoteSuggestion(suggestion.id, name.trim());
+      router.push(`/policies/${encodeURIComponent(out.name)}`);
+      router.refresh();
+      onClose();
+    } catch (e) {
+      setSubmitError((e as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDismiss() {
+    if (!suggestion) {
+      onClose();
+      return;
+    }
+    try {
+      await dismissSuggestion(suggestion.id);
+    } catch {
+      // best-effort — even if dismiss-server-side fails, we close
+      // the modal locally so the operator can move on.
+    }
+    onClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="card p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div>
+          <h2 className="text-lg font-semibold">Block this pattern</h2>
+          <p className="text-sm text-[var(--muted)] mt-1">
+            Auto-drafted from this decision. Review the rule, rename it
+            if you want, then save in shadow mode. You can promote to
+            enforce later from the policy edit page after watching the
+            timeline.
+          </p>
+        </div>
+
+        {error ? (
+          <div className="card p-3 text-sm text-rose-400 border-rose-500/40">
+            Failed to draft suggestion: {String(error.message ?? error)}
+          </div>
+        ) : isLoading || !suggestion ? (
+          <div className="text-center text-[var(--muted)] py-8">
+            Drafting suggestion…
+          </div>
+        ) : (
+          <>
+            <div className="space-y-2 border-t border-[var(--border)] pt-4">
+              <label className="block">
+                <div className="text-sm font-medium mb-1">Rule name</div>
+                <input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="form-input font-mono"
+                  required
+                />
+              </label>
+            </div>
+
+            <div className="space-y-3 border-t border-[var(--border)] pt-4 text-sm">
+              <Row k="Lifecycle" v={suggestion.draft.lifecycle} />
+              <Row k="Action" v={suggestion.draft.action} mono />
+              <Row k="Mode" v={suggestion.draft.mode} mono />
+              <Row k="Severity" v={suggestion.draft.severity} mono />
+              <Row k="Priority" v={String(suggestion.draft.priority)} mono />
+            </div>
+
+            <div className="border-t border-[var(--border)] pt-3">
+              <div className="text-xs uppercase tracking-wider text-[var(--muted)] mb-1">
+                Generated condition
+              </div>
+              <pre className="text-xs bg-[var(--surface-elev)] p-3 rounded border border-[var(--border)] overflow-x-auto whitespace-pre-wrap">
+                {suggestion.draft.condition}
+              </pre>
+            </div>
+
+            <div className="border-t border-[var(--border)] pt-3 text-xs space-y-1">
+              <div className="text-[var(--muted)] uppercase tracking-wider">
+                30-day forecast
+              </div>
+              <div className="text-[var(--foreground-soft)]">
+                Original rule fired{' '}
+                <strong>{suggestion.forecast.count}</strong> time
+                {suggestion.forecast.count === 1 ? '' : 's'} in the last
+                30 days.
+              </div>
+              {suggestion.forecast.examples.length > 0 ? (
+                <div className="text-[var(--muted)] flex flex-wrap gap-1">
+                  Recent traces:{' '}
+                  {suggestion.forecast.examples.slice(0, 5).map((tid) => (
+                    <a
+                      key={tid}
+                      href={`/traces/${tid}`}
+                      className="font-mono text-[var(--accent)] hover:underline"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {tid.slice(0, 8)}…
+                    </a>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+
+            {submitError ? (
+              <div className="card p-3 text-sm text-rose-400 border-rose-500/40">
+                {submitError}
+              </div>
+            ) : null}
+
+            <div className="flex items-center justify-end gap-2 border-t border-[var(--border)] pt-3">
+              <button
+                onClick={handleDismiss}
+                disabled={submitting}
+                className="px-3 py-1.5 rounded text-sm border border-[var(--border)] hover:bg-[var(--surface-hover)] disabled:opacity-50"
+              >
+                Dismiss
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={submitting || !name.trim()}
+                className="px-4 py-1.5 rounded text-sm font-medium bg-[var(--accent)] text-[var(--accent-foreground)] disabled:opacity-50"
+              >
+                {submitting ? 'Saving…' : 'Save in shadow mode'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+
+function Row({
+  k,
+  v,
+  mono = false,
+}: {
+  k: string;
+  v: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline gap-3">
+      <div className="w-24 shrink-0 text-[var(--muted)]">{k}</div>
+      <div className={mono ? 'font-mono text-xs' : ''}>{v}</div>
+    </div>
+  );
+}

--- a/packages/dashboard/components/EnforcementTimeline.tsx
+++ b/packages/dashboard/components/EnforcementTimeline.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useState } from 'react';
 import useSWR from 'swr';
 
 import {
@@ -11,6 +12,8 @@ import {
   fetchDecisions,
 } from '@/lib/api';
 import { useUrlString } from '@/lib/url-state';
+
+import BlockThisPatternModal from './BlockThisPatternModal';
 
 /**
  * Live timeline of every decision the firewall produced — the
@@ -31,6 +34,7 @@ export default function EnforcementTimeline() {
   const [decision, setDecision] = useUrlString('decision', '');
   const [lifecycle, setLifecycle] = useUrlString('lifecycle', '');
   const [agent, setAgent] = useUrlString('agent', '');
+  const [blockPatternFor, setBlockPatternFor] = useState<string | null>(null);
 
   const params: Parameters<typeof fetchDecisions>[0] = {
     limit: 100,
@@ -111,22 +115,40 @@ export default function EnforcementTimeline() {
                 <th className="px-3 py-2">Agent / Tool</th>
                 <th className="px-3 py-2">Trace</th>
                 <th className="px-3 py-2 text-right">Latency</th>
+                <th className="px-3 py-2 text-right">Action</th>
               </tr>
             </thead>
             <tbody>
               {data.decisions.map((d) => (
-                <DecisionRowView key={d.id} d={d} />
+                <DecisionRowView
+                  key={d.id}
+                  d={d}
+                  onBlockPattern={() => setBlockPatternFor(d.id)}
+                />
               ))}
             </tbody>
           </table>
         </div>
       )}
+
+      {blockPatternFor ? (
+        <BlockThisPatternModal
+          decisionId={blockPatternFor}
+          onClose={() => setBlockPatternFor(null)}
+        />
+      ) : null}
     </div>
   );
 }
 
 
-function DecisionRowView({ d }: { d: DecisionRow }) {
+function DecisionRowView({
+  d,
+  onBlockPattern,
+}: {
+  d: DecisionRow;
+  onBlockPattern: () => void;
+}) {
   return (
     <tr className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--surface-hover)]">
       <td className="px-3 py-2 whitespace-nowrap text-[var(--muted)]">
@@ -161,6 +183,15 @@ function DecisionRowView({ d }: { d: DecisionRow }) {
         )}
       </td>
       <td className="px-3 py-2 text-right text-[var(--muted)]">{d.duration_ms}ms</td>
+      <td className="px-3 py-2 text-right">
+        <button
+          onClick={onBlockPattern}
+          className="text-xs text-[var(--accent)] hover:underline"
+          title="Auto-draft a new rule from this pattern"
+        >
+          + Block pattern
+        </button>
+      </td>
     </tr>
   );
 }

--- a/packages/dashboard/lib/api.ts
+++ b/packages/dashboard/lib/api.ts
@@ -436,3 +436,68 @@ export function formatStartedAt(ts: string | null | undefined): string {
 export function deriveStatus(t: Trace): 'ok' | 'running' {
   return t.ended_at ? 'ok' : 'running';
 }
+
+
+// ---- Agent Firewall — pattern suggester (Slice 3 PR D) ------------------
+
+export type SuggestedPolicy = {
+  name: string;
+  description: string | null;
+  trigger: string;
+  condition: string;
+  action: string;
+  severity: string;
+  lifecycle: string;
+  mode: string;
+  priority: number;
+};
+
+export type SuggestionResponse = {
+  id: string;
+  decision_id: string;
+  template: string;
+  draft: SuggestedPolicy;
+  draft_yaml: string;
+  rationale: string;
+  forecast: { count: number; examples: string[] };
+};
+
+export async function createSuggestion(decisionId: string): Promise<SuggestionResponse> {
+  const res = await fetch(`${API_BASE}/v1/policies/suggest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ decision_id: decisionId }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`HTTP ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+export async function promoteSuggestion(
+  suggestionId: string, name: string,
+): Promise<{ name: string; lifecycle: string; mode: string; condition: string }> {
+  const res = await fetch(
+    `${API_BASE}/v1/policies/suggest/${encodeURIComponent(suggestionId)}/promote`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    let detail = text;
+    try { detail = JSON.parse(text).detail ?? text; } catch {}
+    throw new Error(`HTTP ${res.status}: ${detail}`);
+  }
+  return res.json();
+}
+
+export async function dismissSuggestion(suggestionId: string): Promise<void> {
+  await fetch(
+    `${API_BASE}/v1/policies/suggest/${encodeURIComponent(suggestionId)}/dismiss`,
+    { method: 'POST' },
+  );
+}


### PR DESCRIPTION
Closes the **compounding-loop** strategic deliverable from spec §1.4. Operator clicks 'Block pattern' on a fired decision → server drafts a new rule from the matched value → operator reviews + saves in shadow → ModeToggle promotes after watching the timeline.

## Server (firewall/suggester.py)
- `suggest_from_decision(db, decision_id)` — literal-escape the matched value, draft a `block` Policy on the same lifecycle, persist to `pattern_suggestions` table
- `promote_suggestion` / `dismiss_suggestion` lifecycle management
- 30-day back-test forecast (count + 5 example trace_ids)
- 4 endpoints: POST suggest, GET suggest/{id}, POST .../promote, POST .../dismiss

## Dashboard
- `BlockThisPatternModal` — full draft preview + forecast + Save/Dismiss
- `EnforcementTimeline` rows grow a `+ Block pattern` button

## Test plan
- 12 new tests (399 / 399 suite green)
- Manual: click 'Block pattern' on /decisions row → modal renders → save → router pushes to /policies/{name}

## Spec coverage
§5.5, §11.1, §11.2. §11.3 (frequent-pattern miner) lands in next PR.