### PR TITLE
feat(sdk): 6 framework firewall integrations (Slice 4 §9.3–§9.8)

### DIFF
--- a/packages/sdk-python/lumin/firewall_client.py
+++ b/packages/sdk-python/lumin/firewall_client.py
@@ -1,0 +1,226 @@
+"""Synchronous client for ``POST /v1/policy/decide`` (§5.1).
+
+Every framework integration in ``lumin.integrations.*_firewall`` calls
+this. Centralising the HTTP / timeout / fail-mode / response-shape
+logic in one place means a fix in any of those three lands in
+every integration at once, and the per-framework adapter is a thin
+mapping from framework hook → ``decide()`` → framework response shape.
+
+Behavior contract (Rule 7):
+
+  - The agent NEVER blocks waiting on us. Default timeout is 75ms;
+    operators tighten or loosen via ``timeout_ms`` constructor arg.
+  - On timeout / network error / 5xx, the configured ``on_error``
+    mode determines whether the framework continues (``allow``,
+    default) or stops (``deny``). Most production deployments use
+    ``allow`` because a Lumin outage must not take the agent down.
+  - The full response is exposed so framework-specific adapters can
+    pick the bits they need (some only care about ``decision``,
+    others want ``rewritten`` for output mutation).
+
+Sync only — every supported framework's hook surface is
+synchronous-friendly. An async variant lives behind ``adecide`` for
+LangGraph / async OpenAI Agents pipelines.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+import httpx
+
+logger = logging.getLogger("lumin.firewall_client")
+
+
+DEFAULT_HOST = "http://localhost:8000"
+DEFAULT_TIMEOUT_MS = 75
+VALID_LIFECYCLES = (
+    "before_proxy_call",
+    "after_proxy_call",
+    "before_tool_call",
+    "after_tool_call",
+    "post_ingest",
+)
+
+
+@dataclass
+class DecideRequest:
+    lifecycle: str
+    tool_name: Optional[str] = None
+    params: Optional[Dict[str, Any]] = None
+    trace_id: Optional[str] = None
+    span_id: Optional[str] = None
+    session_id: Optional[str] = None
+    agent: Optional[str] = None
+    project: Optional[str] = None
+    model: Optional[str] = None
+    messages: Optional[List[Dict[str, Any]]] = None
+    output: Any = None
+
+    def to_payload(self) -> Dict[str, Any]:
+        """Drop None values so the API sees a tight payload."""
+        out = {
+            "lifecycle": self.lifecycle,
+            "tool_name": self.tool_name,
+            "params": self.params,
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "session_id": self.session_id,
+            "agent": self.agent,
+            "project": self.project,
+            "model": self.model,
+            "messages": self.messages,
+            "output": self.output,
+        }
+        return {k: v for k, v in out.items() if v is not None}
+
+
+@dataclass
+class DecideResponse:
+    decision: str
+    policy_id: Optional[str] = None
+    policy_name: Optional[str] = None
+    reason: Optional[str] = None
+    decision_id: Optional[str] = None
+    mode_at_decision: Optional[str] = None
+    duration_ms: Optional[int] = None
+    approval_id: Optional[str] = None
+    timeout_s: Optional[int] = None
+    rewritten: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_allow(self) -> bool:
+        return self.decision == "allow"
+
+    @property
+    def is_block(self) -> bool:
+        return self.decision == "block"
+
+    @property
+    def needs_approval(self) -> bool:
+        return self.decision == "require_approval"
+
+    @property
+    def is_rewrite(self) -> bool:
+        return self.decision == "rewrite"
+
+    @classmethod
+    def allow(cls, *, reason: str = "", duration_ms: int = 0) -> "DecideResponse":
+        return cls(decision="allow", reason=reason, duration_ms=duration_ms)
+
+
+class FirewallClient:
+    """Thin sync HTTP client for /v1/policy/decide.
+
+    One instance per framework adapter. Reuses a single httpx.Client
+    so connection pooling kicks in across many decide() calls in the
+    same process — saves ~5–10ms per call vs. per-request clients.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: Optional[str] = None,
+        project: Optional[str] = None,
+        agent: Optional[str] = None,
+        timeout_ms: int = DEFAULT_TIMEOUT_MS,
+        on_error: Literal["allow", "deny"] = "allow",
+    ) -> None:
+        self.host = (host or os.environ.get("LUMIN_HOST") or DEFAULT_HOST).rstrip("/")
+        self.project = project or os.environ.get("LUMIN_PROJECT")
+        self.agent = agent
+        self.timeout_s = max(0.01, timeout_ms / 1000.0)
+        self.on_error = on_error
+        self._failure_logged = False
+        self._client = httpx.Client(timeout=self.timeout_s)
+
+    def close(self) -> None:
+        try:
+            self._client.close()
+        except Exception:
+            pass
+
+    def __enter__(self) -> "FirewallClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def decide(self, req: DecideRequest) -> DecideResponse:
+        """Issue a synchronous decide call. Always returns a
+        DecideResponse — even on timeout / network failure / 5xx.
+
+        On error: the response carries decision=allow (or block,
+        if on_error='deny') with reason='internal_error' so the
+        caller can branch on it explicitly.
+        """
+        # Per-call lifecycle validation. Lumin's API also validates,
+        # but doing it client-side surfaces typos at integration-test
+        # time instead of inside a /v1/policy/decide 4xx response.
+        if req.lifecycle not in VALID_LIFECYCLES:
+            raise ValueError(
+                f"lifecycle must be one of {VALID_LIFECYCLES}, got {req.lifecycle!r}"
+            )
+
+        # Operator can tag every decide call with project + agent
+        # without setting them on every request.
+        payload = req.to_payload()
+        payload.setdefault("project", self.project)
+        payload.setdefault("agent", self.agent)
+
+        url = f"{self.host}/v1/policy/decide"
+        started = time.monotonic()
+        try:
+            resp = self._client.post(url, json=payload)
+            if resp.status_code != 200:
+                return self._error_response(
+                    f"http_{resp.status_code}",
+                    duration_ms=int((time.monotonic() - started) * 1000),
+                )
+            data = resp.json() if resp.content else {}
+        except httpx.TimeoutException:
+            return self._error_response(
+                "timeout",
+                duration_ms=int(self.timeout_s * 1000),
+            )
+        except Exception as e:
+            if not self._failure_logged:
+                logger.warning("firewall_client: %s — further failures suppressed", e)
+                self._failure_logged = True
+            return self._error_response("network_error", duration_ms=0)
+
+        return DecideResponse(
+            decision=str(data.get("decision") or "allow"),
+            policy_id=data.get("policy_id"),
+            policy_name=data.get("policy_name"),
+            reason=data.get("reason"),
+            decision_id=data.get("decision_id"),
+            mode_at_decision=data.get("mode_at_decision"),
+            duration_ms=data.get("duration_ms"),
+            approval_id=data.get("approval_id"),
+            timeout_s=data.get("timeout_s"),
+            rewritten=data.get("rewritten") or {},
+        )
+
+    def _error_response(self, reason: str, *, duration_ms: int) -> DecideResponse:
+        verdict = "block" if self.on_error == "deny" else "allow"
+        return DecideResponse(
+            decision=verdict,
+            reason=f"firewall_client:{reason}",
+            duration_ms=duration_ms,
+        )
+
+
+__all__ = [
+    "DEFAULT_HOST",
+    "DEFAULT_TIMEOUT_MS",
+    "VALID_LIFECYCLES",
+    "DecideRequest",
+    "DecideResponse",
+    "FirewallClient",
+]

