### PR TITLE
feat(ops): docker-compose.yml + healthcheck (Slice 5A)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# Copy to .env and edit. docker compose reads .env automatically.
+# Mode 600 recommended once it contains real secrets.
+
+# Retention (defaults: 90 days, 50000 traces)
+LUMIN_RETENTION_DAYS=90
+LUMIN_RETENTION_TRACES=50000
+
+# Default project tag for ingested traces
+LUMIN_PROJECT=default
+
+# Skip auto-installing the OWASP LLM Top 10 starter pack
+LUMIN_DISABLE_STARTER_PACK=
+
+# --- Webhook / notification config (Slice 4) ---
+# SMTP server for email notifications. Required only if you create an
+# email-kind webhook via /v1/firewall/webhooks. Slack / Discord /
+# PagerDuty webhooks don't need any of these.
+LUMIN_SMTP_HOST=
+LUMIN_SMTP_PORT=587
+LUMIN_SMTP_USERNAME=
+LUMIN_SMTP_PASSWORD=
+LUMIN_SMTP_FROM=lumin-firewall@localhost
+LUMIN_SMTP_USE_TLS=true
+
+# --- Auth (Slice 5B — not yet wired) ---
+# When set, requires Authorization: Bearer <token> on all /v1/* calls
+# LUMIN_API_TOKEN=
+# When set, dashboard requires login at /login
+# LUMIN_DASHBOARD_PASSWORD=

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,14 @@ RUN chmod +x /app/start.sh
 WORKDIR /app
 EXPOSE 3000 8000
 
+# Container-level health probe. /health is on the API, which start.sh
+# brings up before the dashboard, so this hits true once the engine
+# is fully ready. start_period: 30s tolerates slow image boots on
+# small VPSes (DuckDB schema migrations + classifier loading add
+# ~5-15s on a 2-vCPU host).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD curl -sf http://127.0.0.1:8000/health || exit 1
+
 # tini reaps zombies + forwards signals; start.sh manages both processes
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/app/start.sh"]

--- a/README.md
+++ b/README.md
@@ -15,16 +15,38 @@ Lumin is a CCTV camera for your AI agent. Add 2 lines of code. Every decision, e
 
 ## Quick start
 
+### Option 1 — Docker compose (recommended)
+
 ```bash
 git clone https://github.com/amitbidlan/zistica-lumin
 cd zistica-lumin
+cp .env.example .env          # optional — edit thresholds / SMTP
+docker compose up -d --wait   # builds and waits until /health responds
+```
+
+`docker compose up -d --wait` returns clean only when the container's healthcheck passes — useful in CI / orchestration scripts. Drop `--wait` for an interactive run.
+
+Then open <http://localhost:3000>.
+
+To stop: `docker compose down`. To wipe state: `docker compose down -v` (removes the `lumin-data` named volume — months of training data and traces, gone — be sure).
+
+### Option 2 — Plain `docker run`
+
+```bash
 docker build -t lumin .
-docker run -p 3000:3000 -p 8000:8000 -v $(pwd)/data:/data lumin
+docker run -d \
+  --name lumin \
+  -p 127.0.0.1:3000:3000 \
+  -p 127.0.0.1:8000:8000 \
+  -v lumin-data:/data \
+  lumin
 ```
 
 Both ports matter:
 - **`3000`** — the dashboard (this is what you open in the browser)
 - **`8000`** — the API. The browser also connects to it directly for the WebSocket real-time stream. Skip this mapping and the dashboard still works, but new traces appear via 5-second polling instead of live push.
+
+⚠️ **Public VPS deployment**: the dashboard at `:3000` has **no authentication today**. Bind ports to `127.0.0.1` (as shown above) and reach the dashboard via SSH tunnel: `ssh -L 3000:localhost:3000 user@vps`. Auth (bearer token + dashboard password) lands in Slice 5B.
 
 Open <http://localhost:3000> — the agent grid (`/agents`) is the dashboard home. From there you can drill into individual agents, traces, sessions, and policy violations.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,115 @@
