### PR TITLE
chore: v0.5.0 lockstep release (Slice 3)

### DIFF
--- a/packages/api/main.py
+++ b/packages/api/main.py
@@ -275,7 +275,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     title="Lumin API",
     description="Local-first AI agent observability — ingest and query API",
-    version="0.4.0",
+    version="0.5.0",
     lifespan=lifespan,
 )
 

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -36,7 +36,7 @@ export const metadata: Metadata = {
   ],
 };
 
-const VERSION = '0.4.0';
+const VERSION = '0.5.0';
 
 export default function RootLayout({
   children,

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumin-dashboard",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/integrations/mastra/package.json
+++ b/packages/integrations/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/mastra",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Lumin exporter for Mastra agents \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/integrations/openclaw-diagnostics/package.json
+++ b/packages/integrations/openclaw-diagnostics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/openclaw-diagnostics",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Lumin observability + Agent Firewall for OpenClaw \u2014 captures prompts, responses, tool I/O, and synchronously enforces firewall policies on every tool call.",
   "homepage": "https://github.com/amitbidlan/zistica-lumin/tree/main/packages/integrations/openclaw-diagnostics",
   "repository": {

--- a/packages/integrations/openclaw/package.json
+++ b/packages/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/openclaw",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Lumin exporter for OpenClaw agents \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/integrations/voltagent/package.json
+++ b/packages/integrations/voltagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/voltagent",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Lumin exporter for VoltAgent \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lumin"
-version = "0.4.0"
+version = "0.5.0"
 description = "Local-first AI agent observability SDK"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Local-first AI agent observability SDK (TypeScript)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Lockstep version bump for the v0.5.0 release. Bumps all 9 version locations to 0.5.0:

- ``packages/api/main.py``
- ``packages/sdk-python/pyproject.toml``
- ``packages/sdk-typescript/package.json``
- ``packages/dashboard/package.json``
- ``packages/dashboard/app/layout.tsx`` (embedded ``VERSION`` constant)
- ``packages/integrations/openclaw/package.json``
- ``packages/integrations/mastra/package.json``
- ``packages/integrations/voltagent/package.json``
- ``packages/integrations/openclaw-diagnostics/package.json``

## What's in v0.5.0

Slice 3 — full firewall-tier-2 + dashboard-UX rollout:

| PR | Feature |
| --- | --- |
| #58 | Rule template gallery UI |
| #59 | PolicyEditor firewall verb extension (block / require_approval / rewrite / allow) |
| #60 | Decision-detail actions + ``POST /v1/labels`` |
| #61 | Pattern suggester + Block-this-pattern UX |
| #62 | Frequent-pattern miner (hourly background scan) |
| #63 | Drift detection (14-day baseline z-score alerts) |
| #64 | Prompt Guard 2 detector (opt-in 22M classifier) |
| #65 | Llama Guard 4 detector (opt-in 12B content-safety classifier) |
| #66 | Embedding similarity matcher + corpus CRUD |
| #67 | Mastra firewall integration (parity with OpenClaw v0.4.0) |

## Post-merge

Tag ``v0.5.0`` to trigger the standard release flow:

```bash
git tag v0.5.0
git push origin v0.5.0
```

That fires the Docker Hub + npm + ClawHub republish workflows.

## Test plan

- [x] All 9 versions read 0.5.0
- [ ] CI passes on the bump commit
- [ ] After tag: ``zistica/lumin:0.5.0`` lands on Docker Hub
- [ ] After tag: ``@lumin-io/openclaw@0.5.0``, ``@lumin-io/mastra@0.5.0``, ``@lumin-io/voltagent@0.5.0``, ``@lumin-io/openclaw-diagnostics@0.5.0`` republish to npm