### PR TITLE
feat(api): multi-tenant project filter on read endpoints (Slice 6B)

### DIFF
--- a/packages/api/routers/policy.py
+++ b/packages/api/routers/policy.py
@@ -122,6 +122,10 @@ def list_violations(
     trace_id: Optional[str] = Query(None),
     severity: Optional[str] = Query(None),
     policy_name: Optional[str] = Query(None),
+    project: Optional[str] = Query(
+        None,
+        description="Multi-tenant scope — JOINs through traces.project.",
+    ),
     limit: int = Query(100, ge=1, le=1000),
     offset: int = Query(0, ge=0),
     db: Database = Depends(get_db),
@@ -130,27 +134,42 @@ def list_violations(
     where: list[str] = []
     params: list = []
     if trace_id:
-        where.append("trace_id = ?")
+        where.append("v.trace_id = ?")
         params.append(trace_id)
     if severity:
-        where.append("severity = ?")
+        where.append("v.severity = ?")
         params.append(severity)
     if policy_name:
-        where.append("policy_name = ?")
+        where.append("v.policy_name = ?")
         params.append(policy_name)
+    if project:
+        # policy_violations doesn't carry project directly. JOIN
+        # through traces so the dashboard's project filter still
+        # scopes the violations view correctly.
+        if project == "default":
+            where.append(
+                "COALESCE("
+                "(SELECT project FROM traces t WHERE t.id = v.trace_id), '')"
+                " IN ('', 'default')"
+            )
+        else:
+            where.append(
+                "(SELECT project FROM traces t WHERE t.id = v.trace_id) = ?"
+            )
+            params.append(project)
     where_clause = ("WHERE " + " AND ".join(where)) if where else ""
 
     rows = db.fetchall_dict(
         f"""
-        SELECT * FROM policy_violations
+        SELECT v.* FROM policy_violations v
         {where_clause}
-        ORDER BY created_at DESC
+        ORDER BY v.created_at DESC
         LIMIT ? OFFSET ?
         """,
         [*params, limit, offset],
     )
     total_row = db.fetchone(
-        f"SELECT COUNT(*) FROM policy_violations {where_clause}", params
+        f"SELECT COUNT(*) FROM policy_violations v {where_clause}", params
     )
     total = int(total_row[0]) if total_row else 0
 

--- a/packages/api/routers/sessions.py
+++ b/packages/api/routers/sessions.py
@@ -76,18 +76,31 @@ _BASE_AGG = """
 def list_sessions(
     limit: int = Query(100, ge=1, le=1000),
     offset: int = Query(0, ge=0),
+    project: Optional[str] = Query(
+        None,
+        description="Multi-tenant scope. Same semantics as /v1/traces.",
+    ),
     db: Database = Depends(get_db),
 ) -> List[Session]:
+    extra: list = ["session_id IS NOT NULL", "session_id != ''"]
+    params: list = []
+    if project:
+        if project == "default":
+            extra.append("COALESCE(project, '') IN ('', 'default')")
+        else:
+            extra.append("project = ?")
+            params.append(project)
+    where_clause = "WHERE " + " AND ".join(extra)
     rows = db.fetchall_dict(
         f"""
         SELECT {_BASE_AGG}
         FROM traces
-        WHERE session_id IS NOT NULL AND session_id != ''
+        {where_clause}
         GROUP BY session_id
         ORDER BY last_seen DESC NULLS LAST
         LIMIT ? OFFSET ?
         """,
-        [limit, offset],
+        [*params, limit, offset],
     )
     return [_row_to_session(r) for r in rows]
 

--- a/packages/api/routers/traces.py
+++ b/packages/api/routers/traces.py
@@ -187,13 +187,39 @@ def upsert_trace(payload: TraceCreate, db: Database = Depends(get_db)) -> Trace:
 def list_traces(
     limit: int = Query(100, ge=1, le=1000),
     offset: int = Query(0, ge=0),
+    project: Optional[str] = Query(
+        None,
+        description=(
+            "Multi-tenant scope. When set, returns only traces tagged "
+            "with this project. Use 'default' for the un-tagged bucket. "
+            "Omit to see all projects (operator view)."
+        ),
+    ),
     db: Database = Depends(get_db),
 ) -> List[Trace]:
+    where, params = _project_filter(project, table_alias="t")
     rows = db.fetchall_dict(
-        _TRACE_WITH_AGGREGATES + " ORDER BY t.started_at DESC LIMIT ? OFFSET ?",
-        [limit, offset],
+        _TRACE_WITH_AGGREGATES + where + " ORDER BY t.started_at DESC LIMIT ? OFFSET ?",
+        [*params, limit, offset],
     )
     return [_row_to_trace(r) for r in rows]
+
+
+def _project_filter(
+    project: Optional[str], *, table_alias: str = "t",
+) -> tuple[str, list]:
+    """Multi-tenant scope helper. Returns ('', []) when no project
+    filter requested; otherwise (' WHERE project = ?', [project])
+    with one twist: 'default' also matches NULL / empty so traces
+    that landed without an X-Lumin-Project header still surface in
+    the default bucket.
+    """
+    if not project:
+        return "", []
+    col = f"{table_alias}.project" if table_alias else "project"
+    if project == "default":
+        return f" WHERE COALESCE({col}, '') IN ('', 'default')", []
+    return f" WHERE {col} = ?", [project]
 
 
 @router.get("/v1/traces/{trace_id}", response_model=TraceDetail)

--- a/packages/api/tests/test_project_scope.py
+++ b/packages/api/tests/test_project_scope.py
@@ -1,0 +1,163 @@
+"""Tests for multi-tenant project filtering on read endpoints
+(Slice 6B)."""
+
+from __future__ import annotations
+
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from db import Database
+import main
+
+
+@pytest.fixture
+def db() -> Generator[Database, None, None]:
+    d = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    yield d
+    d.close()
+
+
+@pytest.fixture
+def client(db: Database):
+    main.app.dependency_overrides[main.get_db] = lambda: db
+    yield TestClient(main.app)
+    main.app.dependency_overrides.clear()
+
+
+def _seed_traces(db: Database) -> None:
+    """Seed traces across three projects."""
+    db.execute(
+        "INSERT INTO traces (id, name, started_at, project, session_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ["t-prod-1", "agent_a", "2026-05-01 00:00:00", "prod", "s-prod-1"],
+    )
+    db.execute(
+        "INSERT INTO traces (id, name, started_at, project, session_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ["t-prod-2", "agent_a", "2026-05-02 00:00:00", "prod", "s-prod-1"],
+    )
+    db.execute(
+        "INSERT INTO traces (id, name, started_at, project, session_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ["t-staging-1", "agent_b", "2026-05-03 00:00:00", "staging", "s-staging-1"],
+    )
+    db.execute(
+        "INSERT INTO traces (id, name, started_at, project, session_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ["t-untagged", "agent_c", "2026-05-04 00:00:00", None, "s-untagged"],
+    )
+
+
+# ----- /v1/traces ---------------------------------------------------------
+
+
+def test_traces_no_filter_returns_all(client: TestClient, db: Database) -> None:
+    _seed_traces(db)
+    resp = client.get("/v1/traces")
+    body = resp.json()
+    assert {t["id"] for t in body} == {
+        "t-prod-1", "t-prod-2", "t-staging-1", "t-untagged",
+    }
+
+
+def test_traces_filter_by_project(client: TestClient, db: Database) -> None:
+    _seed_traces(db)
+    resp = client.get("/v1/traces?project=prod")
+    ids = {t["id"] for t in resp.json()}
+    assert ids == {"t-prod-1", "t-prod-2"}
+
+
+def test_traces_filter_default_includes_untagged(
+    client: TestClient, db: Database,
+) -> None:
+    """project=default should match both NULL and the literal 'default'
+    so traces ingested without an X-Lumin-Project header still
+    surface in the operator's default bucket."""
+    _seed_traces(db)
+    db.execute(
+        "INSERT INTO traces (id, name, started_at, project) "
+        "VALUES ('t-default', 'agent_d', '2026-05-05 00:00:00', 'default')",
+    )
+    resp = client.get("/v1/traces?project=default")
+    ids = {t["id"] for t in resp.json()}
+    assert ids == {"t-untagged", "t-default"}
+
+
+def test_traces_unknown_project_returns_empty(
+    client: TestClient, db: Database,
+) -> None:
+    _seed_traces(db)
+    resp = client.get("/v1/traces?project=does-not-exist")
+    assert resp.json() == []
+
+
+# ----- /v1/sessions -------------------------------------------------------
+
+
+def test_sessions_filter_by_project(client: TestClient, db: Database) -> None:
+    _seed_traces(db)
+    resp = client.get("/v1/sessions?project=prod")
+    ids = {s["session_id"] for s in resp.json()}
+    assert ids == {"s-prod-1"}
+
+
+def test_sessions_no_filter_returns_all(client: TestClient, db: Database) -> None:
+    _seed_traces(db)
+    resp = client.get("/v1/sessions")
+    ids = {s["session_id"] for s in resp.json()}
+    assert ids == {"s-prod-1", "s-staging-1", "s-untagged"}
+
+
+# ----- /v1/violations -----------------------------------------------------
+
+
+def _seed_violations(db: Database) -> None:
+    """Seed violations linked to the seeded traces."""
+    _seed_traces(db)
+    for vid, tid in (
+        ("v-prod-1", "t-prod-1"),
+        ("v-prod-2", "t-prod-2"),
+        ("v-staging-1", "t-staging-1"),
+    ):
+        db.execute(
+            """
+            INSERT INTO policy_violations (
+                id, policy_name, trace_id, condition_text, action_taken,
+                severity
+            ) VALUES (?, 'p', ?, 'c', 'block', 'high')
+            """,
+            [vid, tid],
+        )
+
+
+def test_violations_filter_by_project(client: TestClient, db: Database) -> None:
+    _seed_violations(db)
+    resp = client.get("/v1/violations?project=prod")
+    ids = {v["id"] for v in resp.json()["violations"]}
+    assert ids == {"v-prod-1", "v-prod-2"}
+
+
+def test_violations_no_filter_returns_all(client: TestClient, db: Database) -> None:
+    _seed_violations(db)
+    resp = client.get("/v1/violations")
+    ids = {v["id"] for v in resp.json()["violations"]}
+    assert ids == {"v-prod-1", "v-prod-2", "v-staging-1"}
+
+
+def test_violations_filter_combines_with_severity(
+    client: TestClient, db: Database,
+) -> None:
+    _seed_violations(db)
+    db.execute(
+        """
+        INSERT INTO policy_violations (
+            id, policy_name, trace_id, condition_text, action_taken,
+            severity
+        ) VALUES ('v-prod-low', 'p', 't-prod-1', 'c', 'flag', 'low')
+        """,
+    )
+    resp = client.get("/v1/violations?project=prod&severity=high")
+    ids = {v["id"] for v in resp.json()["violations"]}
+    assert ids == {"v-prod-1", "v-prod-2"}


### PR DESCRIPTION
## Summary

Adds an optional `?project=` query param to `/v1/traces`, `/v1/sessions`, `/v1/violations` so a single Lumin instance can serve multiple projects with isolated views. `/v1/decisions` and `/v1/agents` already supported this; this completes the read surface.

## Semantics

| Query | Returns |
|---|---|
| `(omitted)` | All projects (operator god view) |
| `?project=prod` | Exact match `traces.project = 'prod'` |
| `?project=default` | Both `'default'` AND `NULL`/empty — traces ingested without `X-Lumin-Project` header surface in the default bucket |

## Implementation

| Endpoint | How |
|---|---|
| `/v1/traces` | New `_project_filter()` helper applies `WHERE traces.project = ?` |
| `/v1/sessions` | Extended the existing aggregate query's `WHERE` |
| `/v1/violations` | JOINs through traces — `policy_violations` doesn't carry project directly, so we resolve via `trace_id` |

## What this is NOT

- **Not RBAC.** A caller who omits the filter still sees everything. Per-user scopes wait for the auth-with-roles slice.
- **Not row-level security.** No DuckDB-level enforcement; the filter is application-side.
- **Not data isolation.** All projects share one DuckDB. Truly isolated tenants need separate Lumin instances (one per VPC). On the roadmap.

This is enough for the dashboard's project switcher to scope what's shown. Combined with the per-policy `scope_agents` and per-webhook `project_filter` already in place, it gets you reasonable separation between two teams sharing one Lumin box.

## Tests

9 new tests in `tests/test_project_scope.py`:

- `?project=prod` → only prod traces / sessions / violations
- `?project=default` → matches NULL + 'default' literal
- No filter → returns everything across projects
- `?project=does-not-exist` → empty
- Combined `?project=prod&severity=high` → both filters apply

**Full API suite: 586 passed** (was 577 — +9 new, no regressions).