### PR TITLE
feat(firewall): trace replay endpoint (Slice 3 PR M — §5.10 / §14.1)

### DIFF
--- a/packages/api/firewall/decide.py
+++ b/packages/api/firewall/decide.py
@@ -411,12 +411,28 @@ def decide(
     model: Optional[str] = None,
     messages: Optional[List[Dict[str, Any]]] = None,
     output: Optional[Any] = None,
+    persist: bool = True,
 ) -> Dict[str, Any]:
     """Run the firewall against a single decision request.
 
     Returns the response dict per spec §5.1. Never raises.
+
+    When ``persist=False``, the decision is NOT written to the
+    ``decisions`` / ``approvals`` tables — used by the replay
+    endpoint (§5.10) and the rule unit-test harness (§14.3). All
+    side effects that touch persistent state are skipped:
+      - decisions row insert
+      - approvals row insert (require_approval -> dummy id)
+      - deny-cache writes
+      - auto-circuit-breaker fire tracking
     """
     t0 = time.perf_counter()
+    # Local recorder honours `persist` — replay/test paths see
+    # decision_id=None and no DB writes happen for the decision row.
+    def _record(*args, **kwargs) -> Optional[str]:
+        if not persist:
+            return None
+        return _record_decision(*args, **kwargs)
     budget_ms = LATENCY_BUDGET_MS.get(lifecycle, 500)
     deadline = t0 + (budget_ms / 1000.0)
 