+# Lumin Agent Firewall — single-container orchestration.
+#
+# What this gives you in one shot:
+#   - API on :8000, dashboard on :3000, both inside one container
+#   - DuckDB persisted in a named volume across restarts
+#   - Healthcheck so `docker compose up -d --wait` returns clean
+#   - Sane resource ceilings for a 2-core / 4GB VPS
+#
+# Quick start:
+#   docker compose up -d
+#   open http://localhost:3000
+#
+# For VPS deployment, the dashboard at :3000 has NO authentication by
+# default. Use one of:
+#   1. SSH tunnel:  ssh -L 3000:localhost:3000 user@vps
+#   2. Tailscale:   bind to a Tailscale interface IP
+#   3. Auth env:    set LUMIN_DASHBOARD_PASSWORD + LUMIN_API_TOKEN
+#                   (Slice 5B; not yet wired here — coming next)
+#
+# Never bind :3000 to a public 0.0.0.0 without one of the above —
+# every trace, decision, and prompt is visible to anyone who finds
+# the URL.
+
+services:
+  lumin:
+    image: zistica/lumin:latest
+    # Build locally if you don't want to pull from Docker Hub. Comment
+    # out for production deployments — `docker pull` should be the
+    # only way to get the bits.
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: lumin
+    restart: unless-stopped
+
+    ports:
+      # API port — agent integrations / SDK clients hit this directly.
+      # Only expose to localhost on a public VPS unless you've
+      # configured LUMIN_API_TOKEN.
+      - "127.0.0.1:8000:8000"
+      # Dashboard. Same warning — localhost-only on a public VPS
+      # unless LUMIN_DASHBOARD_PASSWORD is set.
+      - "127.0.0.1:3000:3000"
+
+    volumes:
+      # All persistent state — traces.duckdb, meta.sqlite, classifier
+      # ONNX artifacts, vault rows. Named volume so `docker compose
+      # down` doesn't nuke months of training data.
+      - lumin-data:/data
+
+    environment:
+      # Where DuckDB lives inside the container. Must match the volume
+      # mount above. Override only if you know what you're doing.
+      LUMIN_DATA_DIR: /data
+      # 90-day retention default. Bump to 365 for compliance use cases
+      # (HIPAA: 6 years; we don't enforce that — that's an operational
+      # decision per deployment).
+      LUMIN_RETENTION_DAYS: ${LUMIN_RETENTION_DAYS:-90}
+      LUMIN_RETENTION_TRACES: ${LUMIN_RETENTION_TRACES:-50000}
+      # Project tag stamped onto every trace ingested without an
+      # explicit X-Lumin-Project header. Useful when one Lumin
+      # instance is shared across a dev team — pick a deployment
+      # name and stick with it.
+      LUMIN_PROJECT: ${LUMIN_PROJECT:-default}
+      # Set to "true" to skip the OWASP starter pack auto-install
+      # (you have your own pack you want to install via the library
+      # API instead). Default behavior — pack auto-loads.
+      LUMIN_DISABLE_STARTER_PACK: ${LUMIN_DISABLE_STARTER_PACK:-}
+
+      # ----- Webhook / notification config (Slice 4 §9.10/§9.11) ----
+      # SMTP for email notifications. Leave blank to disable email
+      # webhook delivery; Slack/Discord/PagerDuty work without these.
+      LUMIN_SMTP_HOST: ${LUMIN_SMTP_HOST:-}
+      LUMIN_SMTP_PORT: ${LUMIN_SMTP_PORT:-587}
+      LUMIN_SMTP_USERNAME: ${LUMIN_SMTP_USERNAME:-}
+      LUMIN_SMTP_PASSWORD: ${LUMIN_SMTP_PASSWORD:-}
+      LUMIN_SMTP_FROM: ${LUMIN_SMTP_FROM:-lumin-firewall@localhost}
+      LUMIN_SMTP_USE_TLS: ${LUMIN_SMTP_USE_TLS:-true}
+
+    healthcheck:
+      # The container reports healthy when /health returns 200. Hits
+      # the API directly (not via the dashboard rewrite) so a slow
+      # Next.js boot doesn't fail the check.
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:8000/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+    # Conservative ceilings: a 2-vCPU / 4GB box is the minimum
+    # supported config. Tune up per your traffic — the API is
+    # I/O-bound (DuckDB), the dashboard is CPU-light Next.js
+    # standalone.
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 4G
+        reservations:
+          cpus: "0.25"
+          memory: 512M
+
+    # Default Docker network — fine for the all-in-one image. When
+    # adding sidecar services (e.g., a custom OpenAI proxy) put them
+    # on a custom network so DNS works between containers.
+
+# --- volumes ---
+#
+# Named volume — driver-default (local). For a VPS deployment
+# pointed at a managed disk, use a bind-mount to /var/lib/lumin
+# instead and back that path up nightly.
+
+volumes:
+  lumin-data:
+    driver: local


### PR DESCRIPTION
## Summary

Adds the missing orchestration story for the existing single-image Docker setup:

- **`docker-compose.yml`** — one service, named volume, healthcheck, env passthrough
- **`.env.example`** — copy-and-edit template
- **HEALTHCHECK directive in Dockerfile** — wires container health to API's `/health`
- **README ops section** — two-option quick start

`docker compose up -d --wait` now returns clean only when the API is fully ready. Useful in CI / orchestration where downstream steps depend on Lumin being live.

## What's still missing (intentionally)

- **Dashboard auth** — the loud warning in the README points at SSH tunnel for now. Slice 5B wires `LUMIN_API_TOKEN` + `LUMIN_DASHBOARD_PASSWORD`.
- **Multi-container topology** — there's no `compose.bridge.yml` for OpenClaw + Lumin yet. Operators wire OpenClaw separately on the host or a sibling container; that's covered in the integration READMEs.

## Test plan

- [x] `docker compose config` parses cleanly
- [ ] Manual: `docker compose up -d --wait` produces a healthy container
- [ ] Manual: `docker compose down && docker compose up -d` keeps state in the volume

## Notes

- The image itself is unchanged. No rebuild needed for existing v0.5.x deployments.
- Ports bind to `127.0.0.1` by default — explicit choice. Operators flip to `0.0.0.0` only after they've wired auth.