### PR TITLE
chore: v0.5.2 lockstep release (OpenClaw LLM-side firewall hooks)

### DIFF
--- a/packages/api/main.py
+++ b/packages/api/main.py
@@ -275,7 +275,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     title="Lumin API",
     description="Local-first AI agent observability — ingest and query API",
-    version="0.5.0",
+    version="0.5.2",
     lifespan=lifespan,
 )
 

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -36,7 +36,7 @@ export const metadata: Metadata = {
   ],
 };
 
-const VERSION = '0.5.0';
+const VERSION = '0.5.2';
 
 export default function RootLayout({
   children,

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumin-dashboard",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/integrations/mastra/package.json
+++ b/packages/integrations/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/mastra",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "description": "Lumin exporter for Mastra agents \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/integrations/openclaw-diagnostics/package.json
+++ b/packages/integrations/openclaw-diagnostics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/openclaw-diagnostics",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Lumin observability + Agent Firewall for OpenClaw \u2014 captures prompts, responses, tool I/O, and synchronously enforces firewall policies on every tool call.",
   "homepage": "https://github.com/amitbidlan/zistica-lumin/tree/main/packages/integrations/openclaw-diagnostics",
   "repository": {

--- a/packages/integrations/openclaw/package.json
+++ b/packages/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/openclaw",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "description": "Lumin exporter for OpenClaw agents \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/integrations/voltagent/package.json
+++ b/packages/integrations/voltagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/voltagent",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "description": "Lumin exporter for VoltAgent \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lumin"
-version = "0.5.0"
+version = "0.5.2"
 description = "Local-first AI agent observability SDK"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/sdk",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "description": "Local-first AI agent observability SDK (TypeScript)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Patch release driven by PR #78 (OpenClaw plugin LLM-side firewall hooks). All 9 lockstep version locations bumped 0.5.0/0.5.1 → 0.5.2:

- ``packages/api/main.py``
- ``packages/sdk-python/pyproject.toml``
- ``packages/sdk-typescript/package.json``
- ``packages/dashboard/package.json``
- ``packages/dashboard/app/layout.tsx``
- ``packages/integrations/openclaw/package.json``
- ``packages/integrations/mastra/package.json``
- ``packages/integrations/voltagent/package.json``
- ``packages/integrations/openclaw-diagnostics/package.json``

## What's actually new in v0.5.2

**``@lumin-io/openclaw-diagnostics``** — LLM-message-side firewall hooks (PR #78):
- ``before_prompt_build`` → calls ``decide(before_proxy_call)``; injects security directive on block
- ``before_agent_reply`` → calls ``decide(after_proxy_call)``; replaces reply on block / rewrite

Other packages: no functional changes, lockstep version bump only.

## Post-merge

Tag ``v0.5.2`` to fire the publish workflow:

```
git tag v0.5.2
git push origin v0.5.2
```

That will publish:
- Docker: ``zistica/lumin:0.5.2`` + ``:latest``
- npm: ``@lumin-io/{openclaw,mastra,voltagent,openclaw-diagnostics}@0.5.2``

Then your bot can pick it up:
```
npm install @lumin-io/openclaw-diagnostics@0.5.2
```