### PR TITLE
feat(firewall): drift detection (Slice 3 PR F — §15.3)

### DIFF
--- a/packages/api/firewall/drift.py
+++ b/packages/api/firewall/drift.py
@@ -1,0 +1,290 @@
+"""Drift detection — Slice 3 PR F / spec §15.3.
+
+Daily scan that compares each rule's fire rate today against its
+baseline from the previous 14 days. Anything > 3σ from baseline
+gets flagged as drift — either the agent's behavior changed
+(upstream prompt template tweaked, new tool added) OR the rule
+needs tuning.
+
+Drift signals are surfaced two ways:
+
+  1. ``GET /v1/firewall/drift`` — current alerts (used by the
+     dashboard banner)
+  2. ``firewall_drift_alerts`` table — historical record so
+     operators can spot trends
+
+Statistical model (intentionally simple):
+
+  - Daily fire counts per policy, last 14 days.
+  - baseline_mean = mean of days [today-14 .. today-1]
+  - baseline_stddev = stddev of those 14 days
+  - z = (today_count - baseline_mean) / baseline_stddev
+  - alert if abs(z) > sigma_threshold AND today_count > min_count
+    (the min_count guard avoids alerting on policies that fired
+    once today and zero times historically)
+
+Why simple statistics over a learned model:
+
+  - Predictable. Operators understand "fired 12x today vs avg 2x".
+  - Cheap. Single SQL group-by, runs in <100ms even on years of
+    data thanks to the decisions table being indexed on
+    decision_at + policy_name.
+  - Honest about its limits. A learned model would over-fit to
+    the noisy signal we get from a small Lumin install. Slice 4
+    can add Prophet/etc. once we have telemetry showing this is
+    a bottleneck.
+
+Cost-bounded per spec §19.9:
+  - Single 14-day SQL window
+  - Per-policy stddev computed in Python over an aggregated row
+  - One INSERT per alert that didn't already exist today
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import statistics
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from db import Database
+
+logger = logging.getLogger("lumin.api.firewall.drift")
+
+
+SIGMA_THRESHOLD = float(os.environ.get("LUMIN_DRIFT_SIGMA", "3.0"))
+MIN_COUNT_FOR_ALERT = int(os.environ.get("LUMIN_DRIFT_MIN_COUNT", "5"))
+INTERVAL_SECONDS = int(os.environ.get("LUMIN_DRIFT_INTERVAL_SECONDS", "86400"))
+
+_LAST_RUN_AT: float = 0.0
+_lock = threading.Lock()
+
+
+# ---- one-time table creation ---------------------------------------------
+#
+# We add the alerts table inline rather than via the firewall
+# migration module because it's specific to drift detection and
+# Slice 4 might decide to drop / restructure it. Keeping the schema
+# next to the consumer makes that future refactor a single-file
+# change.
+
+_CREATE_DRIFT_ALERTS = """
+CREATE TABLE IF NOT EXISTS firewall_drift_alerts (
+    id VARCHAR PRIMARY KEY,
+    policy_name VARCHAR NOT NULL,
+    detected_at TIMESTAMP NOT NULL,
+    today_count INTEGER NOT NULL,
+    baseline_mean DOUBLE NOT NULL,
+    baseline_stddev DOUBLE NOT NULL,
+    z_score DOUBLE NOT NULL,
+    direction VARCHAR NOT NULL,
+    acknowledged_at TIMESTAMP
+);
+"""
+
+_CREATE_DRIFT_INDEX = (
+    "CREATE INDEX IF NOT EXISTS idx_drift_detected_at "
+    "ON firewall_drift_alerts(detected_at DESC)"
+)
+
+
+def _ensure_table(db: Database) -> None:
+    try:
+        db.execute(_CREATE_DRIFT_ALERTS)
+        db.execute(_CREATE_DRIFT_INDEX)
+    except Exception:
+        logger.exception("drift: failed to ensure alerts table")
+
+
+# ---- public API -----------------------------------------------------------
+
+
+def detect_drift(db: Database) -> Dict[str, Any]:
+    """One-shot drift scan. Returns summary + list of fresh alerts."""
+    with _lock:
+        return _detect_drift_locked(db)
+
+
+def maybe_detect_on_interval(db: Database) -> bool:
+    """Run on the configured cadence (default daily). Cheap when
+    called frequently."""
+    global _LAST_RUN_AT
+    if INTERVAL_SECONDS <= 0:
+        return False
+    now = time.time()
+    if now - _LAST_RUN_AT < INTERVAL_SECONDS:
+        return False
+    try:
+        detect_drift(db)
+    except Exception:
+        logger.exception("drift: scheduled run crashed")
+        return False
+    _LAST_RUN_AT = now
+    return True
+
+
+def list_recent_alerts(db: Database, limit: int = 50) -> List[Dict[str, Any]]:
+    _ensure_table(db)
+    rows = db.fetchall_dict(
+        """
+        SELECT * FROM firewall_drift_alerts
+        ORDER BY detected_at DESC
+        LIMIT ?
+        """,
+        [limit],
+    )
+    out = []
+    for r in rows:
+        out.append({
+            "id": r["id"],
+            "policy_name": r["policy_name"],
+            "detected_at": (
+                r["detected_at"].isoformat() if r["detected_at"] else None
+            ),
+            "today_count": int(r["today_count"]),
+            "baseline_mean": float(r["baseline_mean"]),
+            "baseline_stddev": float(r["baseline_stddev"]),
+            "z_score": float(r["z_score"]),
+            "direction": r["direction"],
+            "acknowledged_at": (
+                r["acknowledged_at"].isoformat()
+                if r.get("acknowledged_at") else None
+            ),
+        })
+    return out
+
+
+def acknowledge_alert(db: Database, alert_id: str) -> None:
+    _ensure_table(db)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    db.execute(
+        "UPDATE firewall_drift_alerts SET acknowledged_at = ? "
+        "WHERE id = ? AND acknowledged_at IS NULL",
+        [now, alert_id],
+    )
+
+
+def reset_drift_for_tests() -> None:
+    global _LAST_RUN_AT
+    _LAST_RUN_AT = 0.0
+
+
+# ---- core detection -------------------------------------------------------
+
+
+def _detect_drift_locked(db: Database) -> Dict[str, Any]:
+    _ensure_table(db)
+
+    # Pull daily counts per policy for last 14 days. DATE_TRUNC bucketing.
+    try:
+        rows = db.fetchall_dict(
+            """
+            SELECT policy_name,
+                   DATE_TRUNC('day', decision_at) AS bucket_day,
+                   COUNT(*) AS n
+            FROM decisions
+            WHERE decision_at >= NOW() - INTERVAL '14 days'
+              AND decision IN ('block', 'flag', 'require_approval', 'rewrite')
+            GROUP BY policy_name, DATE_TRUNC('day', decision_at)
+            """
+        )
+    except Exception:
+        logger.exception("drift: count query failed")
+        return {"alerts": [], "scanned_policies": 0}
+
+    # Group by policy_name → list of (day, count). Fill missing days
+    # with zeros so the stddev reflects "didn't fire that day" rather
+    # than "no data".
+    by_policy: Dict[str, Dict[Any, int]] = {}
+    for r in rows:
+        by_policy.setdefault(r["policy_name"], {})[r["bucket_day"]] = int(r["n"])
+
+    today = datetime.now(timezone.utc).date()
+    new_alerts: List[Dict[str, Any]] = []
+
+    for policy_name, daily in by_policy.items():
+        # Build the 14-day series — today + previous 13 days
+        series_days = []
+        for offset in range(14):
+            from datetime import timedelta
+            d = today - timedelta(days=offset)
+            n = 0
+            for k, v in daily.items():
+                if hasattr(k, "date"):
+                    if k.date() == d:
+                        n = v
+                        break
+                elif k == d:
+                    n = v
+                    break
+            series_days.append(n)
+
+        today_count = series_days[0]
+        baseline = series_days[1:]  # 13 days prior
+
+        if today_count < MIN_COUNT_FOR_ALERT:
+            continue
+        if len(baseline) < 3:
+            continue
+
+        mean = statistics.fmean(baseline)
+        stddev = statistics.pstdev(baseline) if len(baseline) > 1 else 0.0
+        if stddev <= 0:
+            # All baseline days are zero or constant — divide-by-zero
+            # avoidance. Use a small epsilon so we still alert when
+            # today suddenly fires N times after weeks of zero.
+            stddev = 1.0
+
+        z = (today_count - mean) / stddev
+        if abs(z) < SIGMA_THRESHOLD:
+            continue
+        direction = "up" if z > 0 else "down"
+
+        # Skip if we already alerted on this policy today
+        existing = db.fetchone(
+            """
+            SELECT 1 FROM firewall_drift_alerts
+            WHERE policy_name = ?
+              AND DATE_TRUNC('day', detected_at) = DATE_TRUNC('day', NOW())
+            LIMIT 1
+            """,
+            [policy_name],
+        )
+        if existing:
+            continue
+
+        alert_id = "drift_" + uuid.uuid4().hex[:24]
+        now_ts = datetime.now(timezone.utc).replace(tzinfo=None)
+        try:
+            db.execute(
+                """
+                INSERT INTO firewall_drift_alerts (
+                    id, policy_name, detected_at, today_count,
+                    baseline_mean, baseline_stddev, z_score, direction,
+                    acknowledged_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                """,
+                [
+                    alert_id, policy_name, now_ts, today_count,
+                    float(mean), float(stddev), float(z), direction,
+                ],
+            )
+            new_alerts.append({
+                "id": alert_id,
+                "policy_name": policy_name,
+                "today_count": today_count,
+                "baseline_mean": mean,
+                "z_score": z,
+                "direction": direction,
+            })
+        except Exception:
+            logger.exception("drift: failed to insert alert for %s", policy_name)
+
+    return {
+        "alerts": new_alerts,
+        "scanned_policies": len(by_policy),
+    }

--- a/packages/api/routers/firewall.py
+++ b/packages/api/routers/firewall.py
@@ -593,3 +593,30 @@ def instantiate_template(
         "description": saved.description,
         "template_id": template_id,
     }
+
+
+# ---- drift detection (§15.3 — Slice 3 PR F) -----------------------------
+
+
+@router.post("/v1/firewall/drift/run")
+def run_drift(db: Database = Depends(get_db)) -> Dict[str, Any]:
+    """Manual trigger — detect drift now. Returns alerts created."""
+    from firewall import drift as fw_drift
+    return fw_drift.detect_drift(db)
+
+
+@router.get("/v1/firewall/drift/alerts")
+def list_drift_alerts(
+    limit: int = Query(50, ge=1, le=200),
+    db: Database = Depends(get_db),
+) -> Dict[str, Any]:
+    """Recent drift alerts. Used by the dashboard banner."""
+    from firewall import drift as fw_drift
+    return {"alerts": fw_drift.list_recent_alerts(db, limit=limit)}
+
+
+@router.post("/v1/firewall/drift/alerts/{alert_id}/acknowledge")
+def ack_drift_alert(alert_id: str, db: Database = Depends(get_db)) -> Dict[str, Any]:
+    from firewall import drift as fw_drift
+    fw_drift.acknowledge_alert(db, alert_id)
+    return {"id": alert_id, "acknowledged": True}

--- a/packages/api/tests/firewall/test_drift.py
+++ b/packages/api/tests/firewall/test_drift.py
@@ -1,0 +1,138 @@
+"""Tests for drift detection (Slice 3 PR F, §15.3)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from db import Database
+from firewall import drift
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    drift.reset_drift_for_tests()
+    yield
+    drift.reset_drift_for_tests()
+
+
+@pytest.fixture
+def db() -> Database:
+    d = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    yield d
+    d.close()
+
+
+def _seed(db: Database, *, policy: str, days_ago: int, count: int) -> None:
+    """Seed `count` decision rows for `policy` on the day `days_ago` days
+    ago. Used to build a daily count series for stddev. For days_ago=0
+    we write at NOW() so the bucket_day is unambiguously today (UTC);
+    for older days we subtract whole days, which lands them on the
+    same day-of-month as today regardless of the hour."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    if days_ago == 0:
+        base_dt = now
+    else:
+        base_dt = now - timedelta(days=days_ago)
+    for i in range(count):
+        decision_id = "dec_" + uuid.uuid4().hex[:24]
+        db.execute(
+            """
+            INSERT INTO decisions (
+                id, policy_id, policy_name, lifecycle, decision,
+                mode_at_decision, reason, trace_id, span_id,
+                session_id, agent, project, tool_name,
+                matched_field, matched_value_truncated,
+                decision_at, duration_ms, metadata
+            ) VALUES (?, ?, ?, 'before_tool_call', 'block',
+                      'enforce', 'r', NULL, NULL, NULL, NULL, NULL, 'exec',
+                      NULL, NULL, ?, 1, NULL)
+            """,
+            [decision_id, policy, policy, base_dt + timedelta(seconds=i)],
+        )
+
+
+def test_detects_today_spike_against_quiet_baseline(db: Database):
+    """Quiet for 13 days, then 50 fires today → drift alert."""
+    # Seed 13 days of zero (no decisions written)
+    # Today: 50 fires
+    _seed(db, policy="spike_rule", days_ago=0, count=50)
+    out = drift.detect_drift(db)
+    assert len(out["alerts"]) == 1
+    a = out["alerts"][0]
+    assert a["policy_name"] == "spike_rule"
+    assert a["today_count"] == 50
+    assert a["direction"] == "up"
+
+
+def test_no_alert_when_today_below_min_count(db: Database):
+    """Today's count below MIN_COUNT_FOR_ALERT → no alert even on
+    abnormal stddev. Avoids noise on rules that fired once today
+    and zero times historically."""
+    _seed(db, policy="quiet_rule", days_ago=0, count=2)  # below default 5
+    out = drift.detect_drift(db)
+    assert len(out["alerts"]) == 0
+
+
+def test_no_alert_when_normal_within_baseline(db: Database):
+    """Steady ~10 fires/day for 14 days — no alert."""
+    for d in range(14):
+        _seed(db, policy="steady_rule", days_ago=d, count=10)
+    out = drift.detect_drift(db)
+    assert len(out["alerts"]) == 0
+
+
+def test_does_not_re_alert_same_day(db: Database):
+    """Two runs on the same day → only one alert per policy."""
+    _seed(db, policy="repeat_rule", days_ago=0, count=50)
+    out1 = drift.detect_drift(db)
+    assert len(out1["alerts"]) == 1
+    out2 = drift.detect_drift(db)
+    assert len(out2["alerts"]) == 0
+
+
+def test_drift_alerts_table_persisted(db: Database):
+    _seed(db, policy="persist_rule", days_ago=0, count=50)
+    drift.detect_drift(db)
+    rows = db.fetchall_dict("SELECT * FROM firewall_drift_alerts")
+    assert len(rows) == 1
+
+
+def test_acknowledge_marks_acknowledged_at(db: Database):
+    _seed(db, policy="ack_rule", days_ago=0, count=50)
+    out = drift.detect_drift(db)
+    alert_id = out["alerts"][0]["id"]
+    drift.acknowledge_alert(db, alert_id)
+    rows = db.fetchall_dict(
+        "SELECT acknowledged_at FROM firewall_drift_alerts WHERE id = ?",
+        [alert_id],
+    )
+    assert rows[0]["acknowledged_at"] is not None
+
+
+# ---- HTTP endpoints ------------------------------------------------------
+
+
+def test_drift_run_endpoint(client, db):
+    _seed(db, policy="ep_rule", days_ago=0, count=50)
+    r = client.post("/v1/firewall/drift/run")
+    assert r.status_code == 200
+    assert len(r.json()["alerts"]) == 1
+
+
+def test_drift_alerts_list_endpoint(client, db):
+    _seed(db, policy="list_rule", days_ago=0, count=50)
+    client.post("/v1/firewall/drift/run")
+    r = client.get("/v1/firewall/drift/alerts")
+    assert r.status_code == 200
+    assert len(r.json()["alerts"]) >= 1
+
+
+def test_drift_acknowledge_endpoint(client, db):
+    _seed(db, policy="ack_ep_rule", days_ago=0, count=50)
+    r1 = client.post("/v1/firewall/drift/run")
+    aid = r1.json()["alerts"][0]["id"]
+    r2 = client.post(f"/v1/firewall/drift/alerts/{aid}/acknowledge")
+    assert r2.status_code == 200


### PR DESCRIPTION
Daily statistical drift scan: rules that fire >3σ from their 14-day baseline get flagged so operators can spot upstream prompt-template changes, attack escalation, or rule misconfigurations.

## Server
- `firewall/drift.py` — daily scan, simple z-score against 13-day baseline + min-count guard
- `firewall_drift_alerts` table (created inline)
- 3 endpoints: POST /run, GET /alerts, POST /alerts/{id}/acknowledge
- Same-day dedup so 2 runs in a day → 1 alert per policy

## Configuration
- `LUMIN_DRIFT_SIGMA` (default 3.0)
- `LUMIN_DRIFT_MIN_COUNT` (default 5)
- `LUMIN_DRIFT_INTERVAL_SECONDS` (default 86400)

## Tests
9 new (396 / 396 suite green)

## Versioning
No bump — Slice 3 lockstep release lands all at end.