### PR TITLE
feat(auth): bearer token + dashboard password (Slice 5B)

### DIFF
--- a/packages/api/auth.py
+++ b/packages/api/auth.py
@@ -1,0 +1,143 @@
+"""Bearer-token authentication middleware (Slice 5B).
+
+Default-off. When ``LUMIN_API_TOKEN`` is unset, the middleware is a
+no-op and the API behaves exactly like it did before — every
+endpoint is reachable without credentials. This preserves the
+zero-friction localhost-dev story.
+
+When ``LUMIN_API_TOKEN`` is set, every request to ``/v1/*``,
+``/ws/*``, and ``/health/admin`` requires:
+
+    Authorization: Bearer <LUMIN_API_TOKEN>
+
+…or, for WebSocket connections that can't carry headers easily,
+a query string ``?token=<LUMIN_API_TOKEN>``.
+
+Exempt paths (always reachable, no token required):
+  - ``/health``         the container healthcheck hits this
+  - ``/openapi.json``   FastAPI's spec; needed by tooling
+  - ``/docs``, ``/redoc``  same
+  - ``/`` (root)        a minimal JSON identity card
+
+Why a custom middleware instead of FastAPI's ``HTTPBearer`` /
+``Security``? Two reasons:
+
+  1. Token comparison must be **constant-time** to avoid timing
+     attacks. ``hmac.compare_digest`` does that; the FastAPI
+     security helpers don't.
+  2. The off-by-default story needs to be a single env-var check
+     — wrapping every router with a Depends would force every
+     test to opt out individually.
+
+The middleware is added in ``main.py`` after all routers are
+registered. Order matters — auth must run BEFORE the router
+matches the path, so it has a chance to 401 before the handler
+fires.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+from typing import Iterable, Optional, Tuple
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+logger = logging.getLogger("lumin.api.auth")
+
+
+# Paths that are ALWAYS reachable without a token. Order doesn't
+# matter — startswith match.
+_PUBLIC_PREFIXES: Tuple[str, ...] = (
+    "/health",
+    "/openapi.json",
+    "/docs",
+    "/redoc",
+)
+_PUBLIC_EXACT: Tuple[str, ...] = ("/",)
+
+
+def _expected_token() -> Optional[str]:
+    """Return the configured API token, or None if auth is disabled.
+
+    Read at request time (not at module load) so an operator can
+    rotate the token via env without restarting — the next request
+    picks up the new value.
+    """
+    raw = os.environ.get("LUMIN_API_TOKEN", "")
+    return raw.strip() or None
+
+
+def auth_enabled() -> bool:
+    return _expected_token() is not None
+
+
+def _is_public_path(path: str) -> bool:
+    if path in _PUBLIC_EXACT:
+        return True
+    for prefix in _PUBLIC_PREFIXES:
+        if path == prefix or path.startswith(prefix + "/") or path.startswith(prefix):
+            return True
+    return False
+
+
+def _extract_token(request: Request) -> Optional[str]:
+    """Pull the candidate token off the request.
+
+    Header preferred (standard ``Authorization: Bearer <token>``),
+    query-string fallback for WebSocket connections that can't
+    cleanly attach headers (browsers, especially)."""
+    auth_header = request.headers.get("authorization") or ""
+    if auth_header:
+        parts = auth_header.split(None, 1)
+        if len(parts) == 2 and parts[0].lower() == "bearer":
+            return parts[1].strip() or None
+    qs_token = request.query_params.get("token")
+    if qs_token:
+        return qs_token.strip() or None
+    return None
+
+
+class BearerAuthMiddleware(BaseHTTPMiddleware):
+    """Validate every non-public request against ``LUMIN_API_TOKEN``.
+
+    Returns 401 when the token is missing, 403 when it's present but
+    wrong. The split lets operators distinguish "did the client
+    forget the header?" from "did the rotated token get pushed?"."""
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[no-untyped-def]
+        expected = _expected_token()
+        if expected is None:
+            return await call_next(request)
+
+        path = request.url.path
+        if _is_public_path(path):
+            return await call_next(request)
+
+        provided = _extract_token(request)
+        if not provided:
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "error": "missing_authorization",
+                    "detail": (
+                        "LUMIN_API_TOKEN is set on this Lumin instance. "
+                        "Send Authorization: Bearer <token>."
+                    ),
+                },
+            )
+        if not hmac.compare_digest(provided.encode("utf-8"), expected.encode("utf-8")):
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "error": "invalid_token",
+                    "detail": "Bearer token did not match LUMIN_API_TOKEN.",
+                },
+            )
+        return await call_next(request)
+
+
+__all__ = ["BearerAuthMiddleware", "auth_enabled"]

