### PR TITLE
test(firewall): fix drift test UTC day-boundary flake

### DIFF
--- a/packages/api/tests/firewall/test_drift.py
+++ b/packages/api/tests/firewall/test_drift.py
@@ -27,15 +27,15 @@ def db() -> Database:
 
 def _seed(db: Database, *, policy: str, days_ago: int, count: int) -> None:
     """Seed `count` decision rows for `policy` on the day `days_ago` days
-    ago. Used to build a daily count series for stddev. For days_ago=0
-    we write at NOW() so the bucket_day is unambiguously today (UTC);
-    for older days we subtract whole days, which lands them on the
-    same day-of-month as today regardless of the hour."""
-    now = datetime.now(timezone.utc).replace(tzinfo=None)
-    if days_ago == 0:
-        base_dt = now
-    else:
-        base_dt = now - timedelta(days=days_ago)
+    ago. Used to build a daily count series for stddev.
+
+    Anchors each day's rows to noon UTC of that day so the seeded
+    rows can never spill across the UTC day boundary regardless of
+    when the test runs (CI hitting 23:59:58 UTC was previously
+    splitting today's 50 rows across two calendar days)."""
+    now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+    today_noon = now_utc.replace(hour=12, minute=0, second=0, microsecond=0)
+    base_dt = today_noon - timedelta(days=days_ago)
     for i in range(count):
         decision_id = "dec_" + uuid.uuid4().hex[:24]
         db.execute(


### PR DESCRIPTION
## Summary

Drift test ``test_detects_today_spike_against_quiet_baseline`` failed in CI at 23:59:38 UTC because the seed helper inserted 50 rows incrementing forward in time from ``now``. Rows after 23:59:59.999 landed in the *next* UTC day, so the drift detector counted only 22 in today's bucket instead of 50.

CI run: https://github.com/amitbidlan/zistica-lumin/actions/runs/25528704314

### Fix

Anchor every day's seed batch to ``today_noon`` (12:00 UTC) plus a small per-row offset, so rows can never cross the day boundary regardless of when the test runs. With this anchor, all 9 drift tests are CI-time-of-day independent.

The same root cause was previously suspected on ``test_does_not_re_alert_same_day`` (per its earlier comment) but only the spike-detection test was sensitive enough to trip in production CI.

## Test plan

- [x] All 9 ``test_drift.py`` tests pass locally
- [ ] CI green