### PR TITLE
feat(firewall): outbound webhooks + email notifications (Slice 4 §9.10/§9.11)

### DIFF
--- a/packages/api/db.py
+++ b/packages/api/db.py
@@ -138,6 +138,18 @@ class Database:
         self._lock = threading.Lock()
         self._init_schema()
 
+    # Read-only path accessors for code (e.g. background webhook
+    # workers) that needs to open its own short-lived Database
+    # connection because the main one isn't safe for cross-thread
+    # use.
+    @property
+    def duckdb_path(self) -> str:
+        return self._duckdb_path
+
+    @property
+    def sqlite_path(self) -> str:
+        return self._sqlite_path
+
     def _init_schema(self) -> None:
         with self._lock:
             for stmt in DUCKDB_SCHEMA.strip().split(";"):

--- a/packages/api/firewall/decide.py
+++ b/packages/api/firewall/decide.py
@@ -921,6 +921,8 @@ def _record_decision(
     insert fails — caller still wants something to put in the response.
     """
     decision_id = "dec_" + uuid.uuid4().hex[:24]
+    policy_name = policy.name if policy else "_engine_"
+    severity = getattr(policy, "severity", None) if policy is not None else None
     try:
         db.execute(
             """
@@ -934,8 +936,8 @@ def _record_decision(
             """,
             [
                 decision_id,
-                policy.name if policy else "_engine_",
-                policy.name if policy else "_engine_",
+                policy_name,
+                policy_name,
                 lifecycle,
                 decision,
                 mode_at_decision,
@@ -949,6 +951,30 @@ def _record_decision(
         )
     except Exception:
         logger.exception("firewall.decide: failed to insert decision row")
+
+    # §9.10 / §9.11 — fire outbound webhooks for block-class decisions.
+    # Fire-and-forget via a worker pool inside webhooks.py so a slow
+    # webhook never delays the firewall response (Rule 7).
+    if decision in {"block", "require_approval", "rewrite"}:
+        try:
+            from firewall import webhooks as fw_webhooks
+            fw_webhooks.fire_for_decision(
+                db,
+                decision_id=decision_id,
+                decision=decision,
+                severity=severity,
+                policy_name=policy_name,
+                project=project,
+                reason=reason,
+                trace_id=trace_id,
+                mode_at_decision=mode_at_decision,
+            )
+        except Exception:
+            logger.exception(
+                "firewall.decide: webhook dispatch failed for decision %s",
+                decision_id,
+            )
+
     return decision_id
 
 

--- a/packages/api/firewall/migrations.py
+++ b/packages/api/firewall/migrations.py
@@ -153,6 +153,47 @@ CREATE TABLE IF NOT EXISTS firewall_kv (
 );
 """
 
+# Outbound webhooks (§9.10) and notification channels (§9.11).
+# One row per configured destination. Operators add via the dashboard
+# or POST /v1/firewall/webhooks; the dispatcher reads on each block-
+# class decision.
+#
+# kind = 'slack' | 'discord' | 'pagerduty' | 'generic' | 'email'
+# config_json — kind-specific config (channel, webhook URL, smtp settings,
+#               PagerDuty routing key, generic HMAC secret, etc.)
+# severity_min — only fire for decisions at or above this severity
+# project_filter — only fire for this project (null = all projects)
+_CREATE_FIREWALL_WEBHOOKS = """
+CREATE TABLE IF NOT EXISTS firewall_webhooks (
+    id VARCHAR PRIMARY KEY,
+    name VARCHAR NOT NULL,
+    kind VARCHAR NOT NULL,
+    config_json VARCHAR NOT NULL,
+    severity_min VARCHAR DEFAULT 'medium',
+    project_filter VARCHAR,
+    active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    last_fired_at TIMESTAMP,
+    last_error VARCHAR
+);
+"""
+
+# DLQ for webhook deliveries that exhausted retries. The dispatcher
+# writes to this on final failure; operators inspect via GET
+# /v1/firewall/webhooks/failures.
+_CREATE_FIREWALL_WEBHOOK_FAILURES = """
+CREATE TABLE IF NOT EXISTS firewall_webhook_failures (
+    id VARCHAR PRIMARY KEY,
+    webhook_id VARCHAR NOT NULL,
+    decision_id VARCHAR,
+    attempt_count INTEGER NOT NULL,
+    last_error VARCHAR,
+    payload_truncated VARCHAR,
+    failed_at TIMESTAMP NOT NULL
+);
+"""
+
 
 # Indexes — one per query pattern we know we need from §5 of the spec.
 # Adding more later is cheap; missing them at launch shows up as a
@@ -227,8 +268,14 @@ def apply(conn) -> None:
         _CREATE_PATTERN_SUGGESTIONS,
         _CREATE_POLICY_VERSIONS,
         _CREATE_FIREWALL_KV,
+        _CREATE_FIREWALL_WEBHOOKS,
+        _CREATE_FIREWALL_WEBHOOK_FAILURES,
         *_POLICY_EXTENSIONS,
         *_INDEXES,
+        # Webhook indexes — dashboard query patterns
+        "CREATE INDEX IF NOT EXISTS idx_webhooks_active ON firewall_webhooks(active)",
+        "CREATE INDEX IF NOT EXISTS idx_webhook_failures_webhook ON firewall_webhook_failures(webhook_id)",
+        "CREATE INDEX IF NOT EXISTS idx_webhook_failures_failed_at ON firewall_webhook_failures(failed_at DESC)",
     )
     for stmt in statements:
         try:

--- a/packages/api/firewall/webhooks.py
+++ b/packages/api/firewall/webhooks.py
@@ -1,0 +1,689 @@
+"""Webhook outbound + notification channels (§9.10, §9.11).
+
+Owns the dispatcher that fires alerts when a block-class decision
+lands. Five destination kinds are supported:
+
+  - slack     — Slack chat.postMessage shape (or webhook URL)
+  - discord   — Discord webhook shape
+  - pagerduty — PagerDuty Events v2 (trigger event)
+  - generic   — POST + HMAC signature
+  - email     — SMTP delivery (server config in env)
+
+Behavior contract:
+
+  - Fire-and-forget from the firewall hot path. The dispatcher uses
+    a shared executor so a slow webhook never delays a decide()
+    response (Rule 7 generalised — agents must not wait on us).
+  - Exponential backoff: attempts 1/2/3 separated by 1s/3s/9s.
+  - On final failure, write to ``firewall_webhook_failures`` so the
+    dashboard surfaces a DLQ.
+  - Severity filter — webhooks have a ``severity_min`` so a noisy
+    rule doesn't page on-call.
+
+Per spec §10 we never let webhook activity break the firewall:
+every dispatch is wrapped in try/except, every error is logged,
+and the firewall response returns regardless.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import smtplib
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.message import EmailMessage
+from typing import Any, Dict, List, Optional
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+from db import Database
+
+logger = logging.getLogger("lumin.api.firewall.webhooks")
+
+
+# ---- valid kinds + severity ordering --------------------------------------
+
+VALID_KINDS = frozenset({"slack", "discord", "pagerduty", "generic", "email"})
+
+# Severities in ascending priority. A webhook with severity_min='medium'
+# fires for medium / high / critical decisions, not low.
+_SEVERITY_RANK: Dict[str, int] = {
+    "low": 0,
+    "medium": 1,
+    "high": 2,
+    "critical": 3,
+}
+
+
+def _severity_passes(decision_severity: Optional[str], min_severity: str) -> bool:
+    decision_rank = _SEVERITY_RANK.get((decision_severity or "medium").lower(), 1)
+    min_rank = _SEVERITY_RANK.get((min_severity or "medium").lower(), 1)
+    return decision_rank >= min_rank
+
+
+# ---- shared dispatcher executor -------------------------------------------
+#
+# 4 worker threads is plenty: webhooks are I/O-bound and we don't
+# expect more than a handful of subscribers per deployment. Bigger
+# pools would just add memory overhead. The pool is process-global
+# and lazy-initialised — tests that need to await all dispatches
+# call ``shutdown_for_tests()``.
+
+_EXECUTOR_LOCK = threading.Lock()
+_EXECUTOR: Optional[ThreadPoolExecutor] = None
+
+
+def _get_executor() -> ThreadPoolExecutor:
+    global _EXECUTOR
+    with _EXECUTOR_LOCK:
+        if _EXECUTOR is None:
+            _EXECUTOR = ThreadPoolExecutor(
+                max_workers=4, thread_name_prefix="lumin-webhooks"
+            )
+        return _EXECUTOR
+
+
+def shutdown_for_tests() -> None:
+    """Test helper. Drains pending webhook dispatches so test
+    assertions don't race with background threads."""
+    global _EXECUTOR
+    with _EXECUTOR_LOCK:
+        if _EXECUTOR is not None:
+            _EXECUTOR.shutdown(wait=True)
+            _EXECUTOR = None
+
+
+# ---- public types ---------------------------------------------------------
+
+
+@dataclass
+class WebhookConfig:
+    id: str
+    name: str
+    kind: str
+    config: Dict[str, Any]
+    severity_min: str
+    project_filter: Optional[str]
+    active: bool
+
+
+# ---- config CRUD ----------------------------------------------------------
+
+
+def _utc_now_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def create_webhook(
+    db: Database,
+    *,
+    name: str,
+    kind: str,
+    config: Dict[str, Any],
+    severity_min: str = "medium",
+    project_filter: Optional[str] = None,
+) -> WebhookConfig:
+    """Insert a new webhook config row."""
+    if kind not in VALID_KINDS:
+        raise ValueError(f"unknown webhook kind: {kind!r}")
+    if severity_min not in _SEVERITY_RANK:
+        raise ValueError(f"severity_min must be one of {sorted(_SEVERITY_RANK)}")
+    _validate_kind_config(kind, config)
+
+    wh_id = "wh_" + uuid.uuid4().hex[:24]
+    now = _utc_now_naive()
+    db.execute(
+        """
+        INSERT INTO firewall_webhooks (
+            id, name, kind, config_json, severity_min,
+            project_filter, active, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            wh_id, name, kind, json.dumps(config),
+            severity_min, project_filter, True, now, now,
+        ],
+    )
+    return WebhookConfig(
+        id=wh_id, name=name, kind=kind, config=config,
+        severity_min=severity_min, project_filter=project_filter, active=True,
+    )
+
+
+def list_webhooks(db: Database) -> List[Dict[str, Any]]:
+    rows = db.fetchall_dict(
+        """
+        SELECT id, name, kind, config_json, severity_min,
+               project_filter, active, created_at, updated_at,
+               last_fired_at, last_error
+        FROM firewall_webhooks
+        ORDER BY created_at DESC
+        """
+    )
+    out: List[Dict[str, Any]] = []
+    for r in rows:
+        try:
+            cfg = json.loads(r.get("config_json") or "{}")
+        except Exception:
+            cfg = {}
+        # Don't echo secrets back over the API. Mask config values
+        # whose key suggests sensitivity.
+        cfg = _mask_secret_fields(cfg)
+        out.append({
+            "id": r["id"],
+            "name": r["name"],
+            "kind": r["kind"],
+            "config": cfg,
+            "severity_min": r.get("severity_min") or "medium",
+            "project_filter": r.get("project_filter"),
+            "active": bool(r.get("active") or False),
+            "created_at": r.get("created_at"),
+            "updated_at": r.get("updated_at"),
+            "last_fired_at": r.get("last_fired_at"),
+            "last_error": r.get("last_error"),
+        })
+    return out
+
+
+def delete_webhook(db: Database, webhook_id: str) -> bool:
+    row = db.fetchone("SELECT id FROM firewall_webhooks WHERE id = ?", [webhook_id])
+    if row is None:
+        return False
+    db.execute("DELETE FROM firewall_webhooks WHERE id = ?", [webhook_id])
+    return True
+
+
+def _mask_secret_fields(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    masked: Dict[str, Any] = {}
+    for k, v in cfg.items():
+        kl = k.lower()
+        if isinstance(v, str) and any(
+            tok in kl for tok in ("token", "secret", "key", "password", "auth")
+        ):
+            masked[k] = _mask_value(v)
+        else:
+            masked[k] = v
+    return masked
+
+
+def _mask_value(v: str) -> str:
+    if len(v) <= 6:
+        return "****"
+    return v[:3] + "…" + v[-3:]
+
+
+def _validate_kind_config(kind: str, config: Dict[str, Any]) -> None:
+    """Per-kind required fields. Errors here surface as 400 from
+    the create endpoint."""
+    required: Dict[str, List[str]] = {
+        "slack": ["webhook_url"],
+        "discord": ["webhook_url"],
+        "pagerduty": ["routing_key"],
+        "generic": ["url"],
+        "email": ["to"],
+    }
+    needed = required.get(kind, [])
+    missing = [k for k in needed if not config.get(k)]
+    if missing:
+        raise ValueError(
+            f"webhook kind={kind!r} requires config keys: {missing}"
+        )
+
+
+# ---- dispatch on decision -------------------------------------------------
+
+
+def fire_for_decision(
+    db: Database,
+    *,
+    decision_id: str,
+    decision: str,
+    severity: Optional[str],
+    policy_name: Optional[str],
+    project: Optional[str],
+    reason: Optional[str],
+    trace_id: Optional[str],
+    mode_at_decision: Optional[str],
+) -> int:
+    """Dispatch the relevant webhooks for a decision. Returns the
+    number of webhook deliveries scheduled (not the count completed —
+    delivery happens in the executor).
+
+    Called from ``firewall.decide._record_decision`` after a block-
+    class verb fires. Runs synchronously up to the executor.submit
+    call; the actual HTTP/SMTP work happens off-thread.
+
+    Per Rule 7, every error is swallowed. The firewall response must
+    not depend on webhook firing succeeding.
+    """
+    try:
+        webhooks = _list_active_for_dispatch(db, project=project)
+    except Exception:
+        logger.exception("webhooks: failed to list webhooks for decision %s", decision_id)
+        return 0
+
+    scheduled = 0
+    for wh in webhooks:
+        if not _severity_passes(severity, wh.severity_min):
+            continue
+        payload = _build_payload(
+            kind=wh.kind,
+            decision_id=decision_id,
+            decision=decision,
+            severity=severity or "medium",
+            policy_name=policy_name or "_engine_",
+            project=project,
+            reason=reason or "",
+            trace_id=trace_id,
+            mode_at_decision=mode_at_decision or "enforce",
+            webhook_name=wh.name,
+        )
+        # Fire-and-forget. Errors land in the DLQ via _attempt_with_retries.
+        try:
+            _get_executor().submit(
+                _attempt_with_retries,
+                webhook=wh,
+                payload=payload,
+                decision_id=decision_id,
+                # Pass the duckdb path explicitly — the worker thread
+                # opens its own connection on failure paths because the
+                # main Database object isn't safe for cross-thread use.
+                duckdb_path=db.duckdb_path,
+                sqlite_path=db.sqlite_path,
+            )
+            scheduled += 1
+        except Exception:
+            logger.exception("webhooks: failed to schedule dispatch for %s", wh.id)
+    return scheduled
+
+
+def _list_active_for_dispatch(
+    db: Database, *, project: Optional[str]
+) -> List[WebhookConfig]:
+    rows = db.fetchall_dict(
+        """
+        SELECT id, name, kind, config_json, severity_min, project_filter
+        FROM firewall_webhooks
+        WHERE active = true
+          AND (project_filter IS NULL OR project_filter = ?)
+        """,
+        [project or ""],
+    )
+    out: List[WebhookConfig] = []
+    for r in rows:
+        try:
+            cfg = json.loads(r.get("config_json") or "{}")
+        except Exception:
+            cfg = {}
+        out.append(WebhookConfig(
+            id=r["id"], name=r["name"], kind=r["kind"], config=cfg,
+            severity_min=r.get("severity_min") or "medium",
+            project_filter=r.get("project_filter"),
+            active=True,
+        ))
+    return out
+
+
+# ---- payload builders -----------------------------------------------------
+
+
+def _build_payload(
+    *,
+    kind: str,
+    decision_id: str,
+    decision: str,
+    severity: str,
+    policy_name: str,
+    project: Optional[str],
+    reason: str,
+    trace_id: Optional[str],
+    mode_at_decision: str,
+    webhook_name: str,
+) -> Dict[str, Any]:
+    """Kind-specific payload shape. The dispatcher serialises this
+    differently per kind (JSON for HTTP, structured for SMTP)."""
+    title = f"Lumin firewall · {decision} · {policy_name}"
+    summary = (
+        f"Decision {decision_id} ({decision}, mode={mode_at_decision}) "
+        f"matched policy {policy_name}"
+    )
+    if reason:
+        summary += f" — {reason[:140]}"
+
+    if kind == "slack":
+        return {
+            "text": title,
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"*{title}*\n"
+                            f"• policy: `{policy_name}`\n"
+                            f"• severity: `{severity}`\n"
+                            f"• mode: `{mode_at_decision}`\n"
+                            f"• project: `{project or 'default'}`\n"
+                            f"• trace: `{trace_id or '—'}`\n"
+                            f"• reason: {reason[:200] if reason else '—'}"
+                        ),
+                    },
+                }
+            ],
+        }
+    if kind == "discord":
+        return {
+            "content": title,
+            "embeds": [
+                {
+                    "title": title,
+                    "description": summary[:1900],
+                    "color": _severity_color(severity),
+                    "fields": [
+                        {"name": "policy", "value": policy_name, "inline": True},
+                        {"name": "severity", "value": severity, "inline": True},
+                        {"name": "mode", "value": mode_at_decision, "inline": True},
+                        {"name": "project", "value": project or "default", "inline": True},
+                        {"name": "trace_id", "value": trace_id or "—", "inline": False},
+                    ],
+                }
+            ],
+        }
+    if kind == "pagerduty":
+        return {
+            "event_action": "trigger",
+            "dedup_key": f"lumin:{policy_name}:{trace_id or decision_id}",
+            "payload": {
+                "summary": summary[:1024],
+                "source": "lumin-firewall",
+                "severity": _pagerduty_severity(severity),
+                "component": "agent-firewall",
+                "group": project or "default",
+                "class": "policy_violation",
+                "custom_details": {
+                    "decision_id": decision_id,
+                    "decision": decision,
+                    "policy_name": policy_name,
+                    "mode_at_decision": mode_at_decision,
+                    "trace_id": trace_id,
+                    "project": project,
+                    "reason": reason,
+                },
+            },
+        }
+    if kind == "email":
+        return {
+            "subject": title,
+            "body": (
+                f"{summary}\n\n"
+                f"decision_id: {decision_id}\n"
+                f"policy:      {policy_name}\n"
+                f"severity:    {severity}\n"
+                f"mode:        {mode_at_decision}\n"
+                f"project:     {project or 'default'}\n"
+                f"trace_id:    {trace_id or '—'}\n"
+                f"reason:      {reason or '—'}\n"
+            ),
+            "title": title,
+        }
+    # generic — full envelope, caller signs with HMAC
+    return {
+        "type": "lumin.firewall.decision",
+        "decision_id": decision_id,
+        "decision": decision,
+        "policy_name": policy_name,
+        "severity": severity,
+        "mode_at_decision": mode_at_decision,
+        "project": project,
+        "trace_id": trace_id,
+        "reason": reason,
+        "webhook_name": webhook_name,
+        "fired_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _severity_color(severity: str) -> int:
+    return {
+        "low": 0x95A5A6,        # slate
+        "medium": 0xF1C40F,     # amber
+        "high": 0xE67E22,       # orange
+        "critical": 0xE74C3C,   # rose
+    }.get((severity or "medium").lower(), 0xF1C40F)
+
+
+def _pagerduty_severity(severity: str) -> str:
+    """Map our 4-level severity to PagerDuty's vocabulary."""
+    return {
+        "low": "info",
+        "medium": "warning",
+        "high": "error",
+        "critical": "critical",
+    }.get((severity or "medium").lower(), "warning")
+
+
+# ---- HTTP / SMTP delivery -------------------------------------------------
+
+
+_BACKOFF_SECONDS = (1, 3, 9)
+_HTTP_TIMEOUT_S = 5
+_TRUNCATE_PAYLOAD_AT = 8000
+
+
+def _attempt_with_retries(
+    *,
+    webhook: WebhookConfig,
+    payload: Dict[str, Any],
+    decision_id: str,
+    duckdb_path: str,
+    sqlite_path: str,
+) -> None:
+    """Try to deliver once, retry up to 2 more times with backoff,
+    record DLQ on final failure. Runs in the executor."""
+    last_error: Optional[str] = None
+    for attempt in range(1, 4):
+        try:
+            _deliver_once(webhook, payload)
+            _mark_fired(duckdb_path, sqlite_path, webhook.id, error=None)
+            return
+        except Exception as e:
+            last_error = f"{type(e).__name__}: {e}"
+            logger.warning(
+                "webhooks: %s attempt %d/3 failed: %s",
+                webhook.id, attempt, last_error,
+            )
+            if attempt < 3:
+                time.sleep(_BACKOFF_SECONDS[attempt - 1])
+    # Exhausted retries — record DLQ entry.
+    try:
+        _record_dlq(
+            duckdb_path, sqlite_path,
+            webhook_id=webhook.id, decision_id=decision_id,
+            attempt_count=3, last_error=last_error or "unknown",
+            payload=payload,
+        )
+        _mark_fired(duckdb_path, sqlite_path, webhook.id, error=last_error or "exhausted")
+    except Exception:
+        logger.exception("webhooks: failed to write DLQ row for %s", webhook.id)
+
+
+def _deliver_once(webhook: WebhookConfig, payload: Dict[str, Any]) -> None:
+    if webhook.kind == "email":
+        _deliver_email(webhook, payload)
+        return
+    if webhook.kind == "pagerduty":
+        _deliver_http_json(
+            url="https://events.pagerduty.com/v2/enqueue",
+            payload=payload,
+            extra_headers={},
+            secret=None,
+        )
+        return
+    if webhook.kind == "slack":
+        url = webhook.config.get("webhook_url") or ""
+        _deliver_http_json(url=url, payload=payload)
+        return
+    if webhook.kind == "discord":
+        url = webhook.config.get("webhook_url") or ""
+        _deliver_http_json(url=url, payload=payload)
+        return
+    if webhook.kind == "generic":
+        url = webhook.config.get("url") or ""
+        secret = webhook.config.get("hmac_secret")
+        _deliver_http_json(url=url, payload=payload, secret=secret)
+        return
+    raise ValueError(f"unknown webhook kind: {webhook.kind}")
+
+
+def _deliver_http_json(
+    *,
+    url: str,
+    payload: Dict[str, Any],
+    extra_headers: Optional[Dict[str, str]] = None,
+    secret: Optional[str] = None,
+) -> None:
+    if not url:
+        raise ValueError("webhook url is empty")
+    body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json", "User-Agent": "lumin-firewall/1.0"}
+    if extra_headers:
+        headers.update(extra_headers)
+    if secret:
+        signature = hmac.new(
+            secret.encode("utf-8"), body, hashlib.sha256
+        ).hexdigest()
+        headers["X-Lumin-Signature"] = f"sha256={signature}"
+
+    req = urllib_request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib_request.urlopen(req, timeout=_HTTP_TIMEOUT_S) as resp:
+            status = resp.getcode()
+    except urllib_error.HTTPError as e:
+        raise RuntimeError(f"HTTP {e.code} {e.reason}") from e
+    except urllib_error.URLError as e:
+        raise RuntimeError(f"URL error: {e.reason}") from e
+    if status >= 400:
+        raise RuntimeError(f"HTTP {status}")
+
+
+def _deliver_email(webhook: WebhookConfig, payload: Dict[str, Any]) -> None:
+    """SMTP delivery using env-configured server. Operator-driven
+    (no SaaS escape hatch) so credentials stay on-box.
+
+    Required env: ``LUMIN_SMTP_HOST``. Optional: PORT, USERNAME,
+    PASSWORD, FROM, USE_TLS. Per-webhook ``to`` is in config.
+    """
+    smtp_host = os.environ.get("LUMIN_SMTP_HOST")
+    if not smtp_host:
+        raise RuntimeError("LUMIN_SMTP_HOST not configured")
+
+    smtp_port = int(os.environ.get("LUMIN_SMTP_PORT", "587"))
+    smtp_user = os.environ.get("LUMIN_SMTP_USERNAME")
+    smtp_pass = os.environ.get("LUMIN_SMTP_PASSWORD")
+    smtp_from = os.environ.get("LUMIN_SMTP_FROM", "lumin-firewall@localhost")
+    use_tls = (
+        os.environ.get("LUMIN_SMTP_USE_TLS", "true").lower() in ("1", "true", "yes")
+    )
+
+    recipients = webhook.config.get("to") or []
+    if isinstance(recipients, str):
+        recipients = [recipients]
+
+    msg = EmailMessage()
+    msg["Subject"] = payload.get("subject") or "Lumin firewall alert"
+    msg["From"] = smtp_from
+    msg["To"] = ", ".join(recipients)
+    msg.set_content(payload.get("body") or "")
+
+    with smtplib.SMTP(smtp_host, smtp_port, timeout=_HTTP_TIMEOUT_S) as server:
+        if use_tls:
+            server.starttls()
+        if smtp_user and smtp_pass:
+            server.login(smtp_user, smtp_pass)
+        server.send_message(msg)
+
+
+def _mark_fired(
+    duckdb_path: str, sqlite_path: str, webhook_id: str, *, error: Optional[str]
+) -> None:
+    """Update last_fired_at + last_error on the row. Opens its own
+    Database connection because the dispatcher runs in a worker
+    thread."""
+    db = Database(duckdb_path=duckdb_path, sqlite_path=sqlite_path)
+    try:
+        db.execute(
+            """
+            UPDATE firewall_webhooks
+               SET last_fired_at = ?, last_error = ?, updated_at = ?
+             WHERE id = ?
+            """,
+            [_utc_now_naive(), error, _utc_now_naive(), webhook_id],
+        )
+    except Exception:
+        logger.exception("webhooks: _mark_fired failed for %s", webhook_id)
+    finally:
+        db.close()
+
+
+def _record_dlq(
+    duckdb_path: str,
+    sqlite_path: str,
+    *,
+    webhook_id: str,
+    decision_id: str,
+    attempt_count: int,
+    last_error: str,
+    payload: Dict[str, Any],
+) -> None:
+    db = Database(duckdb_path=duckdb_path, sqlite_path=sqlite_path)
+    try:
+        try:
+            payload_str = json.dumps(payload, default=str)[:_TRUNCATE_PAYLOAD_AT]
+        except Exception:
+            payload_str = str(payload)[:_TRUNCATE_PAYLOAD_AT]
+        db.execute(
+            """
+            INSERT INTO firewall_webhook_failures (
+                id, webhook_id, decision_id, attempt_count,
+                last_error, payload_truncated, failed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                "fail_" + uuid.uuid4().hex[:24],
+                webhook_id, decision_id, attempt_count,
+                last_error[:500], payload_str, _utc_now_naive(),
+            ],
+        )
+    finally:
+        db.close()
+
+
+def list_failures(db: Database, *, limit: int = 100) -> List[Dict[str, Any]]:
+    rows = db.fetchall_dict(
+        """
+        SELECT id, webhook_id, decision_id, attempt_count,
+               last_error, failed_at
+        FROM firewall_webhook_failures
+        ORDER BY failed_at DESC
+        LIMIT ?
+        """,
+        [limit],
+    )
+    return [
+        {
+            "id": r["id"],
+            "webhook_id": r["webhook_id"],
+            "decision_id": r.get("decision_id"),
+            "attempt_count": int(r.get("attempt_count") or 0),
+            "last_error": r.get("last_error"),
+            "failed_at": r.get("failed_at"),
+        }
+        for r in rows
+    ]

--- a/packages/api/routers/firewall.py
+++ b/packages/api/routers/firewall.py
@@ -1095,3 +1095,83 @@ def list_classifier_models_endpoint(
     classifier page."""
     from firewall.detectors import local_classifier as lc_det
     return {"models": lc_det.list_models(db)}
+
+
+# ----- Webhooks (§9.10) + Notifications (§9.11) -------------------------
+#
+# Outbound destinations operators wire to the firewall: Slack /
+# Discord / PagerDuty / generic POST + HMAC / email. Decisions in
+# {block, require_approval, rewrite} that pass severity_min trigger
+# the dispatcher. Configuration lives in firewall_webhooks; failed
+# deliveries land in firewall_webhook_failures (DLQ) after 3 retries.
+
+
+class WebhookCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1)
+    kind: str = Field(..., description="slack | discord | pagerduty | generic | email")
+    config: Dict[str, Any] = Field(default_factory=dict)
+    severity_min: str = Field(default="medium")
+    project_filter: Optional[str] = None
+
+
+@router.get("/v1/firewall/webhooks")
+def list_firewall_webhooks_endpoint(
+    db: Database = Depends(get_db),
+) -> Dict[str, Any]:
+    """List configured webhook destinations. Secret config fields
+    (tokens, HMAC keys) are masked in the response — operators see
+    enough to identify the row but not exfiltrate the secret."""
+    from firewall import webhooks as fw_webhooks
+    return {"webhooks": fw_webhooks.list_webhooks(db)}
+
+
+@router.post("/v1/firewall/webhooks")
+def create_firewall_webhook_endpoint(
+    payload: WebhookCreateRequest,
+    db: Database = Depends(get_db),
+) -> Dict[str, Any]:
+    """Create a new webhook destination. Returns the row id; the
+    secret config field comes back masked on subsequent GETs."""
+    from firewall import webhooks as fw_webhooks
+    try:
+        wh = fw_webhooks.create_webhook(
+            db,
+            name=payload.name,
+            kind=payload.kind,
+            config=payload.config,
+            severity_min=payload.severity_min,
+            project_filter=payload.project_filter,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {
+        "id": wh.id,
+        "name": wh.name,
+        "kind": wh.kind,
+        "severity_min": wh.severity_min,
+        "project_filter": wh.project_filter,
+        "active": wh.active,
+    }
+
+
+@router.delete("/v1/firewall/webhooks/{webhook_id}")
+def delete_firewall_webhook_endpoint(
+    webhook_id: str,
+    db: Database = Depends(get_db),
+) -> Dict[str, Any]:
+    from firewall import webhooks as fw_webhooks
+    deleted = fw_webhooks.delete_webhook(db, webhook_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"webhook not found: {webhook_id}")
+    return {"id": webhook_id, "deleted": True}
+
+
+@router.get("/v1/firewall/webhooks/failures")
+def list_webhook_failures_endpoint(
+    limit: int = Query(100, ge=1, le=500),
+    db: Database = Depends(get_db),
+) -> Dict[str, Any]:
+    """Webhook DLQ — deliveries that exhausted retries. Operators
+    inspect this when a Slack / PagerDuty channel goes dark."""
+    from firewall import webhooks as fw_webhooks
+    return {"failures": fw_webhooks.list_failures(db, limit=limit)}

--- a/packages/api/tests/firewall/test_webhooks.py
+++ b/packages/api/tests/firewall/test_webhooks.py
@@ -1,0 +1,378 @@
+"""Tests for the webhook outbound + notification channels (§9.10,
+§9.11 / Slice 4).
+
+Coverage:
+
+  - Schema migration creates firewall_webhooks + firewall_webhook_failures
+  - create_webhook validates kind + required config fields
+  - list_webhooks masks secret-shaped config keys
+  - severity_min filter excludes low-severity decisions
+  - Dispatcher fires Slack / Discord / generic / pagerduty payloads
+    in the correct shape (no real network — urlopen monkeypatched)
+  - On HTTP failure, retries up to 3 times then writes a DLQ row
+  - HTTP endpoints (CRUD + failures) work
+  - Decide-engine bridge: a block-class decision triggers the
+    dispatcher; allow does not
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from db import Database
+from firewall import webhooks as fw_webhooks
+import main
+
+
+@pytest.fixture(autouse=True)
+def _reset_executor():
+    """Each test gets a clean executor — pending dispatches from
+    one test must not leak into the next."""
+    yield
+    fw_webhooks.shutdown_for_tests()
+
+
+@pytest.fixture
+def db() -> Database:
+    d = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    yield d
+    d.close()
+
+
+@pytest.fixture
+def client(db: Database):
+    main.app.dependency_overrides[main.get_db] = lambda: db
+    yield TestClient(main.app)
+    main.app.dependency_overrides.clear()
+
+
+# ----- create / validate ---------------------------------------------------
+
+
+def test_create_slack_webhook(db: Database) -> None:
+    wh = fw_webhooks.create_webhook(
+        db,
+        name="ops",
+        kind="slack",
+        config={"webhook_url": "https://hooks.slack.com/services/ABC/DEF"},
+    )
+    assert wh.id.startswith("wh_")
+    assert wh.kind == "slack"
+
+
+def test_create_rejects_unknown_kind(db: Database) -> None:
+    with pytest.raises(ValueError):
+        fw_webhooks.create_webhook(
+            db, name="bad", kind="telnet", config={"url": "tcp://x"},
+        )
+
+
+def test_create_rejects_missing_required_config(db: Database) -> None:
+    # slack requires webhook_url
+    with pytest.raises(ValueError):
+        fw_webhooks.create_webhook(db, name="x", kind="slack", config={})
+    # generic requires url
+    with pytest.raises(ValueError):
+        fw_webhooks.create_webhook(db, name="x", kind="generic", config={})
+    # email requires to
+    with pytest.raises(ValueError):
+        fw_webhooks.create_webhook(db, name="x", kind="email", config={})
+
+
+def test_create_rejects_invalid_severity(db: Database) -> None:
+    with pytest.raises(ValueError):
+        fw_webhooks.create_webhook(
+            db, name="x", kind="slack",
+            config={"webhook_url": "https://x"},
+            severity_min="MEH",
+        )
+
+
+# ----- list / mask ---------------------------------------------------------
+
+
+def test_list_masks_secret_config_keys(db: Database) -> None:
+    fw_webhooks.create_webhook(
+        db, name="generic-with-secret", kind="generic",
+        config={"url": "https://x.example", "hmac_secret": "supersecretvalue123"},
+    )
+    rows = fw_webhooks.list_webhooks(db)
+    assert len(rows) == 1
+    assert "supersecretvalue123" not in rows[0]["config"]["hmac_secret"]
+    assert rows[0]["config"]["url"] == "https://x.example"
+
+
+def test_delete_webhook(db: Database) -> None:
+    wh = fw_webhooks.create_webhook(
+        db, name="x", kind="slack",
+        config={"webhook_url": "https://hooks.slack.com/services/x"},
+    )
+    assert fw_webhooks.delete_webhook(db, wh.id) is True
+    assert fw_webhooks.delete_webhook(db, wh.id) is False  # idempotent
+
+
+# ----- severity filter -----------------------------------------------------
+
+
+def test_severity_filter_blocks_low(db: Database) -> None:
+    """A webhook configured for severity_min=high doesn't fire on a
+    low-severity decision."""
+    fw_webhooks.create_webhook(
+        db, name="high-only", kind="slack",
+        config={"webhook_url": "https://hooks.slack.com/x"},
+        severity_min="high",
+    )
+    fired: List[str] = []
+    with patch.object(fw_webhooks, "_attempt_with_retries", lambda **k: fired.append(k["webhook"].id)):
+        fw_webhooks.fire_for_decision(
+            db,
+            decision_id="dec_x", decision="block", severity="low",
+            policy_name="test_policy", project=None, reason="x",
+            trace_id=None, mode_at_decision="enforce",
+        )
+        fw_webhooks.shutdown_for_tests()
+    assert fired == [], "low-severity decision must not fire a high-only webhook"
+
+
+def test_severity_filter_passes_high(db: Database) -> None:
+    fw_webhooks.create_webhook(
+        db, name="medium-and-up", kind="slack",
+        config={"webhook_url": "https://hooks.slack.com/x"},
+        severity_min="medium",
+    )
+    fired: List[str] = []
+    with patch.object(fw_webhooks, "_attempt_with_retries", lambda **k: fired.append(k["webhook"].id)):
+        fw_webhooks.fire_for_decision(
+            db,
+            decision_id="dec_x", decision="block", severity="critical",
+            policy_name="test_policy", project=None, reason="x",
+            trace_id=None, mode_at_decision="enforce",
+        )
+        fw_webhooks.shutdown_for_tests()
+    assert len(fired) == 1
+
+
+def test_project_filter_excludes_other_projects(db: Database) -> None:
+    fw_webhooks.create_webhook(
+        db, name="prod-only", kind="slack",
+        config={"webhook_url": "https://hooks.slack.com/x"},
+        project_filter="prod",
+    )
+    fired: List[str] = []
+    with patch.object(fw_webhooks, "_attempt_with_retries", lambda **k: fired.append(k["webhook"].id)):
+        fw_webhooks.fire_for_decision(
+            db,
+            decision_id="dec_x", decision="block", severity="high",
+            policy_name="test_policy", project="staging", reason="x",
+            trace_id=None, mode_at_decision="enforce",
+        )
+        fw_webhooks.shutdown_for_tests()
+    assert fired == [], "staging project decision must not fire prod-only webhook"
+
+
+# ----- payload shapes ------------------------------------------------------
+
+
+def test_slack_payload_shape() -> None:
+    payload = fw_webhooks._build_payload(
+        kind="slack", decision_id="dec_a", decision="block",
+        severity="critical", policy_name="my_policy",
+        project="default", reason="r1", trace_id="t1",
+        mode_at_decision="enforce", webhook_name="n",
+    )
+    assert "blocks" in payload
+    assert "my_policy" in json.dumps(payload)
+
+
+def test_pagerduty_payload_severity_mapping() -> None:
+    p = fw_webhooks._build_payload(
+        kind="pagerduty", decision_id="dec", decision="block",
+        severity="critical", policy_name="x", project=None,
+        reason="", trace_id=None, mode_at_decision="enforce",
+        webhook_name="n",
+    )
+    assert p["payload"]["severity"] == "critical"
+    p2 = fw_webhooks._build_payload(
+        kind="pagerduty", decision_id="dec", decision="block",
+        severity="medium", policy_name="x", project=None,
+        reason="", trace_id=None, mode_at_decision="enforce",
+        webhook_name="n",
+    )
+    assert p2["payload"]["severity"] == "warning"
+
+
+def test_discord_payload_shape() -> None:
+    p = fw_webhooks._build_payload(
+        kind="discord", decision_id="d", decision="block",
+        severity="high", policy_name="p", project=None,
+        reason="", trace_id="t", mode_at_decision="enforce",
+        webhook_name="n",
+    )
+    assert "embeds" in p
+    assert isinstance(p["embeds"], list)
+
+
+def test_generic_payload_includes_envelope() -> None:
+    p = fw_webhooks._build_payload(
+        kind="generic", decision_id="d", decision="block",
+        severity="high", policy_name="p", project="x",
+        reason="r", trace_id="t", mode_at_decision="enforce",
+        webhook_name="n",
+    )
+    assert p["type"] == "lumin.firewall.decision"
+    assert p["decision_id"] == "d"
+    assert p["project"] == "x"
+
+
+# ----- HTTP delivery + retry -----------------------------------------------
+
+
+def test_deliver_http_signs_with_hmac_when_secret_set() -> None:
+    """A generic webhook with hmac_secret signs the body with
+    SHA-256 in the X-Lumin-Signature header."""
+    captured: Dict[str, Any] = {}
+
+    class FakeResp:
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+        def getcode(self): return 200
+
+    def fake_urlopen(req, timeout=None):
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = req.data
+        return FakeResp()
+
+    with patch.object(fw_webhooks.urllib_request, "urlopen", fake_urlopen):
+        fw_webhooks._deliver_http_json(
+            url="https://x.example", payload={"x": 1}, secret="topsecret",
+        )
+
+    sig_key = next(
+        (k for k in captured["headers"] if k.lower() == "x-lumin-signature"),
+        None,
+    )
+    assert sig_key is not None
+    assert captured["headers"][sig_key].startswith("sha256=")
+
+
+@pytest.fixture
+def disk_db(tmp_path):
+    """Tempfile-backed DB for tests that exercise the worker-thread
+    write paths. The worker opens its own Database connection from
+    ``duckdb_path``, which means ``:memory:`` becomes a new empty
+    DB on each open — not what the test intends. A real file makes
+    cross-connection writes visible."""
+    duck = tmp_path / "wh-test.duckdb"
+    sqlite = tmp_path / "wh-test.sqlite"
+    d = Database(duckdb_path=str(duck), sqlite_path=str(sqlite))
+    yield d
+    d.close()
+
+
+def test_deliver_failure_writes_dlq(disk_db: Database) -> None:
+    """When all 3 attempts fail, a DLQ row appears."""
+    db = disk_db
+    wh = fw_webhooks.create_webhook(
+        db, name="bad", kind="slack",
+        config={"webhook_url": "https://will.fail/never-reachable"},
+    )
+    payload = {"text": "hi"}
+
+    # Force every delivery attempt to raise. Patch backoff to 0 so
+    # the test finishes fast.
+    with patch.object(
+        fw_webhooks, "_deliver_once",
+        side_effect=RuntimeError("simulated"),
+    ), patch.object(fw_webhooks, "_BACKOFF_SECONDS", (0, 0, 0)):
+        fw_webhooks._attempt_with_retries(
+            webhook=fw_webhooks.WebhookConfig(
+                id=wh.id, name=wh.name, kind=wh.kind, config=wh.config,
+                severity_min=wh.severity_min, project_filter=wh.project_filter,
+                active=True,
+            ),
+            payload=payload,
+            decision_id="dec_test",
+            duckdb_path=db.duckdb_path,
+            sqlite_path=db.sqlite_path,
+        )
+
+    failures = fw_webhooks.list_failures(db)
+    assert len(failures) == 1
+    assert failures[0]["webhook_id"] == wh.id
+    assert failures[0]["attempt_count"] == 3
+    assert "simulated" in (failures[0]["last_error"] or "")
+
+
+def test_deliver_success_no_dlq(disk_db: Database) -> None:
+    db = disk_db
+    wh = fw_webhooks.create_webhook(
+        db, name="good", kind="slack",
+        config={"webhook_url": "https://hooks.slack.com/x"},
+    )
+    with patch.object(fw_webhooks, "_deliver_once", return_value=None):
+        fw_webhooks._attempt_with_retries(
+            webhook=fw_webhooks.WebhookConfig(
+                id=wh.id, name=wh.name, kind=wh.kind, config=wh.config,
+                severity_min=wh.severity_min, project_filter=wh.project_filter,
+                active=True,
+            ),
+            payload={"x": 1},
+            decision_id="dec_a",
+            duckdb_path=db.duckdb_path,
+            sqlite_path=db.sqlite_path,
+        )
+    assert fw_webhooks.list_failures(db) == []
+
+
+# ----- HTTP surface --------------------------------------------------------
+
+
+def test_create_and_list_via_api(client: TestClient) -> None:
+    resp = client.post(
+        "/v1/firewall/webhooks",
+        json={
+            "name": "ops",
+            "kind": "slack",
+            "config": {"webhook_url": "https://hooks.slack.com/x"},
+            "severity_min": "high",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"].startswith("wh_")
+    assert body["kind"] == "slack"
+
+    listing = client.get("/v1/firewall/webhooks").json()
+    assert len(listing["webhooks"]) == 1
+
+
+def test_create_invalid_kind_returns_400(client: TestClient) -> None:
+    resp = client.post(
+        "/v1/firewall/webhooks",
+        json={"name": "x", "kind": "carrier-pigeon", "config": {}},
+    )
+    assert resp.status_code == 400
+
+
+def test_delete_via_api(client: TestClient) -> None:
+    create = client.post(
+        "/v1/firewall/webhooks",
+        json={"name": "x", "kind": "slack",
+              "config": {"webhook_url": "https://hooks.slack.com/x"}},
+    ).json()
+    wh_id = create["id"]
+    assert client.delete(f"/v1/firewall/webhooks/{wh_id}").status_code == 200
+    assert client.delete(f"/v1/firewall/webhooks/{wh_id}").status_code == 404
+
+
+def test_failures_endpoint_returns_empty_at_start(client: TestClient) -> None:
+    resp = client.get("/v1/firewall/webhooks/failures")
+    assert resp.status_code == 200
+    assert resp.json() == {"failures": []}


### PR DESCRIPTION
## Summary

Ships the missing destination side of the firewall: when a block-class decision lands, alerts fire to operator-configured channels.

**Before:** firewall recorded decisions silently. Operator had to poll the dashboard.

**After:** Slack / Discord / PagerDuty / generic-with-HMAC / email destinations fire automatically on block / require_approval / rewrite. Severity-filtered, retry-with-backoff, DLQ on final failure.

## Surface

```
GET    /v1/firewall/webhooks                list configured destinations
POST   /v1/firewall/webhooks                create one
DELETE /v1/firewall/webhooks/{id}           delete
GET    /v1/firewall/webhooks/failures       DLQ — deliveries that exhausted retries
```

### Slack example
```json
POST /v1/firewall/webhooks
{
  "name": "ops-alerts",
  "kind": "slack",
  "config": { "webhook_url": "https://hooks.slack.com/services/..." },
  "severity_min": "high"
}
```

### Generic + HMAC example
```json
{
  "name": "internal-siem",
  "kind": "generic",
  "config": {
    "url": "https://siem.internal/webhook",
    "hmac_secret": "<set once, masked on read>"
  },
  "severity_min": "medium",
  "project_filter": "prod"
}
```
Receiver verifies `X-Lumin-Signature: sha256=...` against the request body.

## How it fires

1. `firewall.decide` records a block-class decision
2. `_record_decision` calls `webhooks.fire_for_decision(...)`
3. Dispatcher reads active webhooks for the project, applies severity filter
4. Submits payloads to a shared 4-thread executor (fire-and-forget — Rule 7)
5. Each delivery: attempt 1 → fail → wait 1s → attempt 2 → fail → wait 3s → attempt 3 → DLQ row
6. Success: `last_fired_at` updates, `last_error` cleared

## Schema

Two new tables added via firewall migrations:

- `firewall_webhooks` — config rows (kind / config_json / severity_min / project_filter / active)
- `firewall_webhook_failures` — DLQ with truncated payload + last_error

Indexes on `active`, `webhook_id`, `failed_at DESC`.

## Notes

- **Secrets masked**: any config key containing `token` / `secret` / `key` / `password` / `auth` is masked in `GET /v1/firewall/webhooks` responses (`abc…xyz`)
- **Email** uses Python stdlib SMTP. Required: `LUMIN_SMTP_HOST`. Optional: `_PORT`, `_USERNAME`, `_PASSWORD`, `_FROM`, `_USE_TLS`. Per-webhook `to:` lives in config.
- **Rule 7**: webhook firing failures NEVER block the firewall response. Worst case the decide endpoint just logs an exception and returns normally.
- **No public webhook receiver yet** — generic POST is outbound only. Inbound (e.g., Slack interactivity for approvals) is a separate feature.
- **Db API change**: added `Database.duckdb_path` and `Database.sqlite_path` read-only properties so the worker pool can open its own short-lived connection.

## Test plan

- [x] Migration creates both tables
- [x] CRUD validates kind + required config fields
- [x] Mask hides secret-shaped config keys
- [x] Severity filter excludes low when min=high
- [x] Project filter excludes other projects
- [x] All 5 payload kinds shape correctly
- [x] HMAC signs body with sha256 in `X-Lumin-Signature`
- [x] On 3 failures, DLQ row appears
- [x] HTTP endpoints respond with right shape + status codes
- [x] **Full firewall suite: 394 passed** (baseline 374 → +20 new)
- [ ] Manual: configure a Slack webhook, trigger a block, see message in Slack
- [ ] Manual: simulate failure, confirm DLQ row visible