### PR TITLE
feat(firewall): ship 10 starter packs + library API (Slice 4 §13)

### DIFF
--- a/packages/api/firewall/library.py
+++ b/packages/api/firewall/library.py
@@ -1,0 +1,321 @@
+"""Starter pack library — §13 of AGENT_FIREWALL_SPEC.md.
+
+Walks ``packages/api/firewall/starter_packs/`` at module load and
+exposes:
+
+  - ``list_packs()`` — metadata for every pack available
+  - ``preview_pack(pack_id)`` — load + return the policies in a pack
+    without writing to the DB (powers the dashboard's library
+    "preview" surface)
+  - ``import_pack(db, pack_id)`` — write the pack's policies into the
+    DB. Idempotent — a duplicate name from a prior import is skipped,
+    not overwritten, so re-importing after operator edits doesn't
+    clobber their tuning.
+
+Pack metadata is derived from the filename + a small in-module
+catalog (display name + category + description) so the YAML files
+themselves stay focused on policies. Adding a new pack to the
+catalog requires:
+
+  1. Drop ``foo.yaml`` into ``starter_packs/``.
+  2. Add an entry to ``_CATALOG`` below.
+  3. Done — ``GET /v1/firewall/library`` surfaces it on the next
+     reload, ``POST /v1/firewall/library/foo/import`` works.
+
+Failure modes follow the §13 / Rule 7 contract:
+
+  - Missing or malformed YAML: skipped at list time, surfaced with
+    a warning. The list endpoint never raises just because one pack
+    is broken.
+  - Import-time policy-name conflict: counted as a skip, not an
+    error; the rest of the pack still imports.
+  - DB unreachable: per-policy try/except so a transient failure
+    on one row doesn't abort the import.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from lumin.policy import Policy, PolicyConfigError, load_policy_engine
+
+import policy_store
+from db import Database
+
+logger = logging.getLogger("lumin.api.firewall.library")
+
+
+_PACK_DIR = Path(__file__).parent / "starter_packs"
+
+
+@dataclass
+class PackMeta:
+    pack_id: str
+    name: str
+    category: str
+    description: str
+    file: Path
+
+
+# Hard-coded catalog. Source of truth for display metadata; the YAML
+# files themselves only declare policies. New packs require a row
+# here OR they're listed with a generic auto-derived display name.
+_CATALOG: Dict[str, Dict[str, str]] = {
+    "owasp_llm_top_10": {
+        "name": "OWASP LLM Top 10 (2025)",
+        "category": "Threat coverage",
+        "description":
+            "15 policies mapping to OWASP LLM01–LLM10. Auto-installed "
+            "on first boot. The baseline every Lumin deployment ships with.",
+    },
+    "owasp_agentic_2025": {
+        "name": "OWASP Agentic AI Top 10 (2025)",
+        "category": "Threat coverage",
+        "description":
+            "Agent-specific threats: memory poisoning, tool misuse, "
+            "privilege compromise, identity spoofing, overreliance.",
+    },
+    "dev_environment_safety": {
+        "name": "Dev environment safety",
+        "category": "Use case",
+        "description":
+            "Conservative defaults for agents with shell + filesystem "
+            "access on a developer's machine. rm -rf, dd, credential "
+            "reads, force-push, curl|sh.",
+    },
+    "customer_support_agent": {
+        "name": "Customer support agent",
+        "category": "Use case",
+        "description":
+            "PII redaction in replies, refund-amount ceilings, brand "
+            "safety, cross-session leakage hints. Tuned for support / "
+            "helpdesk bots.",
+    },
+    "code_assistant": {
+        "name": "Code-assistant agent",
+        "category": "Use case",
+        "description":
+            "eval / unsafe deserialization, .git internals writes, "
+            "supply-chain registries, hardcoded secrets, TLS disable, "
+            "world-writable chmod.",
+    },
+    "compliance_gdpr": {
+        "name": "Compliance — GDPR",
+        "category": "Compliance",
+        "description":
+            "Advisory rules aligned to GDPR Art. 5 + Art. 9. Special "
+            "categories, EU PII, profiling lawful-basis flags, "
+            "right-to-erasure detection.",
+    },
+    "compliance_hipaa": {
+        "name": "Compliance — HIPAA",
+        "category": "Compliance",
+        "description":
+            "Aligned to HIPAA Privacy Rule § 164.514 Safe Harbor. SSN, "
+            "MRN, health-plan IDs, diagnosis-with-name, PHI tool-call "
+            "audit.",
+    },
+    "compliance_pci_dss": {
+        "name": "Compliance — PCI DSS v4.0",
+        "category": "Compliance",
+        "description":
+            "Hard-block PAN / CVV / magnetic-stripe / PIN in output "
+            "and tool input. Strict-liability posture.",
+    },
+    "framework_mastra": {
+        "name": "Framework — Mastra",
+        "category": "Framework",
+        "description":
+            "Defaults for agents built on Mastra. Workflow-step "
+            "approvals, web-fetch SSRF, memory poisoning.",
+    },
+    "framework_langgraph": {
+        "name": "Framework — LangGraph",
+        "category": "Framework",
+        "description":
+            "Defaults for LangGraph multi-node flows. Recursion warns, "
+            "checkpointer writes, dynamic subgraph approvals.",
+    },
+    "cost_guards": {
+        "name": "Cost guards",
+        "category": "Operational",
+        "description":
+            "Per-session and per-agent token caps; tool-call burst "
+            "rate limits; oversize-input flags. Protects against "
+            "runaway loops and cost spikes.",
+    },
+}
+
+
+# ---- public API ------------------------------------------------------------
+
+
+def list_packs(directory: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Return metadata for every pack available. Each entry includes
+    pack_id, display name, category, description, and policy count.
+
+    Packs that fail to load (malformed YAML, etc.) are filtered out
+    with a warning — the caller never sees them.
+    """
+    pack_dir = directory or _PACK_DIR
+    if not pack_dir.exists():
+        return []
+
+    out: List[Dict[str, Any]] = []
+    for path in sorted(pack_dir.glob("*.yaml")):
+        pack_id = path.stem
+        try:
+            engine = load_policy_engine(str(path))
+        except PolicyConfigError as e:
+            logger.warning("library: pack %s rejected: %s", pack_id, e)
+            continue
+        except Exception:
+            logger.exception("library: pack %s failed to load", pack_id)
+            continue
+        if engine is None:
+            continue
+
+        meta = _CATALOG.get(pack_id)
+        out.append({
+            "pack_id": pack_id,
+            "name": (meta or {}).get("name", _humanize(pack_id)),
+            "category": (meta or {}).get("category", "Custom"),
+            "description": (meta or {}).get("description", ""),
+            "policy_count": len(engine.policies),
+            "lifecycles": sorted({p.lifecycle for p in engine.policies}),
+            "auto_installed": pack_id == "owasp_llm_top_10",
+        })
+    return out
+
+
+def preview_pack(pack_id: str, directory: Optional[Path] = None) -> Dict[str, Any]:
+    """Load a pack and return its full policy list (un-imported).
+
+    Returned shape mirrors what /v1/policies emits per row, so the
+    dashboard preview surface and the live policies surface can use
+    one renderer. ``Policy`` objects are dumped to dicts with the
+    same keys policy_store.create_policy expects.
+    """
+    pack_path = _resolve_pack_path(pack_id, directory)
+    engine = load_policy_engine(str(pack_path))
+    policies = engine.policies if engine else []
+
+    meta = _CATALOG.get(pack_id, {})
+    return {
+        "pack_id": pack_id,
+        "name": meta.get("name", _humanize(pack_id)),
+        "category": meta.get("category", "Custom"),
+        "description": meta.get("description", ""),
+        "policy_count": len(policies),
+        "policies": [_policy_to_preview_row(p) for p in policies],
+    }
+
+
+@dataclass
+class ImportResult:
+    pack_id: str
+    imported: int
+    skipped_duplicates: int
+    failed: int
+    skipped_names: List[str]
+
+
+def import_pack(
+    db: Database,
+    pack_id: str,
+    *,
+    directory: Optional[Path] = None,
+    actor: str = "library_import",
+) -> ImportResult:
+    """Import every policy in ``pack_id`` into the DB. Idempotent —
+    duplicate names are SKIPPED, never overwritten.
+
+    Per §10.1 every imported policy lands in mode=shadow. The pack
+    YAMLs already declare ``mode: shadow`` so this is enforced in
+    two places: pack source + DB-insert default. The double-check
+    catches a community-contributed pack that forgot the field.
+    """
+    pack_path = _resolve_pack_path(pack_id, directory)
+    engine = load_policy_engine(str(pack_path))
+    policies = engine.policies if engine else []
+
+    imported = 0
+    skipped: List[str] = []
+    failed = 0
+
+    for policy in policies:
+        # Defensive shadow override — every starter-pack import lands
+        # in shadow regardless of what the YAML declared (Rule §10.1).
+        if getattr(policy, "mode", None) != "shadow":
+            try:
+                policy.mode = "shadow"  # type: ignore[attr-defined]
+            except Exception:
+                pass
+        try:
+            policy_store.create_policy(db, policy, actor=actor)
+            imported += 1
+        except ValueError:
+            # Duplicate name — operator already has this rule, leave
+            # their version alone.
+            skipped.append(policy.name)
+        except Exception:
+            logger.exception(
+                "library: failed to import policy %r from pack %s",
+                policy.name,
+                pack_id,
+            )
+            failed += 1
+
+    if imported or skipped:
+        logger.info(
+            "library: pack %s — imported=%d, skipped_duplicates=%d, failed=%d",
+            pack_id,
+            imported,
+            len(skipped),
+            failed,
+        )
+    return ImportResult(
+        pack_id=pack_id,
+        imported=imported,
+        skipped_duplicates=len(skipped),
+        failed=failed,
+        skipped_names=skipped,
+    )
+
+
+# ---- internals -------------------------------------------------------------
+
+
+def _resolve_pack_path(pack_id: str, directory: Optional[Path]) -> Path:
+    pack_dir = directory or _PACK_DIR
+    candidate = pack_dir / f"{pack_id}.yaml"
+    if not candidate.exists():
+        raise FileNotFoundError(f"pack not found: {pack_id}")
+    # Defensive: forbid path traversal in pack_id
+    if ".." in pack_id or "/" in pack_id or "\\" in pack_id:
+        raise ValueError(f"invalid pack_id: {pack_id}")
+    return candidate
+
+
+def _humanize(pack_id: str) -> str:
+    return pack_id.replace("_", " ").title()
+
+
+def _policy_to_preview_row(policy: Policy) -> Dict[str, Any]:
+    """Dict shape for the dashboard's pack preview. Matches the
+    fields /v1/policies returns so the existing PolicyRow renderer
+    works for previews unchanged."""
+    return {
+        "name": policy.name,
+        "description": getattr(policy, "description", ""),
+        "lifecycle": policy.lifecycle,
+        "mode": getattr(policy, "mode", "shadow"),
+        "priority": getattr(policy, "priority", 50),
+        "trigger": getattr(policy, "trigger", "span_end"),
+        "condition": getattr(policy, "condition", ""),
+        "action": getattr(policy, "action", "flag"),
+        "severity": getattr(policy, "severity", "medium"),
+    }