@@ -438,7 +454,7 @@ def decide(
     cache_key = _deny_cache_key(session_id, tool_name, params)
     cached_policy = _check_deny_cache(cache_key)
     if cached_policy is not None:
-        decision_id = _record_decision(
+        decision_id = _record(
             db, policy=None, lifecycle=lifecycle,
             decision="block", reason=f"cached_deny:{cached_policy}",
             trace_id=trace_id, span_id=span_id, session_id=session_id,
@@ -508,7 +524,7 @@ def decide(
                 "firewall.decide: timeout (%dms budget) at policy %s",
                 budget_ms, policy.name,
             )
-            _record_decision(
+            _record(
                 db, policy=None, lifecycle=lifecycle,
                 decision="allow", reason=f"timeout_{budget_ms}ms",
                 trace_id=trace_id, span_id=span_id, session_id=session_id,
@@ -527,7 +543,7 @@ def decide(
             if on_err == "deny":
                 # Operator chose deny-on-error for this policy
                 # explicitly — log and treat as a block.
-                decision_id = _record_decision(
+                decision_id = _record(
                     db, policy=policy, lifecycle=lifecycle,
                     decision="block", reason="internal_error",
                     trace_id=trace_id, span_id=span_id, session_id=session_id,
@@ -563,7 +579,7 @@ def decide(
             action = "flag"
         if action == "allow":
             # Explicit allow short-circuits — record + return.
-            decision_id = _record_decision(
+            decision_id = _record(
                 db, policy=policy, lifecycle=lifecycle,
                 decision="allow", reason="policy_allow",
                 trace_id=trace_id, span_id=span_id, session_id=session_id,
@@ -594,7 +610,10 @@ def decide(
         # 'tripped' in the DB. The trip applies to *subsequent* calls
         # (this call's decision is honored). _applicable_policies
         # already filters out tripped policies on the next request.
-        _maybe_auto_trip(db, policy.name)
+        # Skipped on replay (persist=False) — replay shouldn't trip
+        # real production circuits.
+        if persist:
+            _maybe_auto_trip(db, policy.name)
 
         # ---- mode resolution --------------------------------------------
         # shadow → record and continue (don't return, lower-priority
@@ -605,7 +624,7 @@ def decide(
         reason = policy.description or f"policy:{policy.name}"
 
         if mode == "shadow":
-            decision_id = _record_decision(
+            decision_id = _record(
                 db, policy=policy, lifecycle=lifecycle,
                 decision=action, reason=reason,
                 trace_id=trace_id, span_id=span_id, session_id=session_id,
@@ -621,7 +640,7 @@ def decide(
             continue
 
         if mode == "flag":
-            decision_id = _record_decision(
+            decision_id = _record(
                 db, policy=policy, lifecycle=lifecycle,
                 decision="flag", reason=reason,
                 trace_id=trace_id, span_id=span_id, session_id=session_id,
@@ -643,7 +662,7 @@ def decide(
             }
 
         # mode == enforce — first non-allow rule wins.
-        decision_id = _record_decision(
+        decision_id = _record(
             db, policy=policy, lifecycle=lifecycle,
             decision=action, reason=reason,
             trace_id=trace_id, span_id=span_id, session_id=session_id,
@@ -653,10 +672,18 @@ def decide(
         )
 
         if action == "require_approval":
-            approval_id = _create_approval(
-                db, decision_id=decision_id, policy=policy,
-                trace_id=trace_id, agent=agent, tool_name=tool_name,
-                params=params,
+            # Replay (persist=False) doesn't create real approvals —
+            # the dashboard would surface a phantom row. The replay
+            # response still says decision="require_approval"; the
+            # caller sees the policy fired without a side effect.
+            approval_id = (
+                _create_approval(
+                    db, decision_id=decision_id, policy=policy,
+                    trace_id=trace_id, agent=agent, tool_name=tool_name,
+                    params=params,
+                )
+                if persist
+                else None
             )
             return {
                 "decision": "require_approval",

--- a/packages/api/firewall/replay.py
+++ b/packages/api/firewall/replay.py
@@ -1,0 +1,249 @@
+"""Trace replay — Slice 3 PR M / spec §5.10 + §14.1.
+
+Replays a past trace through the current policy set and returns
+what *would* have happened, span by span, decision by decision.
+
+The three workflows this enables:
+
+  1. **FP forecast before promoting shadow → enforce.** Operator
+     promotes a rule from shadow to enforce. Replay against the
+     last 30 days of traces shows how many decisions flip from
+     "logged but not blocked" to "actually blocked" — and
+     critically, on which traces, so the operator can audit
+     before flipping.
+
+  2. **Verify a new rule catches the historical incident.** When a
+     new rule is authored (template, suggester, hand-written), the
+     operator wants to check: does it actually fire on the trace
+     that motivated it? Replay against that one trace + filter to
+     just the new rule = answer in 200ms.
+
+  3. **CI regression test.** A team can pin a small set of
+     "golden" traces — known good, known bad — and replay them
+     against current main. Any rule edit that flips a golden
+     decision fails CI.
+
+Implementation: load the trace's spans in chronological order,
+synthesize a ``decide()`` call per span using the same lifecycle /
+tool / params / output that produced it originally, with the
+``policy_ids`` filter (if provided) restricting which rules apply.
+The decisions returned are NOT persisted — replay is read-only.
+
+Key constraint: the engine is per-process state (loaded YAML or DB
+policies). Replay always uses the *current* engine — that's the
+whole point. If an operator wants to replay against a candidate
+policy they haven't yet committed, they can use the dashboard's
+"Test against this trace" button on the editor (uses the same
+endpoint with a one-off policy injected — landed in a follow-up).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from firewall import decide as fw_decide
+
+logger = logging.getLogger("lumin.api.firewall.replay")
+
+
+def replay_trace(
+    db,
+    trace_id: str,
+    policy_ids: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Replay ``trace_id`` through the current engine, optionally
+    filtered to ``policy_ids``. Returns a structured response::
+
+        {
+          "trace_id": "...",
+          "span_count": 12,
+          "decisions": [
+            {
+              "span_id": "...",
+              "lifecycle": "before_tool_call",
+              "tool_name": "shell",
+              "decision": "block",
+              "policy_name": "owasp_llm06_destructive_shell",
+              "reason": "rm -rf detected",
+              "duration_ms": 1.4
+            },
+            ...
+          ],
+          "summary": {
+            "block": 1,
+            "rewrite": 0,
+            "require_approval": 0,
+            "flag": 2,
+            "allow": 9
+          }
+        }
+
+    Empty ``decisions`` is fine — a benign trace generates none.
+
+    Per §10.1, replay does not persist decisions to the
+    ``decisions`` table; that table holds the historical record of
+    what *actually* happened. Replay output is always advisory.
+    """
+    if not trace_id:
+        raise ValueError("trace_id is required")
+
+    # Pull spans in chronological order. We need:
+    #   - lifecycle (derived from span type + name; see below)
+    #   - tool_name (for tool spans)
+    #   - input + output text (for proxy / tool spans)
+    #   - the request that produced it (for before-call replay)
+    rows = db.fetchall_dict(
+        """
+        SELECT id, type, name, tool_name, input, output, started_at,
+               metadata
+        FROM spans
+        WHERE trace_id = ?
+        ORDER BY started_at ASC, id ASC
+        """,
+        [trace_id],
+    )
+
+    if not rows:
+        raise KeyError(f"trace {trace_id!r} has no spans")
+
+    # Pull the agent + project from the trace row so each replay
+    # decide() call has the right routing context — same fields
+    # the original decide saw.
+    trace_row = db.fetchone_dict(
+        "SELECT id, name, project FROM traces WHERE id = ?", [trace_id]
+    )
+    agent = trace_row.get("name") if trace_row else None
+    project = trace_row.get("project") if trace_row else None
+
+    decisions: List[Dict[str, Any]] = []
+    summary = {"block": 0, "rewrite": 0, "require_approval": 0, "flag": 0, "allow": 0}
+
+    # Filter: if policy_ids is set, fence the engine so only those
+    # policies' decisions count. We do this AFTER calling decide()
+    # because decide() doesn't expose a per-call policy filter today
+    # — we just discard mismatched decisions in the response.
+    policy_filter = set(policy_ids) if policy_ids else None
+
+    for span in rows:
+        for lifecycle in _lifecycles_for_span(span):
+            try:
+                resp = fw_decide.decide(
+                    db,
+                    lifecycle=lifecycle,
+                    tool_name=span.get("tool_name"),
+                    params=_params_from_span(span),
+                    trace_id=trace_id,
+                    span_id=span["id"],
+                    agent=agent,
+                    project=project,
+                    output=_output_for_lifecycle(span, lifecycle),
+                    persist=False,  # replay never writes to decisions table
+                )
+            except Exception:
+                logger.exception(
+                    "replay: decide() crashed on span %s lifecycle %s; skipping",
+                    span.get("id"), lifecycle,
+                )
+                continue
+
+            verb = resp.get("decision", "allow")
+            policy_name = resp.get("policy_name")
+
+            if policy_filter is not None:
+                # Skip decisions whose matched policy isn't in the
+                # filter set. ``allow`` with no matched policy is
+                # ALSO skipped — the filter is "what would these
+                # specific rules do".
+                if not policy_name or policy_name not in policy_filter:
+                    continue
+
+            # Don't include the engine's "no rules matched at all"
+            # allows — they're noise in the replay output.
+            if verb == "allow" and not policy_name:
+                continue
+
+            decisions.append({
+                "span_id": span["id"],
+                "lifecycle": lifecycle,
+                "tool_name": span.get("tool_name"),
+                "decision": verb,
+                "policy_name": policy_name,
+                "reason": resp.get("reason"),
+                "duration_ms": resp.get("duration_ms"),
+            })
+            if verb in summary:
+                summary[verb] += 1
+
+    return {
+        "trace_id": trace_id,
+        "span_count": len(rows),
+        "decisions": decisions,
+        "summary": summary,
+    }
+
+
+# ---- helpers --------------------------------------------------------------
+
+
+def _lifecycles_for_span(span: Dict[str, Any]) -> List[str]:
+    """Map a span row to the firewall lifecycles its existence
+    implies. A tool span implies both ``before_tool_call`` and
+    ``after_tool_call`` (we can't tell which fired the original
+    decision without replaying both). A proxy / model span implies
+    both ``before_proxy_call`` + ``after_proxy_call``.
+
+    Why both directions: rules are lifecycle-scoped, so a span that
+    historically passed ``before_tool_call`` rules cleanly might be
+    caught by a *new* ``after_tool_call`` rule the operator just
+    added. We need to surface those.
+    """
+    span_type = (span.get("type") or "").lower()
+    if span_type == "tool":
+        return ["before_tool_call", "after_tool_call"]
+    if span_type in ("llm", "model", "proxy", "generation"):
+        return ["before_proxy_call", "after_proxy_call"]
+    # Generic span — only post_ingest applies (no proxy/tool semantics).
+    return ["post_ingest"]
+
+
+def _params_from_span(span: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Reconstruct the ``params`` dict the original decide() saw
+    for a tool span. Lumin records the raw input as a string in the
+    span's ``input`` column; tool calls are JSON-shaped, so we try
+    to parse. Falls back to ``{"raw": <text>}`` so rules with
+    ``str(Input.params.get("command", ""))`` style conditions still
+    have something useful to pattern-match on (since ``raw`` is the
+    full original payload)."""
+    raw = span.get("input")
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        return raw
+    try:
+        import json as _json
+        parsed = _json.loads(raw)
+        if isinstance(parsed, dict):
+            return parsed
+        return {"raw": raw}
+    except (ValueError, TypeError):
+        return {"raw": raw}
+
+
+def _output_for_lifecycle(
+    span: Dict[str, Any], lifecycle: str
+) -> Optional[Any]:
+    """Output payload for the decide() call. Only meaningful for
+    *after* lifecycles — the *before* ones see a placeholder None.
+
+    Mirroring the runtime: ``Output.text`` is what the engine
+    expressions use, so we wrap the span's output column in a dict
+    when it's a string."""
+    if lifecycle.startswith("before_"):
+        return None
+    out = span.get("output")
+    if out is None:
+        return None
+    if isinstance(out, str):
+        return {"text": out}
+    return out

--- a/packages/api/routers/firewall.py
+++ b/packages/api/routers/firewall.py
@@ -904,3 +904,37 @@ def ack_drift_alert(alert_id: str, db: Database = Depends(get_db)) -> Dict[str, 
     from firewall import drift as fw_drift
     fw_drift.acknowledge_alert(db, alert_id)
     return {"id": alert_id, "acknowledged": True}
+
+
+# ---- Trace replay (Slice 3 PR M — §5.10 / §14.1) -----------------------
+#
+# Run a past trace through the current policy set and report what *would*
+# have happened. Read-only — no decisions written, no approvals created.
+
+
+class ReplayRequest(BaseModel):
+    """Body for POST /v1/firewall/test/replay."""
+    trace_id: str
+    # Optional filter: when set, only decisions where the matched
+    # policy_name is in this list are returned. Useful for "what
+    # would JUST this candidate rule do?" workflows.
+    policy_ids: Optional[List[str]] = None
+
+
+@router.post("/v1/firewall/test/replay")
+def replay_endpoint(
+    payload: ReplayRequest, db: Database = Depends(get_db)
+) -> Dict[str, Any]:
+    """Replay ``trace_id`` against the current engine. Returns a
+    structured per-span decision list + summary counts.
+
+    404 when the trace doesn't exist or has no spans. 400 on
+    invalid request shape. The replay endpoint is read-only — no
+    decisions / approvals / circuit-breaker state are written."""
+    from firewall import replay as fw_replay
+    try:
+        return fw_replay.replay_trace(db, payload.trace_id, payload.policy_ids)
+    except KeyError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/packages/api/tests/firewall/test_replay.py
+++ b/packages/api/tests/firewall/test_replay.py
@@ -1,0 +1,223 @@
+"""Tests for trace replay — Slice 3 PR M / spec §5.10 + §14.1.
+
+Verifies:
+  - Replay produces the same decision verb that decide() would
+  - persist=False does NOT write to the decisions table
+  - Per-span lifecycle expansion (tool span → before+after)
+  - Missing trace → 404 / KeyError
+  - policy_ids filter restricts the response
+  - Summary counts match the decisions list
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from db import Database
+from firewall import decide as fw_decide
+from firewall import replay as fw_replay
+from lumin.policy import Policy
+import policy_store
+
+
+@pytest.fixture
+def db() -> Database:
+    instance = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    fw_decide.set_panic_disabled(False)
+    yield instance
+    instance.close()
+
+
+def _seed_trace_with_shell_span(
+    db: Database, command: str, trace_id: str = "tr-1", span_id: str = "sp-1"
+) -> None:
+    """Insert a trace + a single tool span that records ``command``."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    db.execute(
+        """
+        INSERT INTO traces (id, name, project, started_at, ingest_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        [trace_id, "test_agent", "test_project", now, now],
+    )
+    db.execute(
+        """
+        INSERT INTO spans (
+            id, trace_id, type, name, tool_name,
+            input, output, started_at, ended_at, status
+        )
+        VALUES (?, ?, 'tool', 'shell_call', 'shell',
+                ?, ?, ?, ?, 'ok')
+        """,
+        [
+            span_id, trace_id,
+            json.dumps({"command": command}),
+            "ran",
+            now, now,
+        ],
+    )
+
+
+def _install_block_rm_rule(db: Database) -> None:
+    p = Policy(
+        name="test_block_rm_rf",
+        description="block rm -rf",
+        trigger="span_end",
+        condition='regex_match(str(Input.params.get("command", "")), "(?i)rm\\s+-rf\\s")',
+        action="block",
+        severity="critical",
+        lifecycle="before_tool_call",
+        mode="enforce",
+        priority=100,
+    )
+    policy_store.create_policy(db, p, actor="test")
+
+
+# --- core replay behavior --------------------------------------------------
+
+
+def test_replay_returns_block_for_dangerous_command(db: Database) -> None:
+    """A trace whose tool span ran ``rm -rf /`` should replay as a
+    block under the rule we just installed."""
+    _seed_trace_with_shell_span(db, "rm -rf /")
+    _install_block_rm_rule(db)
+
+    out = fw_replay.replay_trace(db, "tr-1")
+    assert out["trace_id"] == "tr-1"
+    assert out["span_count"] == 1
+    assert len(out["decisions"]) == 1
+    d = out["decisions"][0]
+    assert d["decision"] == "block"
+    assert d["policy_name"] == "test_block_rm_rf"
+    assert d["lifecycle"] == "before_tool_call"
+
+
+def test_replay_returns_no_decisions_for_safe_command(db: Database) -> None:
+    """Safe command + the same rule = empty decisions list. We don't
+    surface the 'allow with no policy matched' rows — they're noise."""
+    _seed_trace_with_shell_span(db, "ls -la")
+    _install_block_rm_rule(db)
+
+    out = fw_replay.replay_trace(db, "tr-1")
+    assert out["span_count"] == 1
+    assert out["decisions"] == []
+    assert out["summary"] == {"block": 0, "rewrite": 0, "require_approval": 0, "flag": 0, "allow": 0}
+
+
+def test_replay_does_not_persist_decisions(db: Database) -> None:
+    """Replay must NOT write to the ``decisions`` table — that table
+    is the historical record of what *actually* happened. Replay is
+    advisory."""
+    _seed_trace_with_shell_span(db, "rm -rf /")
+    _install_block_rm_rule(db)
+
+    before = db.fetchone("SELECT COUNT(*) FROM decisions")
+    fw_replay.replay_trace(db, "tr-1")
+    after = db.fetchone("SELECT COUNT(*) FROM decisions")
+
+    assert before[0] == after[0], "replay should not write to decisions table"
+
+
+def test_replay_respects_policy_ids_filter(db: Database) -> None:
+    """When policy_ids is set, only decisions matching those policies
+    appear in the response."""
+    _seed_trace_with_shell_span(db, "rm -rf /")
+    _install_block_rm_rule(db)
+
+    # Filter that includes our rule → block surfaces.
+    out = fw_replay.replay_trace(db, "tr-1", policy_ids=["test_block_rm_rf"])
+    assert len(out["decisions"]) == 1
+
+    # Filter that excludes our rule → empty.
+    out = fw_replay.replay_trace(db, "tr-1", policy_ids=["nonexistent"])
+    assert out["decisions"] == []
+
+
+def test_replay_unknown_trace_raises_keyerror(db: Database) -> None:
+    with pytest.raises(KeyError, match="ghost"):
+        fw_replay.replay_trace(db, "ghost")
+
+
+def test_replay_empty_trace_id_raises(db: Database) -> None:
+    with pytest.raises(ValueError):
+        fw_replay.replay_trace(db, "")
+
+
+def test_replay_summary_matches_decisions(db: Database) -> None:
+    """Summary counts must equal the per-verb counts in decisions."""
+    _seed_trace_with_shell_span(db, "rm -rf /")
+    _install_block_rm_rule(db)
+
+    out = fw_replay.replay_trace(db, "tr-1")
+    counts = {"block": 0, "rewrite": 0, "require_approval": 0, "flag": 0, "allow": 0}
+    for d in out["decisions"]:
+        if d["decision"] in counts:
+            counts[d["decision"]] += 1
+    assert counts == out["summary"]
+
+
+def test_replay_does_not_create_approvals(db: Database) -> None:
+    """A require_approval rule replayed must NOT create a real
+    approval row — that would surface a phantom in the dashboard."""
+    _seed_trace_with_shell_span(db, "rm -rf /")
+    p = Policy(
+        name="test_approval_rule",
+        description="require approval",
+        trigger="span_end",
+        condition='regex_match(str(Input.params.get("command", "")), "rm")',
+        action="require_approval",
+        severity="high",
+        lifecycle="before_tool_call",
+        mode="enforce",
+        priority=100,
+    )
+    policy_store.create_policy(db, p, actor="test")
+
+    before = db.fetchone("SELECT COUNT(*) FROM approvals")
+    out = fw_replay.replay_trace(db, "tr-1")
+    after = db.fetchone("SELECT COUNT(*) FROM approvals")
+
+    assert before[0] == after[0]
+    # But the decision IS surfaced in the replay output.
+    assert any(d["decision"] == "require_approval" for d in out["decisions"])
+
+
+# --- decide(persist=False) directly ----------------------------------------
+
+
+def test_decide_persist_false_skips_writes(db: Database) -> None:
+    """The persist=False kwarg on decide() itself short-circuits the
+    decisions table write — verified independently of replay."""
+    _install_block_rm_rule(db)
+
+    before = db.fetchone("SELECT COUNT(*) FROM decisions")
+    resp = fw_decide.decide(
+        db,
+        lifecycle="before_tool_call",
+        tool_name="shell",
+        params={"command": "rm -rf /"},
+        persist=False,
+    )
+    after = db.fetchone("SELECT COUNT(*) FROM decisions")
+
+    assert resp["decision"] == "block"
+    assert before[0] == after[0]
+
+
+def test_decide_persist_true_writes(db: Database) -> None:
+    """Sanity: persist=True (default) DOES write."""
+    _install_block_rm_rule(db)
+
+    before = db.fetchone("SELECT COUNT(*) FROM decisions")
+    fw_decide.decide(
+        db,
+        lifecycle="before_tool_call",
+        tool_name="shell",
+        params={"command": "rm -rf /"},
+    )
+    after = db.fetchone("SELECT COUNT(*) FROM decisions")
+
+    assert after[0] == before[0] + 1


### PR DESCRIPTION
## Summary

Replays any past trace through the current policy set and reports what *would* have happened. Read-only — no decisions / approvals / circuit-breaker state are written.

**Stacks on PR #69 (IPI sniffer)** for ordering, but no actual file conflicts.

### Workflows enabled

1. **FP forecast before shadow → enforce.** Operator sees exactly which historical traces would have flipped from "logged" to "actually blocked" before flipping the rule. Big trust-builder.
2. **Verify a new rule.** ``policy_ids`` filter restricts the replay to one rule, resolves in ~200ms — operator confirms the rule fires on the trace that motivated it.
3. **CI regression test.** Pin a small set of "golden" traces; any rule edit that flips a golden decision fails CI.

### Endpoint

```
POST /v1/firewall/test/replay
{
  "trace_id": "tr-xyz",
  "policy_ids": ["candidate_rule"]   // optional
}
```

Returns per-span decision list + summary counts.

### Implementation notes

- ``firewall/replay.py`` — chronological span walk, ``decide(persist=False)`` per lifecycle, response shaping
- ``firewall/decide.py`` — new ``persist=False`` kwarg that short-circuits all persistent writes (decisions, approvals, auto-trip). Default ``True`` preserves existing behavior.
- **Lifecycle expansion**: tool spans replay through both ``before_tool_call`` AND ``after_tool_call`` so newly-added ``after_tool_call`` rules surface against historical traces.
- **Filter behavior**: "engine allow" rows (no policy matched) are excluded — they're noise. Operators see only decisions a rule actually generated.

## Test plan

- [x] Block surfaces for ``rm -rf /``
- [x] Safe command (``ls -la``) → empty decisions list
- [x] Persist=False: 0 rows written to ``decisions``
- [x] ``policy_ids`` filter restricts response
- [x] Missing trace → KeyError → 404
- [x] Empty trace_id → ValueError → 400
- [x] Summary counts match decisions
- [x] ``require_approval`` doesn't create phantom approval rows
- [x] ``decide(persist=False)`` directly verified vs ``persist=True``