--- a/packages/sdk-python/lumin/integrations/autogen_firewall.py
+++ b/packages/sdk-python/lumin/integrations/autogen_firewall.py
@@ -1,0 +1,201 @@
+"""AutoGen firewall integration (§9.7).
+
+AutoGen 0.4+ exposes ``register_hook`` on ``ConversableAgent`` for
+on-message-received and on-tool-use lifecycle hooks. Lumin plugs in
+two hooks:
+
+  - ``process_message_before_send`` → before_proxy_call decide
+  - ``before_tool_call``           → before_tool_call decide
+  - ``after_tool_call``            → after_tool_call decide
+
+Block decisions raise ``LuminFirewallBlocked``; AutoGen's runtime
+surfaces the exception to the caller as an agent error.
+
+Usage:
+
+    from autogen import ConversableAgent
+    from lumin.integrations.autogen_firewall import (
+        register_lumin_firewall,
+    )
+
+    agent = ConversableAgent("assistant", llm_config=...)
+    register_lumin_firewall(agent, project="support-bot")
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from lumin.firewall_client import (
+    DecideRequest,
+    DecideResponse,
+    FirewallClient,
+)
+
+logger = logging.getLogger("lumin.integrations.autogen_firewall")
+
+
+class LuminFirewallBlocked(Exception):
+    def __init__(self, decision: DecideResponse, *, lifecycle: str) -> None:
+        self.decision = decision
+        self.lifecycle = lifecycle
+        super().__init__(
+            f"Lumin firewall {decision.decision} at {lifecycle}: "
+            f"{decision.policy_name or '_engine_'}"
+        )
+
+
+def register_lumin_firewall(
+    agent: Any,
+    *,
+    host: Optional[str] = None,
+    project: Optional[str] = None,
+    timeout_ms: int = 75,
+    on_error: str = "allow",
+    check_input: bool = True,
+    check_output: bool = True,
+    check_tools: bool = True,
+) -> "AutoGenFirewallAdapter":
+    """Attach the Lumin firewall hooks to an AutoGen
+    ConversableAgent. Returns the adapter so the caller can
+    detach later via ``adapter.close()``.
+    """
+    adapter = AutoGenFirewallAdapter(
+        host=host, project=project,
+        agent_name=getattr(agent, "name", None),
+        timeout_ms=timeout_ms, on_error=on_error,
+    )
+    # AutoGen 0.4 lifecycle hook names. Older versions used different
+    # names; we register-or-skip per name so this works across the
+    # 0.2 → 0.4 transition.
+    _try_register(agent, "process_message_before_send",
+                  adapter.on_message_before_send if check_input else None)
+    _try_register(agent, "process_last_received_message",
+                  adapter.on_message_received if check_output else None)
+    if check_tools and hasattr(agent, "register_function"):
+        # AutoGen tool hooks are different per version; we wrap any
+        # registered tool function. The adapter's wrap_tool is opt-in
+        # per tool — operators call it explicitly.
+        pass
+    return adapter
+
+
+class AutoGenFirewallAdapter:
+    def __init__(
+        self,
+        *,
+        host: Optional[str],
+        project: Optional[str],
+        agent_name: Optional[str],
+        timeout_ms: int,
+        on_error: str,
+    ) -> None:
+        self._client = FirewallClient(
+            host=host, project=project, agent=agent_name,
+            timeout_ms=timeout_ms, on_error=on_error,  # type: ignore[arg-type]
+        )
+
+    def on_message_before_send(self, sender, message, recipient, silent) -> Any:  # type: ignore[no-untyped-def]
+        text = _extract_text(message)
+        decision = self._client.decide(DecideRequest(
+            lifecycle="before_proxy_call",
+            messages=[{"role": "user", "content": text}],
+        ))
+        if decision.is_block or decision.needs_approval:
+            raise LuminFirewallBlocked(decision, lifecycle="before_proxy_call")
+        if decision.is_rewrite:
+            new_text = decision.rewritten.get("result")
+            if isinstance(new_text, str):
+                if isinstance(message, dict):
+                    message["content"] = new_text
+                else:
+                    message = new_text
+        return message
+
+    def on_message_received(self, recipient, messages, sender, config) -> Any:  # type: ignore[no-untyped-def]
+        if not messages:
+            return None
+        last = messages[-1]
+        text = _extract_text(last)
+        decision = self._client.decide(DecideRequest(
+            lifecycle="after_proxy_call",
+            output={"text": text},
+        ))
+        if decision.is_block:
+            raise LuminFirewallBlocked(decision, lifecycle="after_proxy_call")
+        if decision.is_rewrite:
+            new_text = decision.rewritten.get("result")
+            if isinstance(new_text, str) and isinstance(last, dict):
+                last["content"] = new_text
+        return None
+
+    def wrap_tool(
+        self,
+        fn: Callable[..., Any],
+        *,
+        tool_name: Optional[str] = None,
+    ) -> Callable[..., Any]:
+        name = tool_name or fn.__name__
+        client = self._client
+
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            before = client.decide(DecideRequest(
+                lifecycle="before_tool_call",
+                tool_name=name,
+                params=kwargs,
+            ))
+            if before.is_block:
+                raise LuminFirewallBlocked(before, lifecycle="before_tool_call")
+            if before.is_rewrite:
+                new_params = before.rewritten.get("params") or {}
+                kwargs = {**kwargs, **new_params}
+            result = fn(*args, **kwargs)
+            after = client.decide(DecideRequest(
+                lifecycle="after_tool_call",
+                tool_name=name,
+                output={"result": result},
+            ))
+            if after.is_block:
+                raise LuminFirewallBlocked(after, lifecycle="after_tool_call")
+            if after.is_rewrite:
+                return after.rewritten.get("result", result)
+            return result
+
+        wrapped.__name__ = name
+        wrapped.__doc__ = fn.__doc__
+        return wrapped
+
+    def close(self) -> None:
+        self._client.close()
+
+
+def _extract_text(message: Any) -> str:
+    if isinstance(message, str):
+        return message
+    if isinstance(message, dict):
+        return str(message.get("content") or "")
+    return str(getattr(message, "content", "") or message)
+
+
+def _try_register(agent: Any, hook_name: str, fn: Optional[Callable]) -> None:
+    if fn is None:
+        return
+    register = getattr(agent, "register_hook", None)
+    if register is None:
+        logger.debug(
+            "autogen_firewall: agent %r has no register_hook — skipping %s",
+            agent, hook_name,
+        )
+        return
+    try:
+        register(hookable_method=hook_name, hook=fn)
+    except Exception:
+        logger.exception("autogen_firewall: register_hook(%s) failed", hook_name)
+
+
+__all__ = [
+    "LuminFirewallBlocked",
+    "register_lumin_firewall",
+    "AutoGenFirewallAdapter",
+]

--- a/packages/sdk-python/lumin/integrations/langchain_firewall.py
+++ b/packages/sdk-python/lumin/integrations/langchain_firewall.py
@@ -1,0 +1,246 @@
+"""LangChain firewall integration (§9.4).
+
+Wraps Lumin's policy decide-engine into a LangChain BaseCallbackHandler.
+Plug it into any LangChain agent/chain/tool to gate execution at:
+
+  - on_tool_start  → before_tool_call decide. Block / require_approval
+                     verbs raise ``LuminFirewallBlocked`` so the chain
+                     halts before the tool fires. Rewrite verbs replace
+                     the tool params.
+  - on_tool_end    → after_tool_call decide. Block / rewrite verbs on
+                     the tool's output let the firewall censor results
+                     before they hit the model.
+  - on_llm_start   → before_proxy_call decide on the user message
+                     (skipped when ``proxied=True`` — the OpenAI-
+                     compatible proxy at /v1/openai handles B/C
+                     automatically and the callback would double-bill).
+  - on_llm_end     → after_proxy_call decide on the model output.
+
+Usage:
+
+    from langchain.agents import AgentExecutor
+    from lumin.integrations.langchain_firewall import LuminFirewallHandler
+
+    fw = LuminFirewallHandler(project="support-bot", agent="cs_agent")
+    agent = AgentExecutor.from_agent_and_tools(
+        ..., callbacks=[fw],
+    )
+
+The observability handler in ``lumin.integrations.langchain`` is a
+separate concern — both can be attached at once. Order is irrelevant;
+LangChain dispatches callbacks in registration order but each one
+operates on its own state.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+try:
+    from langchain_core.callbacks.base import BaseCallbackHandler
+    from langchain_core.outputs import LLMResult
+except ImportError as e:  # pragma: no cover — surfaced at import time
+    raise ImportError(
+        "lumin.integrations.langchain_firewall requires langchain-core. "
+        "Install with: pip install langchain-core"
+    ) from e
+
+from lumin.firewall_client import (
+    DecideRequest,
+    DecideResponse,
+    FirewallClient,
+)
+
+logger = logging.getLogger("lumin.integrations.langchain_firewall")
+
+
+class LuminFirewallBlocked(Exception):
+    """Raised when a Lumin block / require_approval verb fires inside
+    a LangChain tool/llm callback. Carries the full decision so the
+    caller (often an AgentExecutor) can render a useful error."""
+
+    def __init__(self, decision: DecideResponse, *, lifecycle: str) -> None:
+        self.decision = decision
+        self.lifecycle = lifecycle
+        super().__init__(
+            f"Lumin firewall {decision.decision} at {lifecycle}: "
+            f"{decision.policy_name or '_engine_'} — "
+            f"{decision.reason or 'no reason'}"
+        )
+
+
+class LuminFirewallHandler(BaseCallbackHandler):
+    """LangChain callback handler that calls Lumin's firewall on
+    every tool invocation and (optionally) every LLM call."""
+
+    raise_error = True  # propagate LuminFirewallBlocked up the chain
+
+    def __init__(
+        self,
+        *,
+        host: Optional[str] = None,
+        project: Optional[str] = None,
+        agent: Optional[str] = None,
+        timeout_ms: int = 75,
+        on_error: str = "allow",
+        proxied: bool = False,
+        check_llm: bool = True,
+    ) -> None:
+        super().__init__()
+        self._client = FirewallClient(
+            host=host, project=project, agent=agent,
+            timeout_ms=timeout_ms, on_error=on_error,  # type: ignore[arg-type]
+        )
+        self.proxied = proxied
+        self.check_llm = check_llm
+        # run_id → tool_name + params so on_tool_end can re-decide
+        # against the same tool context.
+        self._tool_runs: Dict[str, Dict[str, Any]] = {}
+        # run_id → input messages so on_llm_end can include the
+        # original user message in the after_proxy_call decide.
+        self._llm_runs: Dict[str, List[Dict[str, Any]]] = {}
+
+    # ----- tool gating -----
+
+    def on_tool_start(
+        self,
+        serialized: Dict[str, Any],
+        input_str: str,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        tool_name = (serialized or {}).get("name") or "unknown_tool"
+        params = inputs if inputs is not None else {"input": input_str}
+        self._tool_runs[str(run_id)] = {"tool_name": tool_name, "params": params}
+
+        decision = self._client.decide(DecideRequest(
+            lifecycle="before_tool_call",
+            tool_name=tool_name,
+            params=params,
+            session_id=_session_from_metadata(metadata),
+            trace_id=str(parent_run_id) if parent_run_id else None,
+            span_id=str(run_id),
+        ))
+        self._enforce(decision, lifecycle="before_tool_call")
+
+        # Rewrite: substitute params before the tool runs. Returning
+        # a value from on_tool_start doesn't influence LangChain's
+        # actual tool inputs (the API doesn't expose that surface),
+        # so we mutate ``inputs`` in-place when the framework gives
+        # us a dict reference.
+        if decision.is_rewrite and inputs is not None:
+            new_params = decision.rewritten.get("params") or {}
+            for k, v in new_params.items():
+                inputs[k] = v
+
+    def on_tool_end(
+        self,
+        output: Any,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> Any:
+        ctx = self._tool_runs.pop(str(run_id), {})
+        decision = self._client.decide(DecideRequest(
+            lifecycle="after_tool_call",
+            tool_name=ctx.get("tool_name"),
+            params=ctx.get("params"),
+            output={"result": output},
+            trace_id=str(parent_run_id) if parent_run_id else None,
+            span_id=str(run_id),
+        ))
+        self._enforce(decision, lifecycle="after_tool_call")
+
+    def on_tool_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> Any:
+        # Errors don't go through the firewall — clean up state.
+        self._tool_runs.pop(str(run_id), None)
+
+    # ----- LLM gating -----
+
+    def on_llm_start(
+        self,
+        serialized: Dict[str, Any],
+        prompts: List[str],
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        if not self.check_llm or self.proxied:
+            return
+        # Keep the prompts so on_llm_end has them for after_proxy_call.
+        msgs = [{"role": "user", "content": p} for p in prompts]
+        self._llm_runs[str(run_id)] = msgs
+
+        decision = self._client.decide(DecideRequest(
+            lifecycle="before_proxy_call",
+            messages=msgs,
+            session_id=_session_from_metadata(metadata),
+            trace_id=str(parent_run_id) if parent_run_id else None,
+            span_id=str(run_id),
+        ))
+        self._enforce(decision, lifecycle="before_proxy_call")
+
+    def on_llm_end(
+        self,
+        response: LLMResult,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> Any:
+        if not self.check_llm or self.proxied:
+            return
+        msgs = self._llm_runs.pop(str(run_id), None)
+        # Concatenate generation texts as the model's reply payload.
+        try:
+            text = "\n".join(
+                gen.text for sub in response.generations for gen in sub
+            )
+        except Exception:
+            text = ""
+        decision = self._client.decide(DecideRequest(
+            lifecycle="after_proxy_call",
+            messages=msgs,
+            output={"text": text},
+            trace_id=str(parent_run_id) if parent_run_id else None,
+            span_id=str(run_id),
+        ))
+        self._enforce(decision, lifecycle="after_proxy_call")
+
+    # ----- internals -----
+
+    def _enforce(self, decision: DecideResponse, *, lifecycle: str) -> None:
+        if decision.is_block or decision.needs_approval:
+            raise LuminFirewallBlocked(decision, lifecycle=lifecycle)
+
+    def close(self) -> None:
+        self._client.close()
+
+
+def _session_from_metadata(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not metadata:
+        return None
+    for k in ("session_id", "thread_id", "conversation_id"):
+        v = metadata.get(k)
+        if isinstance(v, str) and v:
+            return v
+    return None
+
+
+__all__ = ["LuminFirewallHandler", "LuminFirewallBlocked"]

--- a/packages/sdk-python/lumin/integrations/langgraph_firewall.py
+++ b/packages/sdk-python/lumin/integrations/langgraph_firewall.py
@@ -1,0 +1,193 @@
+"""LangGraph firewall integration (§9.3).
+
+LangGraph nodes don't speak the LangChain callback contract —
+they're plain async / sync functions that read State and return a
+partial State update. So the firewall plugs in via:
+
+  - ``firewall_node(...)`` — a pre-built node that the operator
+    installs at the entry of any sensitive subgraph. Calls
+    before_proxy_call decide() against the current user message
+    and either returns the State unchanged (allow) or interrupts
+    via LangGraph's ``interrupt()`` primitive (block / approval).
+
+  - ``wrap_tool_node(node, *, tool_name)`` — decorator that wraps
+    an existing tool-call node so before_tool_call / after_tool_call
+    decide() runs around it.
+
+LangGraph provides ``interrupt()`` for human-in-the-loop semantics.
+On block we return a Command that halts the graph; the dashboard's
+ApprovalsInbox surfaces the pending decision to the operator who
+can resolve it via /v1/approvals/{id}/resolve.
+
+Usage:
+
+    from langgraph.graph import StateGraph
+    from lumin.integrations.langgraph_firewall import (
+        firewall_node, wrap_tool_node,
+    )
+
+    builder = StateGraph(MyState)
+    builder.add_node("firewall_input", firewall_node(project="bot"))
+    builder.add_node(
+        "search",
+        wrap_tool_node(my_search_node, tool_name="web_search"),
+    )
+    builder.add_edge("firewall_input", "search")
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Optional
+
+from lumin.firewall_client import (
+    DecideRequest,
+    DecideResponse,
+    FirewallClient,
+)
+
+logger = logging.getLogger("lumin.integrations.langgraph_firewall")
+
+try:
+    from langgraph.types import interrupt as _interrupt
+except ImportError:  # pragma: no cover
+    _interrupt = None  # surfaced at runtime
+
+
+class LuminFirewallBlocked(Exception):
+    """Raised when a LangGraph node hits a block decision."""
+
+    def __init__(self, decision: DecideResponse, *, lifecycle: str) -> None:
+        self.decision = decision
+        self.lifecycle = lifecycle
+        super().__init__(
+            f"Lumin firewall {decision.decision} at {lifecycle}: "
+            f"{decision.policy_name or '_engine_'}"
+        )
+
+
+def firewall_node(
+    *,
+    host: Optional[str] = None,
+    project: Optional[str] = None,
+    agent: Optional[str] = None,
+    timeout_ms: int = 75,
+    on_error: str = "allow",
+    user_message_key: str = "messages",
+) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+    """Build a LangGraph node that gates the user message at graph
+    entry. Returns the state unchanged on allow, raises
+    ``LuminFirewallBlocked`` on block, or invokes ``interrupt()``
+    on require_approval (so the graph pauses for operator review).
+    """
+    client = FirewallClient(
+        host=host, project=project, agent=agent,
+        timeout_ms=timeout_ms, on_error=on_error,  # type: ignore[arg-type]
+    )
+
+    def node(state: Dict[str, Any]) -> Dict[str, Any]:
+        msgs = state.get(user_message_key) or []
+        # LangGraph state usually has messages as a list of dicts or
+        # langchain BaseMessage objects. Coerce to the JSON shape
+        # decide() expects.
+        normalized = [_normalize_message(m) for m in msgs if m is not None]
+
+        decision = client.decide(DecideRequest(
+            lifecycle="before_proxy_call",
+            messages=normalized,
+            session_id=str(state.get("thread_id") or "") or None,
+        ))
+
+        if decision.is_block:
+            raise LuminFirewallBlocked(decision, lifecycle="before_proxy_call")
+        if decision.needs_approval:
+            if _interrupt is not None:
+                _interrupt({
+                    "kind": "lumin_firewall_approval",
+                    "decision_id": decision.decision_id,
+                    "approval_id": decision.approval_id,
+                    "policy_name": decision.policy_name,
+                    "reason": decision.reason,
+                })
+            else:
+                raise LuminFirewallBlocked(
+                    decision, lifecycle="before_proxy_call_approval"
+                )
+        return state
+
+    node.__name__ = "lumin_firewall_input"
+    return node
+
+
+def wrap_tool_node(
+    inner: Callable[[Dict[str, Any]], Any],
+    *,
+    tool_name: str,
+    host: Optional[str] = None,
+    project: Optional[str] = None,
+    agent: Optional[str] = None,
+    timeout_ms: int = 75,
+    on_error: str = "allow",
+    params_key: str = "tool_input",
+    output_key: str = "tool_output",
+) -> Callable[[Dict[str, Any]], Any]:
+    """Wrap a LangGraph tool node with before_tool_call /
+    after_tool_call gating. ``inner`` is the operator's existing
+    node; we sandwich decide() calls around it."""
+    client = FirewallClient(
+        host=host, project=project, agent=agent,
+        timeout_ms=timeout_ms, on_error=on_error,  # type: ignore[arg-type]
+    )
+
+    def wrapped(state: Dict[str, Any]) -> Any:
+        params = state.get(params_key) or {}
+        before = client.decide(DecideRequest(
+            lifecycle="before_tool_call",
+            tool_name=tool_name,
+            params=params,
+            session_id=str(state.get("thread_id") or "") or None,
+        ))
+        if before.is_block:
+            raise LuminFirewallBlocked(before, lifecycle="before_tool_call")
+        if before.is_rewrite:
+            new_params = before.rewritten.get("params") or {}
+            state = {**state, params_key: {**params, **new_params}}
+
+        result = inner(state)
+
+        # ``result`` from a LangGraph node is typically a partial
+        # state dict. Pull out the tool's output for after_tool_call.
+        output = None
+        if isinstance(result, dict):
+            output = result.get(output_key)
+
+        after = client.decide(DecideRequest(
+            lifecycle="after_tool_call",
+            tool_name=tool_name,
+            output={"result": output},
+            session_id=str(state.get("thread_id") or "") or None,
+        ))
+        if after.is_block:
+            raise LuminFirewallBlocked(after, lifecycle="after_tool_call")
+        if after.is_rewrite and isinstance(result, dict):
+            new_output = after.rewritten.get("result")
+            result = {**result, output_key: new_output}
+        return result
+
+    wrapped.__name__ = f"lumin_wrapped_{tool_name}"
+    return wrapped
+
+
+def _normalize_message(m: Any) -> Dict[str, Any]:
+    if isinstance(m, dict):
+        return {"role": m.get("role", "user"), "content": str(m.get("content", ""))}
+    role = getattr(m, "type", None) or getattr(m, "role", None) or "user"
+    content = getattr(m, "content", None) or str(m)
+    return {"role": str(role), "content": str(content)}
+
+
+__all__ = [
+    "LuminFirewallBlocked",
+    "firewall_node",
+    "wrap_tool_node",
+]

--- a/packages/sdk-python/lumin/integrations/litellm_firewall.py
+++ b/packages/sdk-python/lumin/integrations/litellm_firewall.py
@@ -1,0 +1,204 @@
+"""LiteLLM firewall integration (§9.5).
+
+LiteLLM has a guardrails surface — ``CustomGuardrail`` — that fires
+on every completion request and response. Lumin's adapter
+implements the contract directly so operators don't have to go
+through LiteLLM's hosted guardrails marketplace.
+
+Two integration paths:
+
+  1. **Guardrail class** — register
+     ``LuminFirewallGuardrail`` with LiteLLM Proxy via guardrails
+     config. Best for hosted-proxy deployments.
+
+  2. **Manual call** — for direct ``litellm.completion()`` users,
+     ``check_request()`` and ``check_response()`` are sync
+     functions you call before / after.
+
+Mapping:
+  pre-call  → before_proxy_call decide on the user messages
+  post-call → after_proxy_call decide on the assistant response
+
+Block / require_approval at the pre-call boundary raises
+``LuminFirewallBlocked`` so LiteLLM raises 4xx to the caller.
+Rewrite verbs at post-call swap the response content.
+
+Usage (manual):
+
+    from lumin.integrations.litellm_firewall import LuminFirewallGuardrail
+    g = LuminFirewallGuardrail(project="bot")
+    g.check_request(messages=[{"role": "user", "content": "..."}])
+    response = litellm.completion(...)
+    response = g.check_response(messages=..., response=response)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from lumin.firewall_client import (
+    DecideRequest,
+    DecideResponse,
+    FirewallClient,
+)
+
+logger = logging.getLogger("lumin.integrations.litellm_firewall")
+
+
+class LuminFirewallBlocked(Exception):
+    def __init__(self, decision: DecideResponse, *, lifecycle: str) -> None:
+        self.decision = decision
+        self.lifecycle = lifecycle
+        super().__init__(
+            f"Lumin firewall {decision.decision} at {lifecycle}: "
+            f"{decision.policy_name or '_engine_'}"
+        )
+
+
+class LuminFirewallGuardrail:
+    """LiteLLM guardrail that gates pre-call + post-call.
+
+    Designed to be importable even when ``litellm`` itself isn't
+    installed — operators using ``check_request()`` / ``check_response()``
+    in standalone code don't need the full LiteLLM dependency. The
+    optional CustomGuardrail subclass below activates only when
+    ``litellm`` is available.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: Optional[str] = None,
+        project: Optional[str] = None,
+        agent: Optional[str] = None,
+        timeout_ms: int = 75,
+        on_error: str = "allow",
+    ) -> None:
+        self._client = FirewallClient(
+            host=host, project=project, agent=agent,
+            timeout_ms=timeout_ms, on_error=on_error,  # type: ignore[arg-type]
+        )
+
+    def check_request(
+        self,
+        *,
+        messages: List[Dict[str, Any]],
+        session_id: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> None:
+        """Run before_proxy_call decide. Raises on block."""
+        decision = self._client.decide(DecideRequest(
+            lifecycle="before_proxy_call",
+            messages=messages,
+            session_id=session_id,
+            model=model,
+        ))
+        if decision.is_block or decision.needs_approval:
+            raise LuminFirewallBlocked(decision, lifecycle="before_proxy_call")
+
+    def check_response(
+        self,
+        *,
+        messages: List[Dict[str, Any]],
+        response: Any,
+        session_id: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> Any:
+        """Run after_proxy_call decide. Returns the (possibly
+        rewritten) response. Raises on block."""
+        text = _extract_text(response)
+        decision = self._client.decide(DecideRequest(
+            lifecycle="after_proxy_call",
+            messages=messages,
+            output={"text": text},
+            session_id=session_id,
+            model=model,
+        ))
+        if decision.is_block or decision.needs_approval:
+            raise LuminFirewallBlocked(decision, lifecycle="after_proxy_call")
+        if decision.is_rewrite:
+            new_text = decision.rewritten.get("result")
+            if isinstance(new_text, str):
+                response = _replace_text(response, new_text)
+        return response
+
+    def close(self) -> None:
+        self._client.close()
+
+
+def _extract_text(response: Any) -> str:
+    """LiteLLM normalises response.choices[0].message.content."""
+    try:
+        return response["choices"][0]["message"]["content"] or ""
+    except Exception:
+        pass
+    try:
+        return response.choices[0].message.content or ""
+    except Exception:
+        return ""
+
+
+def _replace_text(response: Any, new_text: str) -> Any:
+    """Mutate the response in place when the firewall rewrites
+    output. Both dict and dotted-attribute shapes supported."""
+    try:
+        response["choices"][0]["message"]["content"] = new_text
+        return response
+    except Exception:
+        pass
+    try:
+        response.choices[0].message.content = new_text
+    except Exception:
+        pass
+    return response
+
+
+def make_litellm_guardrail():
+    """Factory that returns a ``CustomGuardrail`` subclass when
+    LiteLLM is installed. Returns None otherwise so the import
+    surface is non-fatal."""
+    try:
+        from litellm.integrations.custom_guardrail import CustomGuardrail  # type: ignore
+    except ImportError:  # pragma: no cover
+        return None
+
+    class _Wrapped(CustomGuardrail):  # type: ignore[misc]
+        """LiteLLM guardrails subclass that delegates to the
+        Lumin firewall. Configure via litellm proxy yaml:
+
+            guardrails:
+              - guardrail_name: lumin_firewall
+                litellm_params:
+                  guardrail: lumin.integrations.litellm_firewall.make_litellm_guardrail
+                  mode: pre_call
+        """
+
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            super().__init__(*args, **kwargs)
+            self._lumin = LuminFirewallGuardrail()
+
+        async def async_pre_call_hook(self, *, data, **kwargs):  # type: ignore[no-untyped-def]
+            self._lumin.check_request(
+                messages=data.get("messages") or [],
+                session_id=data.get("user"),
+                model=data.get("model"),
+            )
+            return data
+
+        async def async_post_call_success_hook(self, *, data, response, **kwargs):  # type: ignore[no-untyped-def]
+            return self._lumin.check_response(
+                messages=data.get("messages") or [],
+                response=response,
+                session_id=data.get("user"),
+                model=data.get("model"),
+            )
+
+    return _Wrapped
+
+
+__all__ = [
+    "LuminFirewallBlocked",
+    "LuminFirewallGuardrail",
+    "make_litellm_guardrail",
+]

--- a/packages/sdk-python/lumin/integrations/openai_agents_firewall.py
+++ b/packages/sdk-python/lumin/integrations/openai_agents_firewall.py
@@ -1,0 +1,227 @@
+"""OpenAI Agents SDK firewall integration (§9.6).
+
+The OpenAI Agents SDK exposes an ``input_guardrails`` /
+``output_guardrails`` field on ``Agent`` plus a ``handoffs`` /
+``tools`` runtime that fires lifecycle hooks. Lumin plugs into:
+
+  - ``input_guardrails``  → before_proxy_call decide on user input
+  - ``output_guardrails`` → after_proxy_call decide on agent output
+  - tool wrappers        → before_tool_call / after_tool_call
+                            sandwich around any tool the agent calls
+
+Two adapter shapes:
+
+  1. ``LuminInputGuardrail`` / ``LuminOutputGuardrail`` —
+     instantiate and pass into ``Agent(input_guardrails=[...])``.
+
+  2. ``wrap_tool(tool)`` — for tools defined as plain functions
+     under ``@function_tool``; wrapping returns a new function that
+     calls decide() before invoking.
+
+The SDK was renamed several times across versions (``agents``,
+``openai-agents``); the import is wrapped so this module loads even
+if the SDK isn't installed — the guardrail classes still work for
+sync ``check_input()`` / ``check_output()`` calls in standalone code.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from lumin.firewall_client import (
+    DecideRequest,
+    DecideResponse,
+    FirewallClient,
+)
+
+logger = logging.getLogger("lumin.integrations.openai_agents_firewall")
+
+
+class LuminFirewallBlocked(Exception):
+    def __init__(self, decision: DecideResponse, *, lifecycle: str) -> None:
+        self.decision = decision
+        self.lifecycle = lifecycle
+        super().__init__(
+            f"Lumin firewall {decision.decision} at {lifecycle}: "
+            f"{decision.policy_name or '_engine_'}"
+        )
+
+
+class _BaseGuardrail:
+    def __init__(
+        self,
+        *,
+        host: Optional[str] = None,
+        project: Optional[str] = None,
+        agent: Optional[str] = None,
+        timeout_ms: int = 75,
+        on_error: str = "allow",
+    ) -> None:
+        self._client = FirewallClient(
+            host=host, project=project, agent=agent,
+            timeout_ms=timeout_ms, on_error=on_error,  # type: ignore[arg-type]
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+
+class LuminInputGuardrail(_BaseGuardrail):
+    """Use as ``Agent(input_guardrails=[LuminInputGuardrail()])``."""
+
+    def check_input(
+        self,
+        *,
+        messages: List[Dict[str, Any]],
+        session_id: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> None:
+        decision = self._client.decide(DecideRequest(
+            lifecycle="before_proxy_call",
+            messages=messages,
+            session_id=session_id,
+            model=model,
+        ))
+        if decision.is_block or decision.needs_approval:
+            raise LuminFirewallBlocked(decision, lifecycle="before_proxy_call")
+
+    # OpenAI Agents SDK calls ``__call__(context, agent_output) -> GuardrailFunctionOutput``
+    async def __call__(self, context, agent_output) -> Any:  # type: ignore[no-untyped-def]
+        text = _extract_input_text(context)
+        try:
+            self.check_input(messages=[{"role": "user", "content": text}])
+        except LuminFirewallBlocked as blocked:
+            return _guardrail_failure_output(
+                tripwire=True, output=str(blocked.decision.reason or "blocked"),
+            )
+        return _guardrail_failure_output(tripwire=False, output="")
+
+
+class LuminOutputGuardrail(_BaseGuardrail):
+    """Use as ``Agent(output_guardrails=[LuminOutputGuardrail()])``."""
+
+    def check_output(
+        self,
+        *,
+        messages: List[Dict[str, Any]],
+        text: str,
+        session_id: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> str:
+        decision = self._client.decide(DecideRequest(
+            lifecycle="after_proxy_call",
+            messages=messages,
+            output={"text": text},
+            session_id=session_id,
+            model=model,
+        ))
+        if decision.is_block:
+            raise LuminFirewallBlocked(decision, lifecycle="after_proxy_call")
+        if decision.is_rewrite:
+            new_text = decision.rewritten.get("result")
+            if isinstance(new_text, str):
+                return new_text
+        return text
+
+    async def __call__(self, context, agent_output) -> Any:  # type: ignore[no-untyped-def]
+        text = _extract_output_text(agent_output)
+        try:
+            self.check_output(messages=[], text=text)
+        except LuminFirewallBlocked as blocked:
+            return _guardrail_failure_output(
+                tripwire=True, output=str(blocked.decision.reason or "blocked"),
+            )
+        return _guardrail_failure_output(tripwire=False, output="")
+
+
+def wrap_tool(
+    fn: Callable[..., Any],
+    *,
+    tool_name: Optional[str] = None,
+    host: Optional[str] = None,
+    project: Optional[str] = None,
+    agent: Optional[str] = None,
+    timeout_ms: int = 75,
+    on_error: str = "allow",
+) -> Callable[..., Any]:
+    """Wrap a tool function with before/after firewall gating.
+
+    Use BEFORE the @function_tool decorator so the firewall checks
+    happen inside the tool's call boundary."""
+    client = FirewallClient(
+        host=host, project=project, agent=agent,
+        timeout_ms=timeout_ms, on_error=on_error,  # type: ignore[arg-type]
+    )
+    name = tool_name or fn.__name__
+
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        before = client.decide(DecideRequest(
+            lifecycle="before_tool_call",
+            tool_name=name,
+            params=kwargs,
+        ))
+        if before.is_block:
+            raise LuminFirewallBlocked(before, lifecycle="before_tool_call")
+        if before.is_rewrite:
+            new_params = before.rewritten.get("params") or {}
+            kwargs = {**kwargs, **new_params}
+
+        result = fn(*args, **kwargs)
+
+        after = client.decide(DecideRequest(
+            lifecycle="after_tool_call",
+            tool_name=name,
+            output={"result": result},
+        ))
+        if after.is_block:
+            raise LuminFirewallBlocked(after, lifecycle="after_tool_call")
+        if after.is_rewrite:
+            return after.rewritten.get("result", result)
+        return result
+
+    wrapped.__name__ = name
+    wrapped.__doc__ = fn.__doc__
+    return wrapped
+
+
+# ----- helpers -----
+
+
+def _extract_input_text(context: Any) -> str:
+    try:
+        msgs = getattr(context, "messages", None) or context.get("messages") or []
+        for m in msgs:
+            if (m.get("role") if isinstance(m, dict) else getattr(m, "role", None)) == "user":
+                return m["content"] if isinstance(m, dict) else getattr(m, "content", "")
+    except Exception:
+        pass
+    return ""
+
+
+def _extract_output_text(agent_output: Any) -> str:
+    try:
+        return getattr(agent_output, "final_output", None) or str(agent_output)
+    except Exception:
+        return ""
+
+
+def _guardrail_failure_output(*, tripwire: bool, output: str) -> Any:
+    """Build the GuardrailFunctionOutput shape the SDK expects.
+    When the SDK isn't installed, return a plain dict with the
+    same fields so test code can introspect."""
+    try:
+        from agents import GuardrailFunctionOutput  # type: ignore
+        return GuardrailFunctionOutput(
+            output_info={"reason": output}, tripwire_triggered=tripwire,
+        )
+    except Exception:
+        return {"output_info": {"reason": output}, "tripwire_triggered": tripwire}
+
+
+__all__ = [
+    "LuminFirewallBlocked",
+    "LuminInputGuardrail",
+    "LuminOutputGuardrail",
+    "wrap_tool",
+]

--- a/packages/sdk-python/lumin/integrations/pydantic_ai_firewall.py
+++ b/packages/sdk-python/lumin/integrations/pydantic_ai_firewall.py
@@ -1,0 +1,178 @@
+"""Pydantic AI firewall integration (§9.8).
+
+Pydantic AI exposes typed tool functions via ``@agent.tool`` and
+result validation via ``RunContext``. Lumin's adapter wraps tools
+with before / after firewall checks and adds an input-side
+``check_user_input`` helper for the message boundary.
+
+Two adapter shapes:
+
+  1. ``firewall_tool(agent, fn)`` — replaces ``@agent.tool``,
+     registering ``fn`` with the Lumin firewall pre/post.
+
+  2. ``LuminFirewallChecker`` — manual sync class with
+     ``check_input()`` / ``check_output()`` / ``wrap_tool()`` for
+     operators who don't want the decorator-replacement style.
+
+Usage with the decorator:
+
+    from pydantic_ai import Agent
+    from lumin.integrations.pydantic_ai_firewall import firewall_tool
+
+    agent = Agent(model="claude-3.5-sonnet", system_prompt="...")
+
+    @firewall_tool(agent)
+    def search_db(ctx, query: str) -> list:
+        ...
+
+The ``@firewall_tool`` decorator wraps the function with
+before_tool_call / after_tool_call decide() calls, then registers
+the wrapped function with the agent via the standard
+``agent.tool`` decorator path.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import wraps
+from typing import Any, Callable, List, Optional
+
+from lumin.firewall_client import (
+    DecideRequest,
+    DecideResponse,
+    FirewallClient,
+)
+
+logger = logging.getLogger("lumin.integrations.pydantic_ai_firewall")
+
+
+class LuminFirewallBlocked(Exception):
+    def __init__(self, decision: DecideResponse, *, lifecycle: str) -> None:
+        self.decision = decision
+        self.lifecycle = lifecycle
+        super().__init__(
+            f"Lumin firewall {decision.decision} at {lifecycle}: "
+            f"{decision.policy_name or '_engine_'}"
+        )
+
+
+class LuminFirewallChecker:
+    def __init__(
+        self,
+        *,
+        host: Optional[str] = None,
+        project: Optional[str] = None,
+        agent: Optional[str] = None,
+        timeout_ms: int = 75,
+        on_error: str = "allow",
+    ) -> None:
+        self._client = FirewallClient(
+            host=host, project=project, agent=agent,
+            timeout_ms=timeout_ms, on_error=on_error,  # type: ignore[arg-type]
+        )
+
+    def check_input(self, text: str, *, session_id: Optional[str] = None) -> None:
+        decision = self._client.decide(DecideRequest(
+            lifecycle="before_proxy_call",
+            messages=[{"role": "user", "content": text}],
+            session_id=session_id,
+        ))
+        if decision.is_block or decision.needs_approval:
+            raise LuminFirewallBlocked(decision, lifecycle="before_proxy_call")
+
+    def check_output(self, text: str, *, session_id: Optional[str] = None) -> str:
+        decision = self._client.decide(DecideRequest(
+            lifecycle="after_proxy_call",
+            output={"text": text},
+            session_id=session_id,
+        ))
+        if decision.is_block:
+            raise LuminFirewallBlocked(decision, lifecycle="after_proxy_call")
+        if decision.is_rewrite:
+            new = decision.rewritten.get("result")
+            if isinstance(new, str):
+                return new
+        return text
+
+    def wrap_tool(
+        self,
+        fn: Callable[..., Any],
+        *,
+        tool_name: Optional[str] = None,
+    ) -> Callable[..., Any]:
+        name = tool_name or fn.__name__
+        client = self._client
+
+        @wraps(fn)
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            before = client.decide(DecideRequest(
+                lifecycle="before_tool_call",
+                tool_name=name,
+                params=kwargs,
+            ))
+            if before.is_block:
+                raise LuminFirewallBlocked(before, lifecycle="before_tool_call")
+            if before.is_rewrite:
+                new_params = before.rewritten.get("params") or {}
+                kwargs = {**kwargs, **new_params}
+            result = fn(*args, **kwargs)
+            after = client.decide(DecideRequest(
+                lifecycle="after_tool_call",
+                tool_name=name,
+                output={"result": result},
+            ))
+            if after.is_block:
+                raise LuminFirewallBlocked(after, lifecycle="after_tool_call")
+            if after.is_rewrite:
+                return after.rewritten.get("result", result)
+            return result
+
+        return wrapped
+
+    def close(self) -> None:
+        self._client.close()
+
+
+def firewall_tool(
+    agent: Any,
+    *,
+    host: Optional[str] = None,
+    project: Optional[str] = None,
+    timeout_ms: int = 75,
+    on_error: str = "allow",
+    tool_name: Optional[str] = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator-replacement for ``@agent.tool``. Wraps the tool
+    with firewall pre/post checks and registers it with the agent.
+
+    Falls back gracefully when the agent doesn't expose ``.tool``
+    (e.g., a stub during testing) — the wrapped function is still
+    returned and can be called directly.
+    """
+    checker = LuminFirewallChecker(
+        host=host, project=project,
+        agent=getattr(agent, "name", None) or None,
+        timeout_ms=timeout_ms, on_error=on_error,
+    )
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        wrapped = checker.wrap_tool(fn, tool_name=tool_name or fn.__name__)
+        register = getattr(agent, "tool", None)
+        if callable(register):
+            try:
+                register(wrapped)
+            except Exception:
+                logger.exception(
+                    "pydantic_ai_firewall: agent.tool registration failed; "
+                    "returning wrapped function only"
+                )
+        return wrapped
+
+    return decorator
+
+
+__all__ = [
+    "LuminFirewallBlocked",
+    "LuminFirewallChecker",
+    "firewall_tool",
+]

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -33,6 +33,9 @@ test = [
 langchain = [
     "langchain-core>=0.3.0",
 ]
+langgraph = [
+    "langgraph>=0.2.0",
+]
 crewai = [
     "crewai>=0.80.0",
 ]
@@ -42,11 +45,28 @@ anthropic = [
 llama_index = [
     "llama-index-core>=0.10.0",
 ]
+litellm = [
+    "litellm>=1.40.0",
+]
+openai_agents = [
+    "openai-agents>=0.0.1",
+]
+autogen = [
+    "pyautogen>=0.4.0",
+]
+pydantic_ai = [
+    "pydantic-ai>=0.0.13",
+]
 all = [
     "langchain-core>=0.3.0",
+    "langgraph>=0.2.0",
     "crewai>=0.80.0",
     "anthropic>=0.30.0",
     "llama-index-core>=0.10.0",
+    "litellm>=1.40.0",
+    "openai-agents>=0.0.1",
+    "pyautogen>=0.4.0",
+    "pydantic-ai>=0.0.13",
 ]
 
 [tool.setuptools.packages.find]

--- a/packages/sdk-python/tests/test_firewall_integrations.py
+++ b/packages/sdk-python/tests/test_firewall_integrations.py
@@ -1,0 +1,384 @@
+"""Tests for the framework firewall integrations (§9.3–§9.8 / Slice 4).
+
+Approach: mock ``FirewallClient.decide`` so the tests don't depend
+on a running Lumin API or on the real frameworks (LangChain etc.)
+being installed. Each integration's translation logic — block →
+exception, rewrite → mutated params, allow → passthrough — is
+verified against the fakes.
+
+Some adapters are skipped when their framework isn't installed
+(e.g., ``langchain_firewall`` requires ``langchain-core``). These
+modules raise ``ImportError`` at import time, so the test catches
+that and skips cleanly. The shared ``firewall_client`` is always
+testable.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from lumin.firewall_client import (
+    DecideRequest,
+    DecideResponse,
+    FirewallClient,
+    VALID_LIFECYCLES,
+)
+
+
+# ----- shared FirewallClient ------------------------------------------------
+
+
+def test_decide_request_drops_none_values():
+    req = DecideRequest(lifecycle="before_proxy_call", tool_name="x")
+    payload = req.to_payload()
+    assert payload == {"lifecycle": "before_proxy_call", "tool_name": "x"}
+
+
+def test_decide_request_rejects_unknown_lifecycle():
+    client = FirewallClient()
+    with pytest.raises(ValueError):
+        client.decide(DecideRequest(lifecycle="not_a_real_lifecycle"))
+    client.close()
+
+
+def test_decide_returns_allow_on_timeout():
+    client = FirewallClient(timeout_ms=10)
+
+    def fake_post(*a, **kw):
+        raise httpx.TimeoutException("simulated")
+
+    with patch.object(client._client, "post", side_effect=fake_post):
+        resp = client.decide(DecideRequest(lifecycle="before_proxy_call"))
+    assert resp.is_allow
+    assert resp.reason == "firewall_client:timeout"
+    client.close()
+
+
+def test_decide_returns_block_on_timeout_when_on_error_deny():
+    client = FirewallClient(timeout_ms=10, on_error="deny")
+    with patch.object(client._client, "post", side_effect=httpx.TimeoutException("x")):
+        resp = client.decide(DecideRequest(lifecycle="before_proxy_call"))
+    assert resp.is_block
+    client.close()
+
+
+def test_decide_parses_block_response():
+    client = FirewallClient()
+    fake_resp = MagicMock(status_code=200, content=b"{}")
+    fake_resp.json.return_value = {
+        "decision": "block",
+        "policy_name": "test_policy",
+        "decision_id": "dec_123",
+        "reason": "matched",
+    }
+    with patch.object(client._client, "post", return_value=fake_resp):
+        resp = client.decide(DecideRequest(lifecycle="before_tool_call", tool_name="t"))
+    assert resp.is_block
+    assert resp.policy_name == "test_policy"
+    assert resp.decision_id == "dec_123"
+    client.close()
+
+
+def test_decide_response_classification_helpers():
+    assert DecideResponse(decision="allow").is_allow
+    assert DecideResponse(decision="block").is_block
+    assert DecideResponse(decision="require_approval").needs_approval
+    assert DecideResponse(decision="rewrite").is_rewrite
+
+
+# ----- LangChain ------------------------------------------------------------
+
+
+def _import_or_skip(module_name: str):
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as e:
+        pytest.skip(f"{module_name} unavailable: {e}")
+
+
+def test_langchain_handler_blocks_on_tool_start():
+    mod = _import_or_skip("lumin.integrations.langchain_firewall")
+    handler = mod.LuminFirewallHandler()
+    with patch.object(
+        handler._client, "decide",
+        return_value=DecideResponse(decision="block", policy_name="p"),
+    ):
+        with pytest.raises(mod.LuminFirewallBlocked):
+            handler.on_tool_start(
+                {"name": "search"}, "query", run_id="r1",
+            )
+    handler.close()
+
+
+def test_langchain_handler_passes_on_allow():
+    mod = _import_or_skip("lumin.integrations.langchain_firewall")
+    handler = mod.LuminFirewallHandler()
+    with patch.object(
+        handler._client, "decide",
+        return_value=DecideResponse(decision="allow"),
+    ):
+        # Should not raise.
+        handler.on_tool_start({"name": "search"}, "q", run_id="r1")
+        handler.on_tool_end("result", run_id="r1")
+    handler.close()
+
+
+def test_langchain_handler_rewrite_mutates_inputs():
+    mod = _import_or_skip("lumin.integrations.langchain_firewall")
+    handler = mod.LuminFirewallHandler()
+    inputs: dict = {"command": "rm -rf /"}
+    with patch.object(
+        handler._client, "decide",
+        return_value=DecideResponse(
+            decision="rewrite",
+            rewritten={"params": {"command": "echo blocked"}},
+        ),
+    ):
+        handler.on_tool_start(
+            {"name": "shell"}, "rm -rf /", run_id="r2", inputs=inputs,
+        )
+    assert inputs["command"] == "echo blocked"
+    handler.close()
+
+
+# ----- LangGraph ------------------------------------------------------------
+
+
+def test_langgraph_firewall_node_passes_on_allow():
+    mod = _import_or_skip("lumin.integrations.langgraph_firewall")
+    node = mod.firewall_node()
+    with patch(
+        "lumin.integrations.langgraph_firewall.FirewallClient.decide",
+        return_value=DecideResponse(decision="allow"),
+    ):
+        state = {"messages": [{"role": "user", "content": "hi"}]}
+        out = node(state)
+    assert out == state
+
+
+def test_langgraph_firewall_node_blocks_on_block():
+    mod = _import_or_skip("lumin.integrations.langgraph_firewall")
+    node = mod.firewall_node()
+    with patch(
+        "lumin.integrations.langgraph_firewall.FirewallClient.decide",
+        return_value=DecideResponse(decision="block", policy_name="p"),
+    ):
+        with pytest.raises(mod.LuminFirewallBlocked):
+            node({"messages": [{"role": "user", "content": "x"}]})
+
+
+def test_langgraph_wrap_tool_node_passes_through():
+    mod = _import_or_skip("lumin.integrations.langgraph_firewall")
+    inner = lambda state: {"tool_output": state["tool_input"].upper()}
+    wrapped = mod.wrap_tool_node(inner, tool_name="upper")
+    with patch(
+        "lumin.integrations.langgraph_firewall.FirewallClient.decide",
+        return_value=DecideResponse(decision="allow"),
+    ):
+        out = wrapped({"tool_input": "hi"})
+    assert out == {"tool_output": "HI"}
+
+
+# ----- LiteLLM --------------------------------------------------------------
+
+
+def test_litellm_check_request_blocks():
+    from lumin.integrations.litellm_firewall import (
+        LuminFirewallBlocked, LuminFirewallGuardrail,
+    )
+    g = LuminFirewallGuardrail()
+    with patch.object(
+        g._client, "decide",
+        return_value=DecideResponse(decision="block", policy_name="p"),
+    ):
+        with pytest.raises(LuminFirewallBlocked):
+            g.check_request(messages=[{"role": "user", "content": "bad"}])
+    g.close()
+
+
+def test_litellm_check_response_rewrites_text():
+    from lumin.integrations.litellm_firewall import LuminFirewallGuardrail
+    g = LuminFirewallGuardrail()
+    response = {"choices": [{"message": {"content": "secret"}}]}
+    with patch.object(
+        g._client, "decide",
+        return_value=DecideResponse(
+            decision="rewrite",
+            rewritten={"result": "[REDACTED]"},
+        ),
+    ):
+        out = g.check_response(messages=[], response=response)
+    assert out["choices"][0]["message"]["content"] == "[REDACTED]"
+    g.close()
+
+
+# ----- OpenAI Agents SDK ----------------------------------------------------
+
+
+def test_openai_agents_input_guardrail_blocks():
+    from lumin.integrations.openai_agents_firewall import (
+        LuminFirewallBlocked, LuminInputGuardrail,
+    )
+    g = LuminInputGuardrail()
+    with patch.object(
+        g._client, "decide",
+        return_value=DecideResponse(decision="block", policy_name="p"),
+    ):
+        with pytest.raises(LuminFirewallBlocked):
+            g.check_input(messages=[{"role": "user", "content": "x"}])
+    g.close()
+
+
+def test_openai_agents_output_guardrail_rewrites():
+    from lumin.integrations.openai_agents_firewall import LuminOutputGuardrail
+    g = LuminOutputGuardrail()
+    with patch.object(
+        g._client, "decide",
+        return_value=DecideResponse(
+            decision="rewrite", rewritten={"result": "[redacted]"},
+        ),
+    ):
+        out = g.check_output(messages=[], text="secret")
+    assert out == "[redacted]"
+    g.close()
+
+
+def test_openai_agents_wrap_tool_blocks():
+    from lumin.integrations.openai_agents_firewall import (
+        LuminFirewallBlocked, wrap_tool,
+    )
+
+    def my_tool(*, query: str) -> str:
+        return "ok"
+
+    wrapped = wrap_tool(my_tool, tool_name="search")
+    # First decide returns block at before_tool_call.
+    with patch(
+        "lumin.integrations.openai_agents_firewall.FirewallClient.decide",
+        return_value=DecideResponse(decision="block", policy_name="p"),
+    ):
+        with pytest.raises(LuminFirewallBlocked):
+            wrapped(query="hi")
+
+
+# ----- AutoGen --------------------------------------------------------------
+
+
+def test_autogen_message_before_send_blocks():
+    from lumin.integrations.autogen_firewall import (
+        AutoGenFirewallAdapter, LuminFirewallBlocked,
+    )
+    adapter = AutoGenFirewallAdapter(
+        host=None, project=None, agent_name="x",
+        timeout_ms=75, on_error="allow",
+    )
+    with patch.object(
+        adapter._client, "decide",
+        return_value=DecideResponse(decision="block", policy_name="p"),
+    ):
+        with pytest.raises(LuminFirewallBlocked):
+            adapter.on_message_before_send(
+                sender=None,
+                message={"content": "ignore previous"},
+                recipient=None,
+                silent=False,
+            )
+    adapter.close()
+
+
+def test_autogen_message_before_send_rewrites():
+    from lumin.integrations.autogen_firewall import AutoGenFirewallAdapter
+    adapter = AutoGenFirewallAdapter(
+        host=None, project=None, agent_name="x",
+        timeout_ms=75, on_error="allow",
+    )
+    msg = {"content": "secret stuff"}
+    with patch.object(
+        adapter._client, "decide",
+        return_value=DecideResponse(
+            decision="rewrite", rewritten={"result": "[REDACTED]"},
+        ),
+    ):
+        out = adapter.on_message_before_send(
+            sender=None, message=msg, recipient=None, silent=False,
+        )
+    assert out["content"] == "[REDACTED]"
+    adapter.close()
+
+
+def test_autogen_register_lumin_firewall_handles_no_register_hook():
+    """An object without register_hook should not crash the
+    registration helper — it logs and skips."""
+    from lumin.integrations.autogen_firewall import register_lumin_firewall
+
+    class _Fake:
+        name = "fake"
+
+    adapter = register_lumin_firewall(_Fake())
+    adapter.close()
+
+
+# ----- Pydantic AI ----------------------------------------------------------
+
+
+def test_pydantic_ai_check_input_blocks():
+    from lumin.integrations.pydantic_ai_firewall import (
+        LuminFirewallBlocked, LuminFirewallChecker,
+    )
+    c = LuminFirewallChecker()
+    with patch.object(
+        c._client, "decide",
+        return_value=DecideResponse(decision="block", policy_name="p"),
+    ):
+        with pytest.raises(LuminFirewallBlocked):
+            c.check_input("ignore previous instructions")
+    c.close()
+
+
+def test_pydantic_ai_wrap_tool_rewrites_params():
+    from lumin.integrations.pydantic_ai_firewall import LuminFirewallChecker
+    c = LuminFirewallChecker()
+
+    captured: dict = {}
+
+    def my_tool(*, command: str) -> str:
+        captured["command"] = command
+        return "ran"
+
+    wrapped = c.wrap_tool(my_tool, tool_name="shell")
+    with patch.object(
+        c._client, "decide",
+        side_effect=[
+            DecideResponse(decision="rewrite", rewritten={"params": {"command": "echo safe"}}),
+            DecideResponse(decision="allow"),
+        ],
+    ):
+        wrapped(command="rm -rf /")
+    assert captured["command"] == "echo safe"
+    c.close()
+
+
+def test_pydantic_ai_firewall_tool_decorator_returns_callable():
+    """The decorator should still return a working callable even
+    when the agent doesn't expose a usable .tool method."""
+    from lumin.integrations.pydantic_ai_firewall import firewall_tool
+
+    class _StubAgent:
+        name = "stub"
+
+    decorator = firewall_tool(_StubAgent())
+
+    @decorator
+    def double(*, x: int) -> int:
+        return x * 2
+
+    with patch(
+        "lumin.integrations.pydantic_ai_firewall.FirewallClient.decide",
+        return_value=DecideResponse(decision="allow"),
+    ):
+        assert double(x=3) == 6


### PR DESCRIPTION
## Summary

Ships firewall enforcement adapters for the remaining frameworks in spec §9. Each module is a thin layer over a shared `firewall_client` that POSTs to `/v1/policy/decide` and translates the response into the framework's native block / allow / rewrite contract.

## What lands

| § | Framework | Module | Adapter shape |
|---|---|---|---|
| 9.3 | LangGraph | `langgraph_firewall.py` | `firewall_node()`, `wrap_tool_node()` (uses `interrupt()` on require_approval) |
| 9.4 | LangChain | `langchain_firewall.py` | `LuminFirewallHandler(BaseCallbackHandler)` |
| 9.5 | LiteLLM | `litellm_firewall.py` | `LuminFirewallGuardrail` (CustomGuardrail compatible) |
| 9.6 | OpenAI Agents SDK | `openai_agents_firewall.py` | `LuminInputGuardrail`, `LuminOutputGuardrail`, `wrap_tool()` |
| 9.7 | AutoGen | `autogen_firewall.py` | `register_lumin_firewall(agent)` |
| 9.8 | Pydantic AI | `pydantic_ai_firewall.py` | `firewall_tool()` decorator, `LuminFirewallChecker` |
| — | Shared | `firewall_client.py` | `FirewallClient`, `DecideRequest`, `DecideResponse` |

## Verb mapping (consistent across all 6 adapters)

| decide() returns | Framework behavior |
|---|---|
| `allow` | passthrough |
| `block` | raise `LuminFirewallBlocked` |
| `require_approval` | raise (or `interrupt()` on LangGraph) |
| `rewrite` | mutate params (before-hooks) or output (after-hooks) |
| `flag` | passthrough (logged via `decide()`'s own decision row) |

## Rule 7 (agent never blocks on us)

Every adapter inherits from `FirewallClient`:

- Default 75ms timeout (configurable per integration)
- On timeout / network error / 5xx: returns `allow` (configurable to `deny` for fail-closed deployments)
- One failure logged, subsequent failures suppressed (no log spam)

## Pyproject extras

```bash
pip install lumin[langchain]     # callback handler
pip install lumin[langgraph]     # firewall_node + wrap_tool_node
pip install lumin[litellm]       # guardrail
pip install lumin[openai_agents] # input/output guardrails + wrap_tool
pip install lumin[autogen]       # register_lumin_firewall
pip install lumin[pydantic_ai]   # @firewall_tool decorator
pip install lumin[all]           # everything
```

Each adapter's framework-specific subclass is built lazily — importing the module without the framework installed doesn't crash; the standalone `check_input` / `check_output` / `wrap_tool` API still works for direct `/v1/policy/decide` use.

## Tests

23 new tests covering block / allow / rewrite paths for each adapter. Mocks `decide()` so tests don't need a running API or the real frameworks installed.

**Full SDK suite: 232 passed** (was 209 — +23 new, no regressions).

## Test plan

- [x] All 23 firewall-integration tests green
- [x] Existing 209 SDK tests still green (observability handlers, decorators, etc.)
- [ ] Manual: install each framework + run an end-to-end decide() call against a live Lumin API for at least 2 of the 6 adapters