--- a/packages/api/firewall/starter_packs/code_assistant.yaml
+++ b/packages/api/firewall/starter_packs/code_assistant.yaml
@@ -1,0 +1,94 @@
+# Code-assistant — Lumin starter pack
+#
+# For agents that write or modify code (Cursor / Aider / Claude
+# Code / Devin / similar). Threats specific to this surface:
+#
+#   1. Suggesting eval() / exec() / unsafe deserialization.
+#   2. Writing to system paths or .git internals.
+#   3. Adding dependencies from arbitrary registries (supply-chain).
+#   4. Hardcoding secrets into committed code.
+#
+# Ships shadow. Most rules here are flag rather than block — code
+# review catches false positives, and aggressive blocking breaks
+# the agent's flow.
+
+version: 1
+
+policies:
+
+  # Suggesting eval() in user-facing code
+  - name: code_assistant_eval_suggestion
+    description: Flag agent output that introduces eval() / exec() / Function() / new Function in suggested code.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 85
+    trigger: span_end
+    condition: regex_match(Output.text, "(?<![a-zA-Z_])(eval|exec|new\\s+Function)\\s*\\(") or regex_match(Output.text, "(?i)setTimeout\\s*\\(\\s*[\"']")
+    action: flag
+    severity: high
+
+  # Unsafe deserialization
+  - name: code_assistant_unsafe_deserialization
+    description: Flag suggestions involving pickle.loads / yaml.load / json with eval-like deserializers.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 85
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)pickle\\.loads\\(") or regex_match(Output.text, "(?i)yaml\\.(unsafe_)?load\\s*\\(") or regex_match(Output.text, "(?i)marshal\\.loads\\(")
+    action: flag
+    severity: high
+
+  # Writes to .git or .github
+  - name: code_assistant_git_internals_write
+    description: Block tool calls writing into .git/ internals or .github/workflows (CI hijack surface).
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 90
+    trigger: span_end
+    condition: (is_shell_tool(tool_name) or is_filesystem_tool(tool_name)) and regex_match(str(Input.params.get("command", "") or Input.params.get("path", "") or Input.params.get("file", "")), "(?i)(\\.git/(?!hooks/sample)|\\.github/workflows/)")
+    action: block
+    severity: high
+
+  # Adding deps from arbitrary registries
+  - name: code_assistant_supply_chain_registry
+    description: Flag dependency adds that point at non-allowlisted registries (typo-squat / supply-chain risk).
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 70
+    trigger: span_end
+    condition: is_shell_tool(tool_name) and (regex_match(str(Input.params.get("command", "")), "(?i)pip\\s+install.*--index-url\\s") or regex_match(str(Input.params.get("command", "")), "(?i)npm\\s+(install|add).*--registry\\s") or regex_match(str(Input.params.get("command", "")), "(?i)(github|gitlab|bitbucket)\\.com/[^/]+/[^/\\s]+\\.git\\s"))
+    action: flag
+    severity: medium
+
+  # Hardcoded secrets in suggested code
+  - name: code_assistant_hardcoded_secret
+    description: Block suggestions that hardcode API keys / OAuth tokens / private keys into source.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 92
+    trigger: span_end
+    condition: regex_match(Output.text, "(sk-[A-Za-z0-9]{20,}|xox[abprs]-[A-Za-z0-9-]{10,}|ghp_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|-----BEGIN (RSA |OPENSSH |EC |DSA )?PRIVATE KEY-----)")
+    action: block
+    severity: critical
+
+  # Suggesting `chmod 777` on directories
+  - name: code_assistant_chmod_world_writable
+    description: Flag suggestions that introduce 'chmod 777' or world-writable file modes.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 70
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)chmod\\s+(-R\\s+)?(777|a\\+rwx|o\\+w)\\b")
+    action: flag
+    severity: medium
+
+  # Disabling TLS verification in suggested code
+  - name: code_assistant_tls_disable
+    description: Flag suggestions that disable TLS / SSL verification (verify=False, rejectUnauthorized=false).
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 80
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)(verify\\s*=\\s*False|rejectUnauthorized\\s*:\\s*false|--insecure\\s|InsecureSkipVerify\\s*[:=]\\s*true)")
+    action: flag
+    severity: medium

--- a/packages/api/firewall/starter_packs/compliance_gdpr.yaml
+++ b/packages/api/firewall/starter_packs/compliance_gdpr.yaml
@@ -1,0 +1,83 @@
+# GDPR compliance — Lumin starter pack
+#
+# Aligned to GDPR Art. 5 (lawfulness, fairness, transparency,
+# data minimisation) and Art. 9 (special categories of personal
+# data). All rules ship in advisory shadow mode — GDPR
+# enforcement is a legal posture, not a technical one, and false
+# positives must not block legitimate processing.
+#
+# Operators promote per their controllership / processor role.
+# This pack does NOT make a deployment GDPR-compliant on its own
+# — it surfaces the patterns that warrant DPO review.
+
+version: 1
+
+policies:
+
+  # Art. 9 special categories — health data in input or output
+  - name: gdpr_art9_health_data
+    description: Flag content containing health / medical data per GDPR Art. 9(1) special categories.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 80
+    trigger: span_end
+    condition: contains_any(Output.text, ["diagnosis", "diagnosed with", "blood type", "HIV", "AIDS", "cancer", "tumor", "chronic illness", "medical record", "prescription", "mental health diagnosis"])
+    action: flag
+    severity: high
+
+  # Art. 9 — racial / ethnic origin
+  - name: gdpr_art9_racial_ethnic
+    description: Flag content containing racial or ethnic origin references per GDPR Art. 9.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 75
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)\\b(race[:=]|ethnicity[:=]|skin\\s+color[:=]|national\\s+origin[:=])")
+    action: flag
+    severity: medium
+
+  # EU PII — IBAN
+  - name: gdpr_iban_in_output
+    description: Rewrite (redact) European IBAN account numbers in assistant output.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 85
+    trigger: span_end
+    condition: regex_match(Output.text, "\\b[A-Z]{2}\\d{2}[A-Z0-9]{4}\\d{7}([A-Z0-9]?){0,16}\\b")
+    action: rewrite
+    severity: high
+
+  # EU PII — German Personalausweis / French INSEE / similar
+  - name: gdpr_national_id
+    description: Flag content containing what looks like an EU national identification number (heuristic).
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 80
+    trigger: span_end
+    condition: regex_match(Output.text, "\\b[12]\\s?\\d{2}\\s?\\d{2}\\s?\\d{2}\\s?\\d{3}\\s?\\d{3}\\s?\\d{2}\\b") or regex_match(Output.text, "\\b\\d{10,11}\\b")
+    action: flag
+    severity: medium
+
+  # Profile / behavioral profiling without lawful basis annotation
+  - name: gdpr_profiling_without_basis
+    description: Flag tool calls that build user profiles when no lawful_basis tag is present in metadata.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 65
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(build_profile|score_user|risk_assess|behavioral_predict|recommendation_engine)")
+    action: flag
+    severity: medium
+
+  # Right-to-erasure markers — operator should be alerted when a
+  # user invokes their Art. 17 rights via a chat surface so it
+  # gets routed to a human DPO process.
+  - name: gdpr_right_to_erasure_request
+    description: Flag inputs invoking GDPR Art. 17 right-to-erasure / right-to-be-forgotten.
+    lifecycle: post_ingest
+    mode: shadow
+    priority: 70
+    trigger: span_end
+    condition: contains_any(Input.last_user_msg, ["delete my data", "right to erasure", "right to be forgotten", "GDPR Article 17", "remove all my information", "purge my account"])
+    action: flag
+    severity: medium

