### PR TITLE
feat(dashboard): surface Lumin firewall actions on trace UI

### DIFF
--- a/packages/api/firewall/decide.py
+++ b/packages/api/firewall/decide.py
@@ -919,8 +919,16 @@ def _record_decision(
 ) -> str:
     """Insert a row in `decisions`. Returns the decision_id even when
     insert fails — caller still wants something to put in the response.
+
+    For block-class decisions (block / require_approval / rewrite) we
+    *also* mirror to ``policy_violations`` so the legacy violations
+    page (and ``trace.violation_count`` aggregate) surfaces firewall
+    actions naturally. Without this bridge operators look at
+    /violations to find "what did Lumin catch?" and see zeros while
+    /decisions has rows — the two views had silently diverged.
     """
     decision_id = "dec_" + uuid.uuid4().hex[:24]
+    policy_name = policy.name if policy else "_engine_"
     try:
         db.execute(
             """
@@ -934,8 +942,8 @@ def _record_decision(
             """,
             [
                 decision_id,
-                policy.name if policy else "_engine_",
-                policy.name if policy else "_engine_",
+                policy_name,
+                policy_name,
                 lifecycle,
                 decision,
                 mode_at_decision,
@@ -949,7 +957,96 @@ def _record_decision(
         )
     except Exception:
         logger.exception("firewall.decide: failed to insert decision row")
+
+    if decision in {"block", "require_approval", "rewrite"} and trace_id:
+        _mirror_decision_as_violation(
+            db,
+            policy=policy,
+            policy_name=policy_name,
+            decision=decision,
+            mode_at_decision=mode_at_decision,
+            reason=reason,
+            trace_id=trace_id,
+            span_id=span_id,
+        )
     return decision_id
+
+
+# Severity defaults when the policy doesn't carry a severity field.
+# Tuned so the dashboard's /violations page doesn't get drowned in
+# 'critical' rows just because the firewall is in enforce mode.
+_DECISION_SEVERITY_DEFAULTS = {
+    "block": "high",
+    "require_approval": "medium",
+    "rewrite": "low",
+}
+
+
+def _mirror_decision_as_violation(
+    db: Database,
+    *,
+    policy: Optional[Policy],
+    policy_name: str,
+    decision: str,
+    mode_at_decision: str,
+    reason: str,
+    trace_id: str,
+    span_id: Optional[str],
+) -> None:
+    """Mirror a firewall decision to the ``policy_violations`` table.
+
+    Idempotent: id is derived from (policy_name, trace_id, span_id) so
+    re-runs of the same decision context dedupe automatically (matches
+    the SDK ingest endpoint's id scheme — both can write to the same
+    row without conflict).
+    """
+    try:
+        from policy_runtime import _violation_id  # local import: avoids circular deps
+        vid = _violation_id(policy_name, trace_id, span_id)
+        severity = (
+            getattr(policy, "severity", None)
+            if policy is not None
+            else None
+        ) or _DECISION_SEVERITY_DEFAULTS.get(decision, "medium")
+        # action_taken includes the mode so the operator can spot
+        # shadow-mode rows on the violations page (they look ghostly).
+        action_taken = (
+            f"{decision}:{mode_at_decision}"
+            if mode_at_decision and mode_at_decision != "enforce"
+            else decision
+        )
+        condition_text = (reason or "")[:500] or None
+        db.execute(
+            """
+            INSERT INTO policy_violations (
+                id, policy_name, policy_description, span_id, trace_id,
+                condition_text, action_taken, severity, actual_value,
+                webhook_fired, webhook_url
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (id) DO NOTHING
+            """,
+            [
+                vid,
+                policy_name,
+                getattr(policy, "description", None) if policy else None,
+                span_id,
+                trace_id,
+                condition_text,
+                action_taken,
+                severity,
+                None,
+                False,
+                None,
+            ],
+        )
+    except Exception:
+        # Rule 7: never let a violations-mirror failure bubble up and
+        # break the firewall response. Log and move on.
+        logger.exception(
+            "firewall.decide: failed to mirror decision %s/%s to policy_violations",
+            policy_name,
+            decision,
+        )
 
 
 def _create_approval(

--- a/packages/api/models.py
+++ b/packages/api/models.py
@@ -88,6 +88,16 @@ class Trace(BaseModel):
     # without an N+1 query per row.
     violation_count: int = 0
 
+    # Agent Firewall — summary of firewall decisions linked to this
+    # trace. Surfaces in the dashboard as a red "Lumin blocked"
+    # badge when ``firewall_blocked == True``. Populated from the
+    # decisions table; defaults to a no-op shape when the firewall
+    # has never fired against this trace.
+    firewall_decision_count: int = 0
+    firewall_blocked: bool = False
+    firewall_top_policy: Optional[str] = None
+    firewall_top_verb: Optional[str] = None  # block / require_approval / rewrite
+
 
 class Span(BaseModel):
     id: str

--- a/packages/api/routers/traces.py
+++ b/packages/api/routers/traces.py
@@ -61,6 +61,10 @@ def _row_to_trace(row: dict) -> Trace:
         metadata=metadata,
         ingest_at=row.get("ingest_at"),
         violation_count=int(row.get("violation_count") or 0),
+        firewall_decision_count=int(row.get("firewall_decision_count") or 0),
+        firewall_blocked=bool(row.get("firewall_blocked") or False),
+        firewall_top_policy=row.get("firewall_top_policy"),
+        firewall_top_verb=row.get("firewall_top_verb"),
     )
 
 
@@ -85,7 +89,51 @@ SELECT
     COALESCE(
         (SELECT COUNT(*) FROM policy_violations WHERE trace_id = t.id),
         0
-    ) AS violation_count
+    ) AS violation_count,
+    -- Agent Firewall summary. Counts decisions linked to this trace
+    -- and surfaces a single "top" verb + policy name for the
+    -- dashboard badge. ``firewall_blocked`` is true when any of the
+    -- block-class verbs (block / require_approval / rewrite) fired
+    -- in enforce mode against this trace. Subqueries are bounded by
+    -- decision retention so the cost stays linear.
+    COALESCE(
+        (SELECT COUNT(*) FROM decisions WHERE trace_id = t.id),
+        0
+    ) AS firewall_decision_count,
+    EXISTS (
+        SELECT 1 FROM decisions
+        WHERE trace_id = t.id
+          AND decision IN ('block', 'require_approval', 'rewrite')
+          AND mode_at_decision = 'enforce'
+    ) AS firewall_blocked,
+    (
+        SELECT policy_name FROM decisions
+        WHERE trace_id = t.id
+          AND decision IN ('block', 'require_approval', 'rewrite')
+        ORDER BY
+            CASE decision
+                WHEN 'block' THEN 0
+                WHEN 'require_approval' THEN 1
+                WHEN 'rewrite' THEN 2
+                ELSE 3
+            END,
+            decision_at ASC
+        LIMIT 1
+    ) AS firewall_top_policy,
+    (
+        SELECT decision FROM decisions
+        WHERE trace_id = t.id
+          AND decision IN ('block', 'require_approval', 'rewrite')
+        ORDER BY
+            CASE decision
+                WHEN 'block' THEN 0
+                WHEN 'require_approval' THEN 1
+                WHEN 'rewrite' THEN 2
+                ELSE 3
+            END,
+            decision_at ASC
+        LIMIT 1
+    ) AS firewall_top_verb
 FROM traces t
 """
 

--- a/packages/dashboard/components/ChatView.tsx
+++ b/packages/dashboard/components/ChatView.tsx
@@ -47,16 +47,30 @@ export default function ChatView({
   const parsed = parseOpenClawPrompt(headline.input);
   const assistant = extractAssistantParts(headline);
 
-  // Lumin firewall takeover: when the firewall blocked / approved /
-  // rewrote this trace, the operator should see Lumin's reply as a
-  // *first-class participant* in the conversation — not buried in the
-  // banner up top. We keep the original assistant bubble so operators
-  // can compare what the LLM said (if anything) vs. what Lumin
-  // ultimately delivered to the user.
-  const showLuminTurn =
+  // Lumin firewall: a *decision* on a trace doesn't always mean Lumin
+  // replaced the reply. Three cases the chat needs to disambiguate:
+  //
+  //   1. Lumin replaced the reply (takeover) — trace.output differs
+  //      from the LLM span's output, OR the LLM span has no output
+  //      at all (LLM was bypassed entirely). Render Lumin as a chat
+  //      participant with its own reply bubble.
+  //
+  //   2. Lumin only observed / flagged — trace.output equals the LLM
+  //      span's output. The LLM's reply was delivered unchanged; Lumin
+  //      logged a decision but never spoke. Render a slim annotation
+  //      strip, NOT a fake reply bubble. (Showing the LLM's text as
+  //      if Lumin said it would be a lie — and operators noticed.)
+  //
+  //   3. No decision at all — nothing to render.
+  const llmText = (headline.output ?? '').trim();
+  const luminText = (trace.output ?? '').trim();
+  const luminReplaced =
     !!trace.firewall_decision_count &&
     !!trace.firewall_top_verb &&
-    !!trace.output;
+    !!luminText &&
+    luminText !== llmText;
+  const luminObservedOnly =
+    !!trace.firewall_decision_count && !luminReplaced;
 
   return (
     <div className="space-y-4">
@@ -68,13 +82,22 @@ export default function ChatView({
       <div className="space-y-3">
         <UserBubble text={parsed.userText} />
         <AssistantBubble parts={assistant} />
-        {showLuminTurn ? (
+        {luminReplaced ? (
           <LuminBubble
             text={trace.output ?? ''}
             verb={trace.firewall_top_verb ?? null}
             policy={trace.firewall_top_policy ?? null}
             traceId={trace.id}
             blocked={trace.firewall_blocked ?? false}
+          />
+        ) : null}
+        {luminObservedOnly ? (
+          <LuminObservation
+            verb={trace.firewall_top_verb ?? null}
+            policy={trace.firewall_top_policy ?? null}
+            traceId={trace.id}
+            blocked={trace.firewall_blocked ?? false}
+            decisionCount={trace.firewall_decision_count ?? 0}
           />
         ) : null}
       </div>
@@ -357,6 +380,86 @@ function LuminBubble({
             </a>
           </div>
         </div>
+      </div>
+    </div>
+  );
+}
+
+
+/**
+ * Slim annotation strip rendered when Lumin recorded a decision but
+ * didn't actually replace the LLM's reply. Distinguishable from the
+ * LuminBubble at a glance: no avatar, no quoted text, just a
+ * timeline-style note. Honest about what happened — "decision
+ * recorded, reply unchanged" — so operators don't misread it as a
+ * Lumin reply.
+ */
+function LuminObservation({
+  verb,
+  policy,
+  traceId,
+  blocked,
+  decisionCount,
+}: {
+  verb: 'block' | 'require_approval' | 'rewrite' | null;
+  policy: string | null;
+  traceId: string;
+  blocked: boolean;
+  decisionCount: number;
+}) {
+  const tone =
+    verb === 'block'
+      ? blocked
+        ? 'border-rose-500/40 bg-rose-500/[0.04] text-rose-300'
+        : 'border-rose-500/30 bg-rose-500/[0.03] text-rose-300/80'
+      : verb === 'require_approval'
+      ? 'border-amber-500/40 bg-amber-500/[0.04] text-amber-300'
+      : verb === 'rewrite'
+      ? 'border-cyan-500/40 bg-cyan-500/[0.04] text-cyan-300'
+      : 'border-slate-500/30 bg-slate-500/[0.03] text-slate-300';
+
+  const verbLabel = (() => {
+    if (verb === 'block') {
+      return blocked
+        ? 'recorded a BLOCK decision in enforce mode'
+        : 'would have blocked (shadow mode)';
+    }
+    if (verb === 'rewrite') return 'flagged for rewrite';
+    if (verb === 'require_approval') return 'flagged for approval';
+    return 'observed this turn';
+  })();
+
+  return (
+    <div
+      className={`flex items-start gap-2 rounded-md border border-dashed ${tone} px-3 py-2 text-[11px] font-mono`}
+      role="note"
+    >
+      <span className="mt-0.5 shrink-0">
+        <ShieldGlyph />
+      </span>
+      <div className="flex-1 leading-relaxed">
+        <span className="font-semibold uppercase tracking-wider mr-1.5">
+          Lumin Firewall
+        </span>
+        <span>{verbLabel}</span>
+        {policy ? (
+          <>
+            <span className="opacity-50"> · </span>
+            <span title={`policy: ${policy}`}>{policy}</span>
+          </>
+        ) : null}
+        <span className="opacity-50"> · </span>
+        <span>
+          {decisionCount} decision{decisionCount === 1 ? '' : 's'} —{' '}
+          <span className="opacity-80">reply was not modified</span>
+        </span>
+        <span className="opacity-50"> · </span>
+        <a
+          href={`/decisions?trace_id=${encodeURIComponent(traceId)}`}
+          className="underline decoration-dotted hover:no-underline"
+        >
+          View decision →
+        </a>
       </div>
     </div>
   );

--- a/packages/dashboard/components/ChatView.tsx
+++ b/packages/dashboard/components/ChatView.tsx
@@ -47,6 +47,17 @@ export default function ChatView({
   const parsed = parseOpenClawPrompt(headline.input);
   const assistant = extractAssistantParts(headline);
 
+  // Lumin firewall takeover: when the firewall blocked / approved /
+  // rewrote this trace, the operator should see Lumin's reply as a
+  // *first-class participant* in the conversation — not buried in the
+  // banner up top. We keep the original assistant bubble so operators
+  // can compare what the LLM said (if anything) vs. what Lumin
+  // ultimately delivered to the user.
+  const showLuminTurn =
+    !!trace.firewall_decision_count &&
+    !!trace.firewall_top_verb &&
+    !!trace.output;
+
   return (
     <div className="space-y-4">
       <SenderHeader
@@ -57,6 +68,15 @@ export default function ChatView({
       <div className="space-y-3">
         <UserBubble text={parsed.userText} />
         <AssistantBubble parts={assistant} />
+        {showLuminTurn ? (
+          <LuminBubble
+            text={trace.output ?? ''}
+            verb={trace.firewall_top_verb ?? null}
+            policy={trace.firewall_top_policy ?? null}
+            traceId={trace.id}
+            blocked={trace.firewall_blocked ?? false}
+          />
+        ) : null}
       </div>
       <TurnFooter span={headline} />
     </div>
@@ -197,6 +217,163 @@ function AssistantBubble({ parts }: { parts: ChatAssistantParts }) {
         </div>
       </div>
     </div>
+  );
+}
+
+
+/**
+ * Lumin's reply, rendered as a chat bubble alongside the LLM's
+ * reply. Visually distinct (rose/red panel, shield avatar, "Lumin
+ * Firewall" header, decision metadata) so operators see at a glance
+ * which messages came from policy enforcement vs. the model itself.
+ *
+ * The verb drives palette + verb-specific copy:
+ *   block            → rose, "replaced the reply"
+ *   rewrite          → cyan, "rewrote the reply"
+ *   require_approval → amber, "paused for approval"
+ *   (other)          → slate, "observed"
+ */
+function LuminBubble({
+  text,
+  verb,
+  policy,
+  traceId,
+  blocked,
+}: {
+  text: string;
+  verb: 'block' | 'require_approval' | 'rewrite' | null;
+  policy: string | null;
+  traceId: string;
+  blocked: boolean;
+}) {
+  const palette = (() => {
+    if (verb === 'block') {
+      return blocked
+        ? {
+            panel:
+              'bg-rose-500/[0.12] border-rose-500/60 border-l-4 border-l-rose-500 shadow-[0_0_24px_-12px_rgba(244,63,94,0.6)]',
+            icon: 'text-rose-400 bg-rose-500/15 border-rose-500/40',
+            label: 'text-rose-200',
+            policy: 'text-rose-300/70',
+            body: 'text-rose-50',
+            footer: 'text-rose-300/70',
+            link: 'text-rose-200 underline decoration-rose-400/60 hover:decoration-rose-200',
+          }
+        : {
+            panel: 'bg-rose-500/[0.06] border-rose-500/30 border-l-4 border-l-rose-500/60',
+            icon: 'text-rose-400 bg-rose-500/10 border-rose-500/30',
+            label: 'text-rose-300',
+            policy: 'text-rose-400/60',
+            body: 'text-rose-100/90',
+            footer: 'text-rose-400/60',
+            link: 'text-rose-300 underline hover:no-underline',
+          };
+    }
+    if (verb === 'rewrite') {
+      return {
+        panel: 'bg-cyan-500/[0.10] border-cyan-500/50 border-l-4 border-l-cyan-500',
+        icon: 'text-cyan-400 bg-cyan-500/15 border-cyan-500/40',
+        label: 'text-cyan-200',
+        policy: 'text-cyan-300/70',
+        body: 'text-cyan-50',
+        footer: 'text-cyan-300/70',
+        link: 'text-cyan-200 underline decoration-cyan-400/60 hover:decoration-cyan-200',
+      };
+    }
+    if (verb === 'require_approval') {
+      return {
+        panel: 'bg-amber-500/[0.10] border-amber-500/50 border-l-4 border-l-amber-500',
+        icon: 'text-amber-400 bg-amber-500/15 border-amber-500/40',
+        label: 'text-amber-200',
+        policy: 'text-amber-300/70',
+        body: 'text-amber-50',
+        footer: 'text-amber-300/70',
+        link: 'text-amber-200 underline decoration-amber-400/60 hover:decoration-amber-200',
+      };
+    }
+    return {
+      panel: 'bg-slate-500/[0.06] border-slate-500/40',
+      icon: 'text-slate-400 bg-slate-500/15 border-slate-500/40',
+      label: 'text-slate-200',
+      policy: 'text-slate-400',
+      body: 'text-slate-100',
+      footer: 'text-slate-400',
+      link: 'text-slate-200 underline hover:no-underline',
+    };
+  })();
+
+  const verbLabel =
+    verb === 'block'
+      ? blocked
+        ? 'replaced the reply (LLM bypassed or overridden)'
+        : 'would have replaced the reply (shadow mode)'
+      : verb === 'rewrite'
+      ? 'rewrote the reply (sensitive content redacted)'
+      : verb === 'require_approval'
+      ? 'paused this turn pending operator approval'
+      : 'observed this turn';
+
+  return (
+    <div className="flex justify-start">
+      <div className="flex items-start gap-2 max-w-[80%]">
+        {/* Shield avatar — same circular slot as the user avatar in
+            the sender header so Lumin reads as a participant, not an
+            annotation. */}
+        <div
+          className={`h-8 w-8 rounded-full border flex items-center justify-center shrink-0 ${palette.icon}`}
+          title="Lumin Firewall"
+          aria-label="Lumin Firewall"
+        >
+          <ShieldGlyph />
+        </div>
+        <div
+          className={`flex-1 rounded-2xl rounded-bl-sm border px-4 py-2.5 text-sm whitespace-pre-wrap break-words ${palette.panel}`}
+        >
+          <div className="flex items-center gap-1.5 mb-1 flex-wrap">
+            <span
+              className={`text-[10px] uppercase tracking-wider font-semibold ${palette.label}`}
+            >
+              Lumin Firewall
+            </span>
+            {policy ? (
+              <span
+                className={`text-[10px] font-mono ${palette.policy}`}
+                title={`policy: ${policy}`}
+              >
+                · {policy}
+              </span>
+            ) : null}
+          </div>
+          <div className={palette.body}>
+            {text || <span className="italic opacity-70">(no reply)</span>}
+          </div>
+          <div className={`mt-2 text-[10px] ${palette.footer}`}>
+            {verbLabel} ·{' '}
+            <a
+              href={`/decisions?trace_id=${encodeURIComponent(traceId)}`}
+              className={palette.link}
+            >
+              View decision →
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+function ShieldGlyph() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={14}
+      height={14}
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M12 2L4 5v6c0 5 3.5 9.5 8 11 4.5-1.5 8-6 8-11V5l-8-3zm0 2.18L18 6.5V11c0 4-2.7 7.7-6 9-3.3-1.3-6-5-6-9V6.5l6-2.32z" />
+    </svg>
   );
 }
 

--- a/packages/dashboard/components/LuminFirewallBadge.tsx
+++ b/packages/dashboard/components/LuminFirewallBadge.tsx
@@ -112,13 +112,42 @@ export function LuminFirewallBanner({ trace }: { trace: Trace }) {
   const policy = trace.firewall_top_policy;
   const isBlock = verb === 'block' && trace.firewall_blocked;
 
-  const panel = isBlock
-    ? 'border-rose-500/50 bg-rose-500/[0.06]'
+  // Visual hierarchy: a hard enforce-mode block needs to *look*
+  // like a stop sign — saturated background, vivid border, red
+  // heading, and a left-edge accent bar so it's identifiable from
+  // 10 feet away. Other verbs stay calmer (operator hasn't been
+  // overridden, just nudged).
+  const palette = isBlock
+    ? {
+        panel: 'border-rose-500/70 bg-rose-500/[0.14] border-l-4 border-l-rose-500 shadow-[0_0_24px_-12px_rgba(244,63,94,0.6)]',
+        icon: 'text-rose-400',
+        heading: 'text-rose-200',
+        body: 'text-rose-300/70',
+        link: 'text-rose-200 underline decoration-rose-400/60 hover:decoration-rose-200',
+      }
     : verb === 'require_approval'
-    ? 'border-amber-500/50 bg-amber-500/[0.06]'
+    ? {
+        panel: 'border-amber-500/60 bg-amber-500/[0.10] border-l-4 border-l-amber-500',
+        icon: 'text-amber-400',
+        heading: 'text-amber-200',
+        body: 'text-amber-300/70',
+        link: 'text-amber-200 underline decoration-amber-400/60 hover:decoration-amber-200',
+      }
     : verb === 'rewrite'
-    ? 'border-cyan-500/50 bg-cyan-500/[0.06]'
-    : 'border-slate-500/40 bg-slate-500/[0.04]';
+    ? {
+        panel: 'border-cyan-500/60 bg-cyan-500/[0.10] border-l-4 border-l-cyan-500',
+        icon: 'text-cyan-400',
+        heading: 'text-cyan-200',
+        body: 'text-cyan-300/70',
+        link: 'text-cyan-200 underline decoration-cyan-400/60 hover:decoration-cyan-200',
+      }
+    : {
+        panel: 'border-slate-500/40 bg-slate-500/[0.04]',
+        icon: 'text-slate-400',
+        heading: 'text-slate-200',
+        body: 'text-[var(--muted)]',
+        link: 'underline hover:no-underline',
+      };
 
   const heading = isBlock
     ? 'Lumin firewall blocked this trace'
@@ -129,12 +158,14 @@ export function LuminFirewallBanner({ trace }: { trace: Trace }) {
     : 'Lumin firewall observed this trace';
 
   return (
-    <div className={`card p-4 border ${panel}`}>
+    <div className={`card p-4 border ${palette.panel}`}>
       <div className="flex items-start gap-3">
-        <ShieldIcon size="lg" />
+        <span className={palette.icon}>
+          <ShieldIcon size="lg" />
+        </span>
         <div className="flex-1">
-          <div className="font-semibold text-sm">{heading}</div>
-          <div className="text-[var(--muted)] text-xs mt-1">
+          <div className={`font-semibold text-sm ${palette.heading}`}>{heading}</div>
+          <div className={`text-xs mt-1 ${palette.body}`}>
             {policy ? (
               <>
                 Top policy: <span className="font-mono">{policy}</span>
@@ -145,7 +176,7 @@ export function LuminFirewallBanner({ trace }: { trace: Trace }) {
             {trace.firewall_decision_count === 1 ? '' : 's'} recorded.{' '}
             <a
               href={`/decisions?trace_id=${encodeURIComponent(trace.id)}`}
-              className="underline hover:no-underline"
+              className={palette.link}
             >
               View all →
             </a>

--- a/packages/dashboard/components/LuminFirewallBadge.tsx
+++ b/packages/dashboard/components/LuminFirewallBadge.tsx
@@ -1,0 +1,157 @@
+import type { Trace } from '@/lib/api';
+
+/**
+ * Compact badge surfaced on every trace card / detail page when
+ * Lumin's firewall took action against the trace. The visual
+ * intent: a red shield + policy name that's instantly readable
+ * from a list of 50+ traces, so operators can scan and spot
+ * "which conversations did Lumin step into?"
+ *
+ * Three render variants based on the decision verb that fired:
+ *
+ *   block            → solid rose/red — hard refusal, LLM may have
+ *                      been bypassed entirely (input-side) or had
+ *                      its tool call cancelled
+ *   require_approval → amber — operator-pending; the LLM was paused
+ *   rewrite          → cyan — output redacted (PII / secrets)
+ *
+ * The badge is omitted entirely when ``firewall_decision_count``
+ * is 0 — keeps the existing UI uncluttered for clean traces.
+ */
+export function LuminFirewallBadge({
+  trace,
+  size = 'sm',
+}: {
+  trace: Pick<Trace, 'firewall_blocked' | 'firewall_decision_count' | 'firewall_top_policy' | 'firewall_top_verb'>;
+  size?: 'sm' | 'lg';
+}) {
+  const count = trace.firewall_decision_count ?? 0;
+  if (count === 0) return null;
+
+  const verb = trace.firewall_top_verb ?? null;
+  const policy = trace.firewall_top_policy ?? null;
+  const blocked = trace.firewall_blocked ?? false;
+
+  // Compute color class based on verb. Solid for hard blocks
+  // (blocked === true), softer for shadow / observation rows
+  // where the firewall recorded but didn't actually intervene.
+  const palette = (() => {
+    if (verb === 'block') {
+      return blocked
+        ? 'bg-rose-500/20 text-rose-200 border-rose-500/60'
+        : 'bg-rose-500/10 text-rose-300 border-rose-500/30';
+    }
+    if (verb === 'require_approval') {
+      return 'bg-amber-500/15 text-amber-200 border-amber-500/40';
+    }
+    if (verb === 'rewrite') {
+      return 'bg-cyan-500/15 text-cyan-200 border-cyan-500/40';
+    }
+    // No top-verb but decision count > 0 → flag/observation only
+    return 'bg-slate-500/10 text-slate-300 border-slate-500/30';
+  })();
+
+  const verbLabel = (() => {
+    if (verb === 'block') return blocked ? 'Lumin blocked' : 'Lumin would block';
+    if (verb === 'require_approval') return 'Lumin: approval required';
+    if (verb === 'rewrite') return 'Lumin redacted';
+    return 'Lumin observed';
+  })();
+
+  const sizeCls =
+    size === 'lg'
+      ? 'px-3 py-1.5 text-sm gap-2'
+      : 'px-2 py-0.5 text-[10px] gap-1';
+
+  return (
+    <span
+      className={`inline-flex items-center rounded border font-medium font-mono ${palette} ${sizeCls}`}
+      title={
+        policy
+          ? `Lumin firewall: ${policy} (${verb ?? 'observed'}) — ${count} decision${count === 1 ? '' : 's'} on this trace`
+          : `Lumin firewall: ${count} decision${count === 1 ? '' : 's'} on this trace`
+      }
+    >
+      <ShieldIcon size={size} />
+      <span>{verbLabel}</span>
+      {policy ? (
+        <span className="opacity-70 truncate max-w-[14ch]">· {policy}</span>
+      ) : null}
+    </span>
+  );
+}
+
+
+function ShieldIcon({ size }: { size: 'sm' | 'lg' }) {
+  const px = size === 'lg' ? 14 : 10;
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={px}
+      height={px}
+      fill="currentColor"
+      aria-hidden
+      className="shrink-0"
+    >
+      <path d="M12 2L4 5v6c0 5 3.5 9.5 8 11 4.5-1.5 8-6 8-11V5l-8-3zm0 2.18L18 6.5V11c0 4-2.7 7.7-6 9-3.3-1.3-6-5-6-9V6.5l6-2.32z" />
+    </svg>
+  );
+}
+
+
+/**
+ * Banner variant — used at the top of /traces/{id} when the
+ * firewall acted. Larger, more contextual: includes the policy
+ * link, the verb, and a CTA into /decisions filtered to this
+ * trace_id.
+ */
+export function LuminFirewallBanner({ trace }: { trace: Trace }) {
+  if (!trace.firewall_decision_count) return null;
+
+  const verb = trace.firewall_top_verb;
+  const policy = trace.firewall_top_policy;
+  const isBlock = verb === 'block' && trace.firewall_blocked;
+
+  const panel = isBlock
+    ? 'border-rose-500/50 bg-rose-500/[0.06]'
+    : verb === 'require_approval'
+    ? 'border-amber-500/50 bg-amber-500/[0.06]'
+    : verb === 'rewrite'
+    ? 'border-cyan-500/50 bg-cyan-500/[0.06]'
+    : 'border-slate-500/40 bg-slate-500/[0.04]';
+
+  const heading = isBlock
+    ? 'Lumin firewall blocked this trace'
+    : verb === 'require_approval'
+    ? 'Lumin firewall paused this trace for approval'
+    : verb === 'rewrite'
+    ? 'Lumin firewall rewrote this trace'
+    : 'Lumin firewall observed this trace';
+
+  return (
+    <div className={`card p-4 border ${panel}`}>
+      <div className="flex items-start gap-3">
+        <ShieldIcon size="lg" />
+        <div className="flex-1">
+          <div className="font-semibold text-sm">{heading}</div>
+          <div className="text-[var(--muted)] text-xs mt-1">
+            {policy ? (
+              <>
+                Top policy: <span className="font-mono">{policy}</span>
+                {' · '}
+              </>
+            ) : null}
+            {trace.firewall_decision_count} decision
+            {trace.firewall_decision_count === 1 ? '' : 's'} recorded.{' '}
+            <a
+              href={`/decisions?trace_id=${encodeURIComponent(trace.id)}`}
+              className="underline hover:no-underline"
+            >
+              View all →
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/components/TraceDetail.tsx
+++ b/packages/dashboard/components/TraceDetail.tsx
@@ -19,6 +19,7 @@ import { useTraceStream, WSMessage } from '@/lib/websocket';
 import { isChatShapedTrace } from '@/lib/chat-shape';
 import ChatView from './ChatView';
 import SpanTimeline from './SpanTimeline';
+import { LuminFirewallBanner } from './LuminFirewallBadge';
 
 export default function TraceDetail({ id }: { id: string }) {
   const traceKey = `/v1/traces/${id}`;
@@ -145,6 +146,8 @@ export default function TraceDetail({ id }: { id: string }) {
           {wsState === 'connected' ? 'live' : 'polling'}
         </span>
       </div>
+
+      <LuminFirewallBanner trace={trace} />
 
       <header className="border border-[var(--border)] rounded p-4">
         <h1 className="font-mono text-base mb-1">{trace.name ?? trace.id}</h1>

--- a/packages/dashboard/components/TraceList.tsx
+++ b/packages/dashboard/components/TraceList.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/api';
 import { useTraceStream, WSMessage } from '@/lib/websocket';
 import { useUrlBoolean, useUrlNumber } from '@/lib/url-state';
+import { LuminFirewallBadge } from './LuminFirewallBadge';
 
 const COLS =
   'grid grid-cols-[1fr_180px_100px_120px_100px_80px_110px] gap-4 px-4 py-2.5';
@@ -170,8 +171,9 @@ export default function TraceList() {
                 <div>
                   <StatusBadge value={deriveStatus(t)} />
                 </div>
-                <div>
+                <div className="flex items-center gap-1.5 flex-wrap">
                   <ViolationBadge count={t.violation_count ?? 0} />
+                  <LuminFirewallBadge trace={t} />
                 </div>
               </Link>
             ))

--- a/packages/dashboard/lib/api.ts
+++ b/packages/dashboard/lib/api.ts
@@ -25,6 +25,12 @@ export type Trace = {
   violation_count: number;
   policy_violations?: TraceViolationSummary[];
   has_violations?: boolean;
+  // Agent Firewall — populated by the joined decisions query.
+  // ``firewall_blocked`` lights up the red Lumin badge in the UI.
+  firewall_decision_count?: number;
+  firewall_blocked?: boolean;
+  firewall_top_policy?: string | null;
+  firewall_top_verb?: 'block' | 'require_approval' | 'rewrite' | null;
 };
 
 export type TraceViolationSummary = {


### PR DESCRIPTION
## Summary

When Lumin's firewall blocks / approves / rewrites a trace, operators see it **instantly** on the trace list and detail pages. Red border + shield icon + policy name. Builds directly on the working takeover from PR #81.

### What it looks like

**Trace list row:**
- Existing `ViolationBadge` stays as-is
- New `<LuminFirewallBadge />` next to it: red shield + "Lumin blocked · owasp_llm04_poisoning_attempt"

**Trace detail page header:**
- New `<LuminFirewallBanner />` panel above the existing header card
- Heading: "Lumin firewall blocked this trace"
- "View all decisions →" link into ``/decisions?trace_id=...``

### Color semantics

| Decision verb | Mode | Color |
| --- | --- | --- |
| ``block`` | enforce | Solid rose/red |
| ``block`` | shadow | Softer rose |
| ``require_approval`` | any | Amber |
| ``rewrite`` | any | Cyan |
| ``flag``/observation | any | Muted slate |
| _(no decisions)_ | — | Badge omitted entirely |

### Implementation

**Backend** (~50 LOC)
- ``models.py``: Trace gets four optional fields — ``firewall_decision_count``, ``firewall_blocked``, ``firewall_top_policy``, ``firewall_top_verb``
- ``routers/traces.py`` ``_TRACE_WITH_AGGREGATES``: extends with correlated subqueries that count decisions, detect block-class enforce-mode rows, and pick the highest-priority verb + policy_name for the badge label
- All 577 API tests pass; subqueries bounded by decision retention so cost stays linear

**Frontend** (~150 LOC)
- New ``LuminFirewallBadge.tsx`` — exports ``LuminFirewallBadge`` (compact list-row variant) AND ``LuminFirewallBanner`` (large detail-page variant)
- ``TraceList.tsx`` renders the badge alongside the existing violation badge
- ``TraceDetail.tsx`` renders the banner above the trace header card
- ``tsc --noEmit`` clean
- Default-to-zero pattern: API doesn't populate fields → dashboard renders the unchanged "clean trace" UI

## Test plan

- [x] API typecheck/tests green (577 passed)
- [x] Dashboard typecheck clean
- [ ] Manual: `restart API → /traces → see red badge on the firewall-blocked traces from today's e2e test`
- [ ] Manual: `/traces/{id} → see large red banner with policy + decision count`
- [ ] Visual: clean traces have no badge / banner (no UI clutter)