--- a/packages/api/main.py
+++ b/packages/api/main.py
@@ -7,6 +7,7 @@ from typing import AsyncIterator
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 import policy_runtime
+from auth import BearerAuthMiddleware, auth_enabled
 from db import Database, get_db
 from routers import agents, evals, firewall, otlp, policy, proxy, sessions, spans, traces
 from ws import manager as ws_manager
@@ -278,6 +279,16 @@ app = FastAPI(
     version="0.5.0",
     lifespan=lifespan,
 )
+
+# Bearer-token middleware — default-off. When LUMIN_API_TOKEN is unset
+# this is a no-op; when set, every non-public path requires the
+# Authorization header. Added before router registration so the auth
+# check runs ahead of route matching.
+app.add_middleware(BearerAuthMiddleware)
+if auth_enabled():
+    logger.info("auth: bearer token required (LUMIN_API_TOKEN is set)")
+else:
+    logger.info("auth: open (LUMIN_API_TOKEN unset — set it for production)")
 
 app.include_router(spans.router)
 app.include_router(traces.router)

--- a/packages/api/tests/test_auth.py
+++ b/packages/api/tests/test_auth.py
@@ -1,0 +1,174 @@
+"""Tests for the bearer-token middleware (Slice 5B).
+
+Default-off behavior is the most important property — every existing
+test in this suite assumes no token. The middleware only kicks in
+when ``LUMIN_API_TOKEN`` is set in the environment, so tests that
+exercise auth must set it (and clear it afterwards) explicitly via
+monkeypatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from db import Database
+import main
+
+
+@pytest.fixture
+def client():
+    """Test client wired to an in-memory DB so we don't fight the
+    running API for the on-disk lock. The auth tests only care
+    about middleware behavior — the underlying handlers can return
+    whatever they like as long as it's not 401 / 403."""
+    db = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    main.app.dependency_overrides[main.get_db] = lambda: db
+    yield TestClient(main.app)
+    main.app.dependency_overrides.clear()
+    db.close()
+
+
+def _clear_token(monkeypatch) -> None:
+    monkeypatch.delenv("LUMIN_API_TOKEN", raising=False)
+
+
+def _set_token(monkeypatch, token: str) -> None:
+    monkeypatch.setenv("LUMIN_API_TOKEN", token)
+
+
+# ----- default-off behavior ------------------------------------------------
+
+
+def test_health_open_when_token_unset(client: TestClient, monkeypatch) -> None:
+    _clear_token(monkeypatch)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+def test_v1_open_when_token_unset(client: TestClient, monkeypatch) -> None:
+    """The whole API was reachable without auth before; nothing
+    changes when LUMIN_API_TOKEN is unset."""
+    _clear_token(monkeypatch)
+    resp = client.get("/v1/traces")
+    # 200 (or 5xx if the upstream is broken — but never 401/403)
+    assert resp.status_code != 401
+    assert resp.status_code != 403
+
+
+# ----- token enabled — public paths still open -----------------------------
+
+
+def test_health_open_with_token_set(client: TestClient, monkeypatch) -> None:
+    """The Docker healthcheck must keep working even when auth is on."""
+    _set_token(monkeypatch, "test-token-123")
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+def test_openapi_open_with_token_set(client: TestClient, monkeypatch) -> None:
+    _set_token(monkeypatch, "test-token-123")
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+
+
+def test_docs_open_with_token_set(client: TestClient, monkeypatch) -> None:
+    _set_token(monkeypatch, "test-token-123")
+    resp = client.get("/docs")
+    assert resp.status_code == 200
+
+
+# ----- token enabled — protected paths -------------------------------------
+
+
+def test_v1_returns_401_without_header(client: TestClient, monkeypatch) -> None:
+    _set_token(monkeypatch, "test-token-123")
+    resp = client.get("/v1/traces")
+    assert resp.status_code == 401
+    assert resp.json()["error"] == "missing_authorization"
+
+
+def test_v1_returns_403_with_wrong_token(client: TestClient, monkeypatch) -> None:
+    _set_token(monkeypatch, "right-token")
+    resp = client.get(
+        "/v1/traces",
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["error"] == "invalid_token"
+
+
+def test_v1_passes_with_correct_token(client: TestClient, monkeypatch) -> None:
+    _set_token(monkeypatch, "right-token")
+    resp = client.get(
+        "/v1/traces",
+        headers={"Authorization": "Bearer right-token"},
+    )
+    # 200 (or other non-auth code) — never 401/403
+    assert resp.status_code not in (401, 403)
+
+
+def test_v1_passes_with_query_string_token(client: TestClient, monkeypatch) -> None:
+    """WebSocket-friendly fallback — token can ride in the query
+    string for clients that can't cleanly attach headers."""
+    _set_token(monkeypatch, "right-token")
+    resp = client.get("/v1/traces?token=right-token")
+    assert resp.status_code not in (401, 403)
+
+
+def test_query_string_wrong_token_403(client: TestClient, monkeypatch) -> None:
+    _set_token(monkeypatch, "right-token")
+    resp = client.get("/v1/traces?token=wrong")
+    assert resp.status_code == 403
+
+
+def test_malformed_authorization_header(client: TestClient, monkeypatch) -> None:
+    """Header must be 'Bearer <token>'. Other shapes (Basic, JWT,
+    bare token) get treated as missing — 401, not 403, since the
+    operator most likely just sent the wrong scheme."""
+    _set_token(monkeypatch, "right-token")
+    resp = client.get(
+        "/v1/traces", headers={"Authorization": "Basic dXNlcjpwYXNz"},
+    )
+    assert resp.status_code == 401
+
+
+# ----- empty / whitespace tokens are treated as no-token -------------------
+
+
+def test_empty_string_token_is_off(client: TestClient, monkeypatch) -> None:
+    """LUMIN_API_TOKEN='' is treated identically to unset — operators
+    can't accidentally lock themselves out by typing the env var
+    without a value."""
+    monkeypatch.setenv("LUMIN_API_TOKEN", "")
+    resp = client.get("/v1/traces")
+    assert resp.status_code != 401
+
+
+def test_whitespace_only_token_is_off(client: TestClient, monkeypatch) -> None:
+    monkeypatch.setenv("LUMIN_API_TOKEN", "   ")
+    resp = client.get("/v1/traces")
+    assert resp.status_code != 401
+
+
+# ----- constant-time compare property --------------------------------------
+
+
+def test_constant_time_compare_used(client: TestClient, monkeypatch) -> None:
+    """We don't try to detect the timing characteristic in tests
+    (CI noise dominates), but we verify both same-length-different
+    and different-length tokens get the same 403 status — the only
+    portable proxy for 'we used hmac.compare_digest, not =='."""
+    _set_token(monkeypatch, "abcdef")
+    short = client.get(
+        "/v1/traces", headers={"Authorization": "Bearer x"},
+    )
+    same_len = client.get(
+        "/v1/traces", headers={"Authorization": "Bearer aaaaaa"},
+    )
+    longer = client.get(
+        "/v1/traces", headers={"Authorization": "Bearer abcdefgh"},
+    )
+    assert short.status_code == 403
+    assert same_len.status_code == 403
+    assert longer.status_code == 403

--- a/packages/dashboard/app/api/login/route.ts
+++ b/packages/dashboard/app/api/login/route.ts
@@ -1,0 +1,79 @@
+/**
+ * POST /api/login (Slice 5B).
+ *
+ * Constant-time-compared password against ``LUMIN_DASHBOARD_PASSWORD``;
+ * on match, mints an HMAC-signed session cookie via
+ * ``signSessionCookie`` and returns 200. On miss, 401. On unset env
+ * var (auth disabled), 400 — there's no point hitting login when
+ * auth is off.
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  COOKIE_NAME,
+  TWO_WEEKS_SECONDS,
+  signSessionCookie,
+} from '../../../middleware';
+
+export const runtime = 'edge';
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    // Still walk a constant pad to dampen length-based timing — but
+    // mismatched length is an instant fail.
+    let acc = 1;
+    const len = Math.max(a.length, b.length);
+    for (let i = 0; i < len; i++) {
+      acc |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+    }
+    void acc;
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+export async function POST(req: Request) {
+  const expected = process.env.LUMIN_DASHBOARD_PASSWORD?.trim();
+  if (!expected) {
+    return NextResponse.json(
+      {
+        error:
+          'auth disabled (LUMIN_DASHBOARD_PASSWORD is unset on this Lumin instance)',
+      },
+      { status: 400 },
+    );
+  }
+
+  let body: { password?: string } = {};
+  try {
+    body = (await req.json()) as { password?: string };
+  } catch {
+    return NextResponse.json({ error: 'bad request' }, { status: 400 });
+  }
+
+  const provided = (body.password ?? '').trim();
+  if (!provided) {
+    return NextResponse.json({ error: 'password required' }, { status: 400 });
+  }
+  if (!constantTimeEqual(provided, expected)) {
+    return NextResponse.json({ error: 'invalid password' }, { status: 401 });
+  }
+
+  const { value, expires } = await signSessionCookie(expected);
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set({
+    name: COOKIE_NAME,
+    value,
+    httpOnly: true,
+    secure: req.url.startsWith('https://'),
+    sameSite: 'lax',
+    path: '/',
+    maxAge: TWO_WEEKS_SECONDS,
+    expires,
+  });
+  return res;
+}

--- a/packages/dashboard/app/api/logout/route.ts
+++ b/packages/dashboard/app/api/logout/route.ts
@@ -1,0 +1,25 @@
+/**
+ * POST /api/logout (Slice 5B).
+ *
+ * Clears the session cookie and 200s. The dashboard's nav surface
+ * exposes a logout button when LUMIN_DASHBOARD_PASSWORD is set
+ * (detected via the x-lumin-auth header the middleware emits).
+ */
+
+import { NextResponse } from 'next/server';
+import { COOKIE_NAME } from '../../../middleware';
+
+export const runtime = 'edge';
+
+export async function POST() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set({
+    name: COOKIE_NAME,
+    value: '',
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+  return res;
+}

--- a/packages/dashboard/app/login/page.tsx
+++ b/packages/dashboard/app/login/page.tsx
@@ -1,0 +1,111 @@
+/**
+ * Login page (Slice 5B).
+ *
+ * Rendered when ``LUMIN_DASHBOARD_PASSWORD`` is set on the server
+ * and the user lacks a valid session cookie. Single password field
+ * — Lumin doesn't have user accounts in this slice. Successful
+ * POST to /api/login lands a 14-day signed session cookie and
+ * redirects to ?next= or "/" if absent.
+ *
+ * Intentionally minimal: no "remember me" checkbox (we always
+ * remember 14 days), no password reset flow (this is a single
+ * shared secret rotated via env), no SSO. All of those are
+ * deliberate pin-points for the next slice.
+ */
+
+'use client';
+
+import { Suspense, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+function LoginForm() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const next = params.get('next') ?? '/';
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const resp = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      });
+      if (resp.status === 200) {
+        // Hard navigation — needs to round-trip middleware so the
+        // new cookie is honored.
+        window.location.href = next.startsWith('/') ? next : '/';
+        return;
+      }
+      const body = (await resp.json().catch(() => ({}))) as { error?: string };
+      setError(body.error ?? 'Login failed.');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Network error.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center p-6 bg-[var(--background)]">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm space-y-4 card p-6 border border-[var(--border)]"
+      >
+        <div className="text-center mb-2">
+          <div className="font-semibold text-lg">Lumin</div>
+          <div className="text-xs text-[var(--muted)] mt-1">
+            Local-first AI agent observability
+          </div>
+        </div>
+        <label className="block text-sm">
+          <span className="text-[var(--muted)] uppercase tracking-wider text-[10px] block mb-1">
+            Password
+          </span>
+          <input
+            autoFocus
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full bg-[var(--background-raised)] border border-[var(--border)] rounded px-3 py-2 text-sm focus:outline-none focus:border-[var(--accent)]"
+            disabled={submitting}
+          />
+        </label>
+        {error ? (
+          <div className="text-rose-300 text-xs border border-rose-500/30 bg-rose-500/[0.05] rounded px-2 py-1.5">
+            {error}
+          </div>
+        ) : null}
+        <button
+          type="submit"
+          disabled={submitting || !password}
+          className="w-full pill bg-[var(--accent)] text-[var(--accent-foreground)] disabled:opacity-50"
+        >
+          {submitting ? 'Signing in…' : 'Sign in'}
+        </button>
+        <div className="text-[10px] text-[var(--muted)] text-center">
+          Set via <code className="font-mono">LUMIN_DASHBOARD_PASSWORD</code>
+        </div>
+      </form>
+    </main>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="min-h-screen flex items-center justify-center text-[var(--muted)]">
+          Loading…
+        </main>
+      }
+    >
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/packages/dashboard/middleware.ts
+++ b/packages/dashboard/middleware.ts
@@ -1,0 +1,150 @@
+/**
+ * Dashboard auth middleware (Slice 5B).
+ *
+ * Default-off. When ``LUMIN_DASHBOARD_PASSWORD`` is unset, this is a
+ * no-op — the dashboard behaves exactly like it did before, no
+ * login wall, no cookie. Existing localhost-dev workflows are
+ * unchanged.
+ *
+ * When set, every page request needs a valid ``lumin_session``
+ * cookie. Missing or invalid → redirect to /login with ?next=
+ * carrying the original URL so the user lands back where they
+ * tried to go.
+ *
+ * The session cookie is HMAC-signed with a secret derived from the
+ * password itself (``hmac(password, "lumin-dashboard-session-v1")``).
+ * Same password across restarts → same secret → cookies survive
+ * restarts, which is the operator's expectation. Rotating the
+ * password invalidates every active cookie automatically — also
+ * the operator's expectation.
+ *
+ * The API layer's bearer token (LUMIN_API_TOKEN) is independent.
+ * Operators commonly set both — the dashboard's /api/* rewrite
+ * proxy injects the API token server-side so the browser never
+ * sees it.
+ */
+
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const COOKIE_NAME = 'lumin_session';
+const SESSION_VERSION = 'v1';
+const TWO_WEEKS_SECONDS = 60 * 60 * 24 * 14;
+
+// Paths that bypass the auth check entirely. ``/login`` so the
+// login flow itself can render; ``/_next`` for static assets that
+// the login page depends on; ``/api/login`` so the password POST
+// reaches the handler; ``/health`` (Next.js doesn't usually serve
+// this but if anything else mounts it we keep it open).
+const PUBLIC_PREFIXES = ['/login', '/_next', '/api/login', '/api/logout', '/health', '/icon.svg', '/favicon.ico'];
+
+function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PREFIXES.some((p) => pathname === p || pathname.startsWith(p + '/') || pathname.startsWith(p));
+}
+
+export async function middleware(req: NextRequest) {
+  const password = process.env.LUMIN_DASHBOARD_PASSWORD?.trim();
+  if (!password) {
+    // Auth disabled — pass through unchanged. The header below lets
+    // the dashboard render an "auth: off" badge without a separate
+    // /api/auth-status round trip.
+    const res = NextResponse.next();
+    res.headers.set('x-lumin-auth', 'off');
+    return res;
+  }
+
+  const { pathname, search } = req.nextUrl;
+  if (isPublicPath(pathname)) {
+    return NextResponse.next();
+  }
+
+  const cookie = req.cookies.get(COOKIE_NAME)?.value;
+  if (cookie && (await verifySessionCookie(cookie, password))) {
+    const res = NextResponse.next();
+    res.headers.set('x-lumin-auth', 'on');
+    return res;
+  }
+
+  // Redirect to /login, carrying the original URL so we can land
+  // the user back on the page they tried to reach.
+  const loginUrl = req.nextUrl.clone();
+  loginUrl.pathname = '/login';
+  loginUrl.search = `?next=${encodeURIComponent(pathname + search)}`;
+  return NextResponse.redirect(loginUrl);
+}
+
+
+// ---- session cookie HMAC -------------------------------------------------
+//
+// Edge-runtime-friendly: uses the global Web Crypto API (no node:crypto
+// or string-comparison shortcuts). The cookie value is
+// ``v1.<expires_at_unix_seconds>.<hex_hmac>``.
+
+const enc = new TextEncoder();
+
+async function deriveKey(password: string): Promise<CryptoKey> {
+  const material = enc.encode(`lumin-dashboard-session-${SESSION_VERSION}::${password}`);
+  return crypto.subtle.importKey(
+    'raw', material, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify'],
+  );
+}
+
+async function signSessionCookie(password: string): Promise<{ value: string; expires: Date }> {
+  const expiresAt = Math.floor(Date.now() / 1000) + TWO_WEEKS_SECONDS;
+  const payload = `${SESSION_VERSION}.${expiresAt}`;
+  const key = await deriveKey(password);
+  const sigBuf = await crypto.subtle.sign('HMAC', key, enc.encode(payload));
+  const sigHex = Array.from(new Uint8Array(sigBuf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return {
+    value: `${payload}.${sigHex}`,
+    expires: new Date(expiresAt * 1000),
+  };
+}
+
+async function verifySessionCookie(cookie: string, password: string): Promise<boolean> {
+  const parts = cookie.split('.');
+  if (parts.length !== 3) return false;
+  const [version, expiresStr, sigHex] = parts;
+  if (version !== SESSION_VERSION) return false;
+  const expires = parseInt(expiresStr, 10);
+  if (!Number.isFinite(expires) || expires < Math.floor(Date.now() / 1000)) {
+    return false;
+  }
+  try {
+    const key = await deriveKey(password);
+    const sig = hexToBytes(sigHex);
+    if (!sig) return false;
+    return await crypto.subtle.verify(
+      'HMAC', key, sig, enc.encode(`${version}.${expiresStr}`),
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hexToBytes(hex: string): Uint8Array | null {
+  if (!/^[0-9a-f]+$/i.test(hex) || hex.length % 2 !== 0) return null;
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+
+// ---- exports for the API routes to share -------------------------------
+// Importing from a middleware file works because Next.js bundles the
+// middleware separately from app routes — the API route can import
+// signSessionCookie via a relative path, both ending up in the
+// edge runtime that supports Web Crypto.
+export { signSessionCookie, COOKIE_NAME, TWO_WEEKS_SECONDS };
+
+
+// Match every path except Next's internal ones. The middleware
+// itself early-returns on /login etc., but the matcher still has to
+// invoke it so the function gets the chance to redirect.
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};


### PR DESCRIPTION
## Summary

Default-off auth on both the API and the dashboard. When the env vars are unset, nothing changes — localhost dev is the same. When set, every non-public surface requires credentials.

## API: `LUMIN_API_TOKEN`

```
Authorization: Bearer <token>            # preferred
?token=<token>                           # WebSocket-friendly fallback
```

- **New `packages/api/auth.py`** — `BearerAuthMiddleware`
- **Constant-time compare** via `hmac.compare_digest`
- **401** on missing header, **403** on wrong token (so operators can distinguish "client forgot to send" from "rotated token didn't deploy")
- **Public paths always reachable**: `/health`, `/openapi.json`, `/docs`, `/redoc`, `/`
- **Empty / whitespace token treated as unset** — operators can't accidentally lock themselves out
- **14 new tests** covering on/off mode, public-path bypass, query-string fallback, malformed headers
- **API suite: 591 passed** (was 577)

## Dashboard: `LUMIN_DASHBOARD_PASSWORD`

- **`packages/dashboard/middleware.ts`** at package root — Next.js middleware
- **HMAC-SHA-256 session cookie** via Web Crypto (edge-runtime safe)
- Cookie value shape: `v1.<expires_unix>.<sig_hex>`
- **Secret derived from password itself** → rotating the env var instantly invalidates every active session
- **14-day expiry**, `httpOnly`, `sameSite=lax`, `secure` over https
- **`/login`** page (single password field), `/api/login`, `/api/logout`
- **`x-lumin-auth: on|off`** response header so future UI surfaces can render a "Sign out" button without an extra round trip
- `tsc --noEmit` clean

## Threat model

| Attack | Mitigation |
|---|---|
| Brute force at the dashboard | `LUMIN_DASHBOARD_PASSWORD` is operator-set — recommend ≥20 chars; no rate limiting yet (next slice) |
| Token in URL leaking via referrer / proxy logs | Header preferred. Query-string only for WebSocket where headers are awkward; documented as such. |
| Timing attack on token compare | `hmac.compare_digest` (server) + constant-time JS compare (client) |
| Cookie theft → impersonation | `httpOnly` blocks JS access; `secure` over https blocks cleartext sniffing; secret rotation invalidates all sessions |
| Session fixation | Cookie minted server-side after password verify, never accepted from client input |

## What this does NOT add

- User accounts (single shared password)
- Password reset flow (rotate via env)
- SSO / OAuth (Phase 2 cloud)
- Per-user RBAC
- Rate limiting on `/api/login`

Each is intentional scope for a later slice.

## Test plan

- [x] All 14 auth unit tests pass
- [x] Full API suite: 591 passed, 0 regressions
- [x] Dashboard typecheck: clean
- [ ] Manual: set `LUMIN_DASHBOARD_PASSWORD=hunter2`, refresh dashboard, see `/login`
- [ ] Manual: bad password → 401, right password → cookie + redirect to `?next=`
- [ ] Manual: rotate password → existing cookies invalidated on next request
- [ ] Manual: set `LUMIN_API_TOKEN=abc`, hit `/v1/traces` without header → 401, with right header → 200