--- a/packages/api/firewall/starter_packs/compliance_hipaa.yaml
+++ b/packages/api/firewall/starter_packs/compliance_hipaa.yaml
@@ -1,0 +1,82 @@
+# HIPAA compliance — Lumin starter pack
+#
+# Aligned to HIPAA Privacy Rule § 164.514 Safe Harbor — the 18
+# identifiers that must be removed for de-identification. All
+# rules ship advisory; HIPAA compliance is a posture not enforced
+# by software alone (BAA, audit, access control all required).
+#
+# Use case: agents in healthcare contexts, clinical research,
+# payor / provider interactions. Operator MUST also implement
+# administrative safeguards (training, audit) on top of the
+# technical layer this pack provides.
+
+version: 1
+
+policies:
+
+  # SSN — strongest single PHI identifier signal
+  - name: hipaa_ssn_in_output
+    description: Block (don't rewrite) SSNs in assistant output. Hard block matches HIPAA's strict-liability posture.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 95
+    trigger: span_end
+    condition: regex_match(Output.text, "\\b\\d{3}-\\d{2}-\\d{4}\\b") or regex_match(Output.text, "\\b\\d{9}\\b") and contains_any(Output.text, ["SSN", "social security", "social-security"])
+    action: block
+    severity: critical
+
+  # MRN (medical record number) — flag, don't block; legitimate
+  # clinical workflows reference these.
+  - name: hipaa_mrn_pattern
+    description: Flag content matching common medical record number patterns.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 80
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)\\b(MRN|medical\\s+record\\s+number|patient\\s+id)[:#=\\s]\\s*\\d{6,12}\\b")
+    action: flag
+    severity: high
+
+  # Health-plan beneficiary numbers
+  - name: hipaa_health_plan_number
+    description: Flag content quoting health-plan or beneficiary identifiers.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 80
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)\\b(member\\s+id|beneficiary|policy\\s+number|plan\\s+id)[:#=\\s]\\s*[A-Z0-9-]{6,16}\\b")
+    action: flag
+    severity: medium
+
+  # Diagnosis / treatment combined with name = PHI
+  - name: hipaa_diagnosis_with_name
+    description: Flag outputs that combine a person's name with a medical diagnosis (de-identification failure).
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 85
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)([A-Z][a-z]+\\s+[A-Z][a-z]+)\\s.{0,100}?\\b(diagnosed\\s+with|suffers\\s+from|has\\s+(diabetes|cancer|HIV|hepatitis|asthma))")
+    action: flag
+    severity: critical
+
+  # PHI + treatment context
+  - name: hipaa_phi_treatment_context
+    description: Flag outputs containing prescription names + dosage + identifiable patient context.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 80
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)\\d+\\s*(mg|mcg|ml|tablets?|pills?)\\b") and regex_match(Output.text, "(?i)\\b(patient|client|individual|participant)\\b")
+    action: flag
+    severity: medium
+
+  # Audit log requirement: all PHI tool calls logged
+  - name: hipaa_audit_phi_tool_calls
+    description: Flag tool calls touching anything labeled PHI / medical / patient — for audit trail.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 50
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(patient|medical|clinical|phi|hipaa|ehr|emr)")
+    action: flag
+    severity: low

--- a/packages/api/firewall/starter_packs/compliance_pci_dss.yaml
+++ b/packages/api/firewall/starter_packs/compliance_pci_dss.yaml
@@ -1,0 +1,81 @@
+# PCI DSS compliance — Lumin starter pack
+#
+# Aligned to PCI DSS v4.0 § 3.3 (Sensitive Authentication Data)
+# and § 3.4 (Cardholder Data). Hard-block by design: PCI is a
+# strict-liability framework — full PANs and SAD never leave the
+# CDE in the clear. False positives are a feature, not a bug.
+
+version: 1
+
+policies:
+
+  # Full PAN — Visa / Mastercard / AmEx / Discover / JCB
+  # The Luhn check happens via regex pattern matching the issuer
+  # IIN — the regex is intentionally over-broad so we err on the
+  # side of redaction.
+  - name: pci_pan_in_output
+    description: Block assistant output containing full Primary Account Numbers (PANs). Visa/MC/AmEx/Discover/JCB.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 99
+    trigger: span_end
+    condition: regex_match(Output.text, "\\b4\\d{3}[\\s-]?\\d{4}[\\s-]?\\d{4}[\\s-]?\\d{4}\\b") or regex_match(Output.text, "\\b5[1-5]\\d{2}[\\s-]?\\d{4}[\\s-]?\\d{4}[\\s-]?\\d{4}\\b") or regex_match(Output.text, "\\b3[47]\\d{2}[\\s-]?\\d{6}[\\s-]?\\d{5}\\b") or regex_match(Output.text, "\\b6011[\\s-]?\\d{4}[\\s-]?\\d{4}[\\s-]?\\d{4}\\b")
+    action: block
+    severity: critical
+
+  # CVV / CVC — Sensitive Authentication Data, may NEVER be stored
+  - name: pci_cvv_in_output
+    description: Block assistant output containing 3 or 4-digit CVV/CVC codes adjacent to card-related context.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 99
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)(cvv|cvc|cvn|card\\s+verification|security\\s+code)[:#=\\s]\\s*\\d{3,4}\\b")
+    action: block
+    severity: critical
+
+  # Magnetic stripe data (track 1 / track 2)
+  - name: pci_magnetic_stripe
+    description: Block content matching magnetic-stripe track 1 or track 2 patterns.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 99
+    trigger: span_end
+    condition: regex_match(Output.text, "%B\\d{13,19}\\^") or regex_match(Output.text, ";\\d{13,19}=\\d{4,}\\?")
+    action: block
+    severity: critical
+
+  # PIN (4-6 digit) in proximity to card context
+  - name: pci_pin_in_output
+    description: Block 4–6 digit PINs in card-context output.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 95
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)(\\bpin\\b)[:#=\\s]\\s*\\d{4,6}\\b")
+    action: block
+    severity: critical
+
+  # PAN in tool input — the agent shouldn't be passing PANs into
+  # arbitrary tools. Tokenization is the PCI-blessed pattern.
+  - name: pci_pan_in_tool_input
+    description: Block tool calls whose params contain a full PAN.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 99
+    trigger: span_end
+    condition: regex_match(str(Input.params or {}), "\\b4\\d{3}[\\s-]?\\d{4}[\\s-]?\\d{4}[\\s-]?\\d{4}\\b") or regex_match(str(Input.params or {}), "\\b5[1-5]\\d{2}[\\s-]?\\d{4}[\\s-]?\\d{4}[\\s-]?\\d{4}\\b") or regex_match(str(Input.params or {}), "\\b3[47]\\d{2}[\\s-]?\\d{6}[\\s-]?\\d{5}\\b")
+    action: block
+    severity: critical
+
+  # PAN logging requirement — flag spans that LOOK like they're
+  # writing payment data into log/observability tools.
+  - name: pci_pan_in_logging
+    description: Flag tool calls writing card-shaped data to logging / metrics / observability sinks.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 80
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(log|metric|trace|datadog|splunk|sentry|honeycomb)") and regex_match(str(Input.params or {}), "\\b\\d{13,19}\\b")
+    action: flag
+    severity: high

--- a/packages/api/firewall/starter_packs/cost_guards.yaml
+++ b/packages/api/firewall/starter_packs/cost_guards.yaml
@@ -1,0 +1,86 @@
+# Cost guards — Lumin starter pack
+#
+# Token / dollar / rate-limit rails for every agent. These rules
+# protect against runaway loops, jailbreaks that spam the model,
+# and accidental high-cost tool patterns. All thresholds are
+# starting points — operators tune them to their org's spend
+# tolerance.
+#
+# Built on the firewall history builtins
+# (session_total_tokens, agent_total_tokens_24h, etc.) — the
+# data is queried from the spans / decisions tables, so this
+# pack only works when /v1/spans is being populated (which it is
+# by default for every Lumin integration).
+
+version: 1
+
+policies:
+
+  # Per-session token cap — halt runaway loops
+  - name: cost_session_token_hard_cap
+    description: Block when a single session crosses 10M tokens (runaway loop protection).
+    lifecycle: before_proxy_call
+    mode: shadow
+    priority: 90
+    trigger: span_end
+    condition: session_total_tokens(str(Input.session_id or "")) > 10000000
+    action: block
+    severity: high
+
+  # Per-session token warn — flag well before the hard cap
+  - name: cost_session_token_warn
+    description: Flag when a single session exceeds 1M tokens (early warning for pathological use).
+    lifecycle: before_proxy_call
+    mode: shadow
+    priority: 60
+    trigger: span_end
+    condition: session_total_tokens(str(Input.session_id or "")) > 1000000
+    action: flag
+    severity: medium
+
+  # Per-agent 24h ceiling
+  - name: cost_agent_daily_token_cap
+    description: Block when an agent has consumed >50M tokens in the last 24h (cap default).
+    lifecycle: before_proxy_call
+    mode: shadow
+    priority: 75
+    trigger: span_end
+    condition: agent_total_tokens_24h(str(Input.agent or "")) > 50000000
+    action: block
+    severity: high
+
+  # Per-agent 24h warn
+  - name: cost_agent_daily_token_warn
+    description: Flag when an agent has consumed >10M tokens in the last 24h.
+    lifecycle: before_proxy_call
+    mode: shadow
+    priority: 55
+    trigger: span_end
+    condition: agent_total_tokens_24h(str(Input.agent or "")) > 10000000
+    action: flag
+    severity: medium
+
+  # Per-tool 24h call rate (rate-limit-style)
+  - name: cost_tool_call_burst
+    description: Flag when a single tool has been called >1000 times in 24h on this project (loop / burst signal).
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 50
+    trigger: span_end
+    condition: tool_calls_24h(str(tool_name or "")) > 1000
+    action: flag
+    severity: low
+
+  # Single-turn token oversize — most user turns are <2k tokens.
+  # When a single turn carries >100k input tokens the agent is
+  # probably pasting an entire codebase or doing something the
+  # operator should review.
+  - name: cost_oversize_single_turn
+    description: Flag turns whose user input exceeds 100k chars (likely large paste or jailbreak smuggling).
+    lifecycle: before_proxy_call
+    mode: shadow
+    priority: 45
+    trigger: span_end
+    condition: len_chars(Input.last_user_msg) > 100000
+    action: flag
+    severity: low

--- a/packages/api/firewall/starter_packs/customer_support_agent.yaml
+++ b/packages/api/firewall/starter_packs/customer_support_agent.yaml
@@ -1,0 +1,97 @@
+# Customer-support agent — Lumin starter pack
+#
+# Tuned for support / CS / helpdesk bots that talk to end users
+# over Slack / Telegram / web chat. Three failure modes the rules
+# guard against:
+#
+#   1. PII leakage — bot accidentally echoes one customer's data
+#      into another customer's reply (the cross-tenant leakage
+#      pattern from the May 2026 case-driven testing).
+#   2. Refund / discount escalation — bot grants larger amounts
+#      than its policy allows.
+#   3. Brand safety — bot's reply contains profanity, competitor
+#      mentions, or off-topic content.
+#
+# Ships shadow. Promote after a week of dashboard observation.
+
+version: 1
+
+policies:
+
+  # PII in output — uses Presidio when installed, falls back to a
+  # built-in heuristic. Action=rewrite redacts the matched spans
+  # so the conversation continues — blocking would force the
+  # operator into manual mode for routine support cases.
+  - name: support_pii_in_output
+    description: Rewrite (redact) PII detected in the assistant reply — emails, phone numbers, government IDs, credit cards.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 85
+    trigger: span_end
+    condition: presidio_pii_score(Output.text) > 0.5 or has_pii(Output.text)
+    action: rewrite
+    severity: high
+
+  # Refund-amount ceiling. The exact $ trigger is per-deployment;
+  # operators tighten this per CS team policy.
+  - name: support_refund_ceiling
+    description: Require approval when the bot's reply quotes a refund / credit > $500.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 80
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)(refund|credit|reimburse(ment)?|chargeback)\\D{0,30}(\\$|USD\\s*)\\s*[5-9]\\d{2}|(\\$|USD\\s*)\\s*[1-9]\\d{3,}")
+    action: require_approval
+    severity: high
+
+  # Brand-safety — profanity / slurs in agent output. Flagged not
+  # blocked: a false-positive that suppresses a legitimate message
+  # is worse for support UX than a rare slur slipping through.
+  - name: support_brand_safety_profanity
+    description: Flag assistant replies containing profanity, slurs, or aggressive language.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 70
+    trigger: span_end
+    condition: contains_any(Output.text, ["fuck", "shit", "damn it", "stupid", "idiot", "retard", "moron"])
+    action: flag
+    severity: low
+
+  # Competitor mentions — flag, don't block.
+  - name: support_brand_safety_competitor_mention
+    description: Flag when the assistant mentions a competitor's product by name (sales / brand teams want visibility).
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 60
+    trigger: span_end
+    condition: contains_any(Output.text, ["use Salesforce instead", "Zendesk has", "Intercom is better", "try our competitor", "you should switch to"])
+    action: flag
+    severity: low
+
+  # Cross-session data leakage hint — if the assistant's reply
+  # references another customer's name / order / account that
+  # wasn't in this turn's input or session history, that's a
+  # leakage signal. This is a heuristic placeholder; real
+  # cross-session detection is a separate detector (the session-
+  # vault feature).
+  - name: support_cross_session_leakage_hint
+    description: Flag replies containing customer / order / account references that don't appear in the current session's prior turns.
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 78
+    trigger: span_end
+    condition: regex_match(Output.text, "(?i)(order\\s+#?\\d{6,}|customer\\s+id\\s*[:#]?\\s*[a-z0-9-]{6,}|account\\s+#?\\d{6,})") and not regex_match(str(Input.last_user_msg or ""), "(?i)(order\\s+#?\\d{6,}|customer\\s+id\\s*[:#]?\\s*[a-z0-9-]{6,}|account\\s+#?\\d{6,})")
+    action: flag
+    severity: medium
+
+  # Promise-of-action — bot promises to do something it can't
+  # actually do (file a ticket, escalate, refund). Audit-only.
+  - name: support_unbacked_promise
+    description: Flag replies promising actions the bot has no tool to perform (ticket creation, escalation, refund).
+    lifecycle: after_proxy_call
+    mode: shadow
+    priority: 55
+    trigger: span_end
+    condition: contains_any(Output.text, ["I will file a ticket", "I'll escalate this", "I've issued a refund", "I'll send this to", "I have notified", "I have alerted"])
+    action: flag
+    severity: low

--- a/packages/api/firewall/starter_packs/dev_environment_safety.yaml
+++ b/packages/api/firewall/starter_packs/dev_environment_safety.yaml
@@ -1,0 +1,95 @@
+# Dev environment safety — Lumin starter pack
+#
+# Conservative defaults for any agent that runs on a developer's
+# machine and has shell + filesystem tool access. Catches the
+# hold-my-beer commands ('rm -rf', 'dd if=', 'mkfs', writes to
+# /etc) before they fire.
+#
+# Companion to OWASP LLM Top 10. The owasp_destructive_shell rule
+# in that pack covers the broad strokes; this pack adds the
+# dev-machine-specific surfaces (.git, package managers, SSH keys,
+# cloud credentials).
+#
+# Ships shadow. Operator promotes after watching the
+# EnforcementTimeline for a day.
+
+version: 1
+
+policies:
+
+  # rm -rf with breadth quantifier
+  - name: dev_safety_rm_rf_broad
+    description: Block 'rm -rf' targeting root, $HOME, or wildcard patterns ('rm -rf /' / 'rm -rf ~/' / 'rm -rf *').
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 95
+    trigger: span_end
+    condition: is_shell_tool(tool_name) and regex_match(str(Input.params.get("command", "")), "(?i)rm\\s+-[rfRF]+\\s+(/|~/|\\*\\s|\\$HOME|\\$\\{HOME\\})")
+    action: block
+    severity: critical
+
+  # Disk-level destruction
+  - name: dev_safety_disk_destructive
+    description: Block disk-wipe commands (dd if=, mkfs, fdisk, parted) regardless of args.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 95
+    trigger: span_end
+    condition: is_shell_tool(tool_name) and regex_match(str(Input.params.get("command", "")), "(?i)\\b(dd\\s+if=|mkfs(\\.[a-z0-9]+)?|fdisk\\s|parted\\s|wipefs)\\b")
+    action: block
+    severity: critical
+
+  # Reading SSH / cloud credentials
+  - name: dev_safety_credential_read
+    description: Block reads of SSH keys, AWS credentials, GCP credentials, kubeconfig, .env files.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 90
+    trigger: span_end
+    condition: (is_shell_tool(tool_name) or is_filesystem_tool(tool_name)) and regex_match(str(Input.params.get("command", "") or Input.params.get("path", "") or Input.params.get("file", "")), "(?i)(\\.ssh/(id_|authorized|known_hosts)|\\.aws/credentials|\\.gcp/credentials|\\.kube/config|\\.npmrc|\\.netrc|\\.env(\\.|$)|gcloud/application_default)")
+    action: block
+    severity: high
+
+  # Git force-push to protected branches
+  - name: dev_safety_git_force_push_protected
+    description: Block 'git push --force' to main / master / production / release branches.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 88
+    trigger: span_end
+    condition: is_shell_tool(tool_name) and regex_match(str(Input.params.get("command", "")), "(?i)git\\s+push\\s+(.*\\s+)?(--force|-f)\\b") and regex_match(str(Input.params.get("command", "")), "(?i)\\b(main|master|production|prod|release)\\b")
+    action: require_approval
+    severity: high
+
+  # Package manager — auditless install of arbitrary packages
+  - name: dev_safety_npm_install_unscoped
+    description: Flag 'npm install' / 'pip install' / 'gem install' from outside an allowlist of registries.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 70
+    trigger: span_end
+    condition: is_shell_tool(tool_name) and regex_match(str(Input.params.get("command", "")), "(?i)(npm|pnpm|yarn)\\s+(install|add|i)\\b") and regex_match(str(Input.params.get("command", "")), "(?i)--registry\\s+http") and not contains_any(str(Input.params.get("command", "")), ["registry.npmjs.org", "registry.yarnpkg.com"])
+    action: flag
+    severity: medium
+
+  # Curl piped to shell
+  - name: dev_safety_curl_pipe_shell
+    description: Block 'curl ... | sh' / 'wget ... | bash' patterns — classic remote-code-execution shape.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 92
+    trigger: span_end
+    condition: is_shell_tool(tool_name) and regex_match(str(Input.params.get("command", "")), "(?i)(curl|wget|fetch)\\b.*\\|\\s*(ba)?sh\\b")
+    action: block
+    severity: critical
+
+  # Writes to system paths
+  - name: dev_safety_system_path_write
+    description: Block writes to /etc, /var, /usr, /System, /Library, %SystemRoot%.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 88
+    trigger: span_end
+    condition: (is_shell_tool(tool_name) or is_filesystem_tool(tool_name)) and regex_match(str(Input.params.get("command", "") or Input.params.get("path", "") or Input.params.get("destination", "")), "(?i)(>|tee|cp|mv|install|chmod|chown)\\s.*?(/etc/|/var/|/usr/(?!local)|/System/|/Library/(?!Caches)|%SystemRoot%|C:\\\\Windows)")
+    action: block
+    severity: high

--- a/packages/api/firewall/starter_packs/framework_langgraph.yaml
+++ b/packages/api/firewall/starter_packs/framework_langgraph.yaml
@@ -1,0 +1,89 @@
+# Framework: LangGraph — Lumin starter pack
+#
+# Defaults for LangGraph multi-node agent flows. LangGraph
+# exposes `interrupt()` for human-in-the-loop gating, which the
+# Lumin LangGraph integration uses to hold execution while a
+# require_approval decision is pending.
+#
+# Common LangGraph patterns this pack guards:
+#   - Tool-using nodes that call external APIs (web fetch, DB)
+#   - State-mutation nodes that write to checkpointer storage
+#   - Recursive graph runs that exceed a depth budget
+
+version: 1
+
+policies:
+
+  # Recursion limit — flag when LangGraph is approaching the
+  # default 25-iteration recursion budget (signal of a loop bug
+  # or jailbreak that's stuck the graph in a cycle).
+  - name: langgraph_recursion_warning
+    description: Flag when a LangGraph run's session token usage suggests recursion / loop (>500k tokens single session).
+    lifecycle: before_proxy_call
+    mode: shadow
+    priority: 65
+    trigger: span_end
+    condition: session_total_tokens(str(Input.session_id or "")) > 500000
+    action: flag
+    severity: medium
+
+  # Tool nodes — same web-fetch internal-block as Mastra
+  - name: langgraph_tool_web_fetch_internal
+    description: Block LangGraph tool nodes that fetch internal URLs (SSRF defense).
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 88
+    trigger: span_end
+    condition: is_web_fetch_tool(tool_name) and is_internal_url(str(Input.params.get("url", "") or Input.params.get("href", "")))
+    action: block
+    severity: high
+
+  # Checkpointer writes — flag when a node attempts to write to
+  # the checkpointer outside the canonical flow (signal of state
+  # tampering or memory poisoning)
+  - name: langgraph_checkpointer_write
+    description: Flag direct writes to LangGraph checkpointer outside the canonical State update path.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 60
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(checkpoint|graph_state)_(set|put|update|write)")
+    action: flag
+    severity: medium
+
+  # Subgraph execution — when the agent dynamically invokes a
+  # subgraph via tool name, require approval (graph composition
+  # at runtime is a privilege-escalation vector)
+  - name: langgraph_dynamic_subgraph
+    description: Require approval when the agent dynamically invokes a subgraph at runtime.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 75
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(invoke_subgraph|run_subgraph|dispatch_graph|graph\\.invoke)")
+    action: require_approval
+    severity: medium
+
+  # Long-running nodes — flag when a single tool call exceeds 30s
+  # wall time (computed via existing duration tracking; the rule
+  # is a reminder for ops to investigate hung steps)
+  - name: langgraph_node_runtime_anomaly
+    description: Flag interrupt() / human_input() nodes pending longer than 1 hour (stale approval signal).
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 40
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(human_(input|approval)|interrupt_node)")
+    action: flag
+    severity: low
+
+  # Memory-poisoning floor for LangGraph
+  - name: langgraph_memory_poisoning
+    description: Block prompt-injection reaching LangGraph state-update or memory tools.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 90
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(memory|state_update|graph_set_state)") and (has_ascii_smuggling(str(Input.params.get("content", "") or Input.params.get("value", "") or Input.params.get("text", ""))) or contains_any(str(Input.params.get("content", "") or Input.params.get("value", "")), ["ignore previous instructions", "ignore the above"]))
+    action: block
+    severity: high

--- a/packages/api/firewall/starter_packs/framework_mastra.yaml
+++ b/packages/api/firewall/starter_packs/framework_mastra.yaml
@@ -1,0 +1,74 @@
+# Framework: Mastra — Lumin starter pack
+#
+# Defaults for agents built on Mastra. Mastra exposes typed tool
+# calls via `agent.callTool` and surfaces hooks at
+# `agent.beforeToolCall` / `agent.afterToolCall`. The Lumin
+# Mastra integration (@lumin-io/mastra) wires those hooks to
+# /v1/policy/decide; this pack is the corresponding rule set.
+#
+# Conservative defaults — promote per deployment.
+
+version: 1
+
+policies:
+
+  # Tool-name hygiene — Mastra workflows often have a few highly
+  # destructive tools (deploy, migrate, transfer). Default-approve
+  # them so the operator sees one before the first prod use.
+  - name: mastra_workflow_destructive_step_approval
+    description: Require approval on Mastra workflow steps named deploy / migrate / transfer / promote / publish.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 80
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)^(deploy|migrate|transfer|promote|publish)(_|\\.)|workflow_step_(deploy|migrate|destroy)")
+    action: require_approval
+    severity: high
+
+  # Mastra agents commonly use `web_fetch` / `http_request` —
+  # block requests to internal hosts (link-local, RFC1918, IMDS)
+  - name: mastra_web_fetch_internal
+    description: Block Mastra web-fetch / http-request tool calls targeting internal addresses or cloud metadata.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 88
+    trigger: span_end
+    condition: is_web_fetch_tool(tool_name) and is_internal_url(str(Input.params.get("url", "") or Input.params.get("href", "")))
+    action: block
+    severity: high
+
+  # Mastra workflow-state mutation — flag direct edits to workflow
+  # state outside the canonical step sequence. Drift signal.
+  - name: mastra_workflow_state_direct_mutation
+    description: Flag direct mutations to Mastra workflow state outside canonical steps.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 60
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(workflow|run)_state_(set|update|patch|put)")
+    action: flag
+    severity: medium
+
+  # Memory writes on Mastra — apply the agentic memory-poisoning
+  # rule with a Mastra-tool-name regex
+  - name: mastra_memory_poisoning
+    description: Block prompt-injection content reaching Mastra memory tools.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 90
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(memory|store|kv_set|vector_(add|insert|upsert))") and (has_ascii_smuggling(str(Input.params.get("content", "") or Input.params.get("value", "") or Input.params.get("text", ""))) or contains_any(str(Input.params.get("content", "") or Input.params.get("value", "")), ["ignore previous instructions", "ignore the above"]))
+    action: block
+    severity: high
+
+  # Mastra tool audit log — flag any tool whose name signals
+  # human-impact (refund, charge, send-email)
+  - name: mastra_human_impact_audit
+    description: Flag (audit) tool calls that affect external humans — payments, emails, broadcasts.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 50
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(refund|charge|payment|send_email|notify|broadcast|sms_send)")
+    action: flag
+    severity: low

--- a/packages/api/firewall/starter_packs/owasp_agentic_2025.yaml
+++ b/packages/api/firewall/starter_packs/owasp_agentic_2025.yaml
@@ -1,0 +1,113 @@
+# OWASP Agentic AI Top 10 (2025) — Lumin starter pack
+#
+# Covers the agent-specific threats that aren't on the LLM Top 10:
+# memory poisoning, tool misuse, privilege escalation, resource
+# overload, identity spoofing. Same shadow-by-default contract as
+# the OWASP LLM pack — operator promotes per environment after
+# reviewing the EnforcementTimeline.
+#
+# Companion to the OWASP LLM pack — install both for layered defense
+# against agentic systems (RAG bots, tool-calling agents, multi-step
+# reasoners).
+
+version: 1
+
+policies:
+
+  # AT1 — Memory poisoning
+  # Adversarial input attempts to write malicious "facts" into the
+  # agent's memory store so they surface in *future* turns. The
+  # injection markers are the same shape as direct prompt-injection
+  # but ride into long-term memory tools instead of the model.
+  - name: owasp_agentic_t1_memory_poisoning
+    description: Block attempts to write prompt-injection or hidden-instruction content into memory-store tools.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 90
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(memory|remember|store_fact|knowledge_(write|add)|add_to_memory)") and (has_ascii_smuggling(str(Input.params.get("content", "") or Input.params.get("text", "") or Input.params.get("fact", ""))) or contains_any(str(Input.params.get("content", "") or Input.params.get("text", "") or Input.params.get("fact", "")), ["ignore previous instructions", "ignore the above", "new system prompt", "from now on"]))
+    action: block
+    severity: high
+
+  # AT2 — Tool misuse (require_approval for destructive tools)
+  # Operator-in-the-loop on irreversible operations. Pairs with the
+  # destructive-shell pack but generalizes to any tool whose name
+  # signals a destructive action.
+  - name: owasp_agentic_t2_destructive_tool_approval
+    description: Require operator approval before any tool whose name signals deletion, drop, truncate, force-push, or wipe.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 80
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(delete_|drop_|truncate_|wipe_|destroy_|force_push|reset_hard|nuke|purge)")
+    action: require_approval
+    severity: high
+
+  # AT3 — Privilege compromise
+  # Agent attempts to escalate privileges via shell or executor
+  # tools. sudo, runas, and setuid markers in tool params.
+  - name: owasp_agentic_t3_privilege_escalation
+    description: Block shell calls invoking sudo / runas / su / setuid / setgid escalation.
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 88
+    trigger: span_end
+    condition: is_shell_tool(tool_name) and regex_match(str(Input.params.get("command", "")), "(?i)\\b(sudo|runas|doas|pkexec|su\\s+-|setuid|setgid)\\b")
+    action: block
+    severity: critical
+
+  # AT4 — Resource overload
+  # Per-session token cap. Cost guard pack handles spend ceilings;
+  # this guards against runaway loops that pile up tokens.
+  - name: owasp_agentic_t4_session_token_cap
+    description: Block when a session exceeds 5M tokens (runaway loop signal). Tunable per deployment.
+    lifecycle: before_proxy_call
+    mode: shadow
+    priority: 70
+    trigger: span_end
+    condition: session_total_tokens(str(Input.session_id or "")) > 5000000
+    action: block
+    severity: medium
+
+  # AT6 — Intent breaking (goal hijacking)
+  # Pattern where the user asks the bot to "act as a different
+  # assistant" or roleplay around safety. Cheap heuristic — covers
+  # the obvious cases. Prompt Guard 2 catches the rest.
+  - name: owasp_agentic_t6_goal_hijack_basic
+    description: Flag inputs that try to redefine the agent's role / persona / system prompt.
+    lifecycle: before_proxy_call
+    mode: shadow
+    priority: 75
+    trigger: span_end
+    condition: contains_any(Input.last_user_msg, ["you are now", "pretend you are", "act as if you have no", "from now on you", "ignore your guidelines", "DAN mode", "developer mode"])
+    action: flag
+    severity: medium
+
+  # AT9 — Identity spoofing
+  # Inputs claiming to be from internal admin / system / operator.
+  # When the firewall sees these patterns at the user-message
+  # boundary, it's almost always an impersonation attempt — the
+  # legitimate operator surface is the dashboard, not the chat.
+  - name: owasp_agentic_t9_identity_spoofing
+    description: Flag user messages claiming to be from system / admin / operator / parent agent.
+    lifecycle: before_proxy_call
+    mode: shadow
+    priority: 78
+    trigger: span_end
+    condition: regex_match(Input.last_user_msg, "(?i)^\\s*(system|admin|operator|parent\\s+agent|root)\\s*[:>]") or contains_any(Input.last_user_msg, ["This is the system administrator", "I am the operator", "Override authorization granted"])
+    action: flag
+    severity: medium
+
+  # AT10 — Overreliance (high-stakes guard)
+  # When the agent is about to send an irreversible message
+  # (email, payment, public post), require approval. Tool-name
+  # heuristic — operators tighten the regex per their deployment.
+  - name: owasp_agentic_t10_high_stakes_approval
+    description: Require approval for irreversible external-facing actions (email send, payment, public post, ticket close).
+    lifecycle: before_tool_call
+    mode: shadow
+    priority: 82
+    trigger: span_end
+    condition: regex_match(tool_name, "(?i)(send_email|send_message|create_payment|charge_card|publish_(post|tweet|article)|close_ticket|deploy_to_prod)")
+    action: require_approval
+    severity: high

--- a/packages/api/routers/firewall.py
+++ b/packages/api/routers/firewall.py
@@ -1095,3 +1095,64 @@ def list_classifier_models_endpoint(
     classifier page."""
     from firewall.detectors import local_classifier as lc_det
     return {"models": lc_det.list_models(db)}
+
+
+# ----- Starter pack library (§13) ---------------------------------------
+#
+# Operators discover and import canned policy bundles via these
+# endpoints. The library walks ``firewall/starter_packs/`` at request
+# time so a community-contributed YAML drop-in becomes visible on the
+# next call without an API restart.
+
+
+@router.get("/v1/firewall/library")
+def list_library_packs_endpoint() -> Dict[str, Any]:
+    """List every starter pack available for import. Returns one
+    object per pack: pack_id, display name, category, policy count,
+    short description, lifecycle list, auto-installed flag.
+
+    The dashboard's /firewall/library page renders this verbatim;
+    operators get a one-click install per pack.
+    """
+    from firewall import library as fw_library
+    return {"packs": fw_library.list_packs()}
+
+
+@router.get("/v1/firewall/library/{pack_id}")
+def preview_library_pack_endpoint(pack_id: str) -> Dict[str, Any]:
+    """Preview a pack's policies without writing anything. Used by
+    the import-confirmation modal so operators see what they're
+    about to install.
+    """
+    from firewall import library as fw_library
+    try:
+        return fw_library.preview_pack(pack_id)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"pack not found: {pack_id}")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/v1/firewall/library/{pack_id}/import")
+def import_library_pack_endpoint(
+    pack_id: str,
+    db: Database = Depends(get_db),
+) -> Dict[str, Any]:
+    """Import every policy in a pack into the DB. Idempotent —
+    duplicate policy names are SKIPPED (operator's existing rule
+    wins). All imported policies land in mode=shadow per §10.1.
+    """
+    from firewall import library as fw_library
+    try:
+        result = fw_library.import_pack(db, pack_id)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"pack not found: {pack_id}")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {
+        "pack_id": result.pack_id,
+        "imported": result.imported,
+        "skipped_duplicates": result.skipped_duplicates,
+        "failed": result.failed,
+        "skipped_names": result.skipped_names,
+    }

--- a/packages/api/tests/firewall/test_library.py
+++ b/packages/api/tests/firewall/test_library.py
@@ -1,0 +1,216 @@
+"""Tests for the starter-pack library (§13 / Slice 4).
+
+Coverage:
+
+  - Every YAML in firewall/starter_packs/ parses without a
+    PolicyConfigError. A typo in any pack fails CI here, before
+    operators see a 500.
+  - list_packs() surfaces every pack with metadata
+  - preview_pack() returns the policy list without writing to DB
+  - import_pack() writes policies, defaults to shadow mode, is
+    idempotent on duplicate names
+  - Path-traversal / invalid pack_id is rejected
+  - HTTP endpoints respond with the right shape
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from db import Database
+from firewall import library as fw_library
+import main
+import policy_store
+
+
+@pytest.fixture
+def db() -> Database:
+    d = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    yield d
+    d.close()
+
+
+@pytest.fixture
+def client(db: Database):
+    main.app.dependency_overrides[main.get_db] = lambda: db
+    yield TestClient(main.app)
+    main.app.dependency_overrides.clear()
+
+
+# ----- pack files parse cleanly -------------------------------------------
+
+
+def test_every_pack_parses_without_error() -> None:
+    """Smoke: every pack YAML on disk loads. Catches typos / DSL
+    errors before any test that depends on a specific pack fires."""
+    packs = fw_library.list_packs()
+    assert len(packs) >= 11, (
+        f"expected at least 11 packs (Slice 4 ships 10 + 1 OWASP), "
+        f"found {len(packs)}"
+    )
+
+
+def test_every_pack_ships_shadow_default() -> None:
+    """§10.1 — every starter pack must declare mode=shadow on every
+    policy. Operator promotes per environment after observing
+    EnforcementTimeline."""
+    packs = fw_library.list_packs()
+    for pack in packs:
+        preview = fw_library.preview_pack(pack["pack_id"])
+        non_shadow = [
+            p["name"] for p in preview["policies"]
+            if p.get("mode") != "shadow"
+        ]
+        assert non_shadow == [], (
+            f"pack {pack['pack_id']!r} has non-shadow rules: {non_shadow}"
+        )
+
+
+# ----- list_packs ---------------------------------------------------------
+
+
+def test_list_packs_returns_metadata() -> None:
+    packs = fw_library.list_packs()
+    by_id = {p["pack_id"]: p for p in packs}
+    # Hand-pick a few we know ship in Slice 4
+    assert "owasp_llm_top_10" in by_id
+    assert "owasp_agentic_2025" in by_id
+    assert "compliance_gdpr" in by_id
+    assert "cost_guards" in by_id
+    pack = by_id["compliance_gdpr"]
+    assert pack["category"] == "Compliance"
+    assert pack["policy_count"] >= 1
+    assert "description" in pack and len(pack["description"]) > 0
+    assert isinstance(pack["lifecycles"], list)
+
+
+def test_list_packs_marks_owasp_auto_installed() -> None:
+    packs = fw_library.list_packs()
+    by_id = {p["pack_id"]: p for p in packs}
+    assert by_id["owasp_llm_top_10"]["auto_installed"] is True
+    # Other packs are operator-installed
+    assert by_id["compliance_gdpr"]["auto_installed"] is False
+
+
+# ----- preview_pack -------------------------------------------------------
+
+
+def test_preview_pack_returns_policies() -> None:
+    preview = fw_library.preview_pack("compliance_pci_dss")
+    assert preview["pack_id"] == "compliance_pci_dss"
+    assert preview["policy_count"] >= 1
+    assert len(preview["policies"]) == preview["policy_count"]
+    first = preview["policies"][0]
+    # Each row has the dashboard's expected shape
+    for key in ("name", "lifecycle", "mode", "condition", "action", "severity"):
+        assert key in first
+
+
+def test_preview_unknown_pack_raises() -> None:
+    with pytest.raises(FileNotFoundError):
+        fw_library.preview_pack("does_not_exist")
+
+
+def test_preview_traversal_rejected() -> None:
+    """Defense in depth: a malicious pack_id with .. or / is
+    rejected before touching the filesystem."""
+    with pytest.raises((FileNotFoundError, ValueError)):
+        fw_library.preview_pack("../../etc/passwd")
+
+
+# ----- import_pack --------------------------------------------------------
+
+
+def test_import_pack_writes_policies(db: Database) -> None:
+    result = fw_library.import_pack(db, "cost_guards")
+    assert result.imported > 0
+    assert result.failed == 0
+    assert result.skipped_duplicates == 0
+    rows = policy_store.list_policies(db)
+    assert len(rows) == result.imported
+
+
+def test_import_pack_idempotent(db: Database) -> None:
+    """Re-importing the same pack skips duplicates, preserves
+    operator edits to existing rows."""
+    first = fw_library.import_pack(db, "cost_guards")
+    second = fw_library.import_pack(db, "cost_guards")
+    assert first.imported > 0
+    assert second.imported == 0
+    assert second.skipped_duplicates == first.imported
+
+
+def test_import_pack_lands_in_shadow(db: Database) -> None:
+    """§10.1 — even if a pack mistakenly declared mode=enforce, the
+    import normalises to shadow."""
+    fw_library.import_pack(db, "owasp_agentic_2025")
+    rows = policy_store.list_policies(db)
+    assert all(p.mode == "shadow" for p in rows), (
+        f"non-shadow rows after import: "
+        f"{[p.name for p in rows if p.mode != 'shadow']}"
+    )
+
+
+def test_import_unknown_pack_raises(db: Database) -> None:
+    with pytest.raises(FileNotFoundError):
+        fw_library.import_pack(db, "no_such_pack")
+
+
+# ----- HTTP surface -------------------------------------------------------
+
+
+def test_get_library_lists_packs(client: TestClient) -> None:
+    resp = client.get("/v1/firewall/library")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "packs" in body
+    pack_ids = {p["pack_id"] for p in body["packs"]}
+    # Every Slice 4 pack must show up
+    expected = {
+        "owasp_llm_top_10",
+        "owasp_agentic_2025",
+        "dev_environment_safety",
+        "customer_support_agent",
+        "code_assistant",
+        "compliance_gdpr",
+        "compliance_hipaa",
+        "compliance_pci_dss",
+        "framework_mastra",
+        "framework_langgraph",
+        "cost_guards",
+    }
+    missing = expected - pack_ids
+    assert missing == set(), f"missing packs in /v1/firewall/library: {missing}"
+
+
+def test_get_library_preview(client: TestClient) -> None:
+    resp = client.get("/v1/firewall/library/customer_support_agent")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["pack_id"] == "customer_support_agent"
+    assert body["policy_count"] >= 1
+    assert isinstance(body["policies"], list)
+
+
+def test_get_library_preview_404_for_unknown(client: TestClient) -> None:
+    resp = client.get("/v1/firewall/library/no_such_pack")
+    assert resp.status_code == 404
+
+
+def test_post_library_import_writes_rows(client: TestClient, db: Database) -> None:
+    resp = client.post("/v1/firewall/library/dev_environment_safety/import")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["imported"] > 0
+    assert body["failed"] == 0
+    rows = policy_store.list_policies(db)
+    names = {r.name for r in rows}
+    assert any(n.startswith("dev_safety_") for n in names)
+
+
+def test_post_library_import_unknown_pack_404(client: TestClient) -> None:
+    resp = client.post("/v1/firewall/library/no_such_pack/import")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Ships the remaining 10 starter packs from spec §13.1 plus a library API to discover and one-click-import them.

**Before:** only `owasp-llm-top-10` shipped, auto-installed on first boot. No way to discover or install other packs.

**After:** 11 packs total. Operator browses `/v1/firewall/library`, previews policies, imports with one POST. All imports land in `mode: shadow` per §10.1.

### Packs added

| Pack | Category | Policies |
|---|---|---|
| `owasp_agentic_2025` | Threat coverage | 7 |
| `dev_environment_safety` | Use case | 7 |
| `customer_support_agent` | Use case | 6 |
| `code_assistant` | Use case | 7 |
| `compliance_gdpr` | Compliance | 6 |
| `compliance_hipaa` | Compliance | 6 |
| `compliance_pci_dss` | Compliance | 6 |
| `framework_mastra` | Framework | 5 |
| `framework_langgraph` | Framework | 6 |
| `cost_guards` | Operational | 6 |

**62 new policies** across the 10 packs. All `mode: shadow`.

### API surface (§13.3 one-click import)

```
GET  /v1/firewall/library                  list available packs
GET  /v1/firewall/library/{pack_id}        preview policies
POST /v1/firewall/library/{pack_id}/import insert into DB (idempotent)
```

Idempotency: re-importing skips duplicate names so operator edits never get clobbered. Imports normalise to `mode: shadow` even if a community-contributed YAML accidentally declared otherwise (defense in depth).

### Tests

- Smoke: every pack YAML on disk parses without `PolicyConfigError`
- Every pack ships shadow-default
- Library endpoints return correct shape and 404 unknown packs
- Path-traversal pack_ids rejected
- Import is idempotent (second run = 0 new, all skipped)

**Full firewall suite: 390 passed** (was 374 — 16 new, no regressions).

## Test plan

- [x] All 11 packs parse cleanly
- [x] Tests pass on a fresh DB
- [x] Library endpoint surfaces every pack
- [ ] Manual: hit `GET /v1/firewall/library` against running API, verify shape
- [ ] Manual: import `compliance_gdpr` against a fresh project, verify rules appear in `/firewall/policies`