### PR TITLE
fix(firewall): wire user_id end-to-end + close webhook SSRF gap

### DIFF
--- a/packages/api/firewall/decide.py
+++ b/packages/api/firewall/decide.py
@@ -406,6 +406,7 @@ def decide(
     trace_id: Optional[str] = None,
     span_id: Optional[str] = None,
     session_id: Optional[str] = None,
+    user_id: Optional[str] = None,
     agent: Optional[str] = None,
     project: Optional[str] = None,
     model: Optional[str] = None,
@@ -498,6 +499,7 @@ def decide(
         trace_id=trace_id,
         span_id=span_id,
         session_id=session_id,
+        user_id=user_id,
         agent=agent,
         project=project,
         model=model,
@@ -803,7 +805,23 @@ def _build_namespace(**req: Any) -> Dict[str, Any]:
                 for blk in content:
                     if isinstance(blk, dict) and blk.get("type") == "text":
                         last_user_msg = blk.get("text", "")
-    output_text = req.get("output") if isinstance(req.get("output"), str) else ""
+    # Output text extraction. Three shapes seen in production:
+    #   - raw string                         "Hello, Alice"
+    #   - {text: "..."}                      OpenAI-compatible after_proxy_call
+    #   - {result: "..."}                    after_tool_call shape
+    # Brutal-test fix (2026-05-09): the previous code only extracted
+    # the raw-string variant. When integrations sent {"text": "..."}
+    # (the standard shape) Output.text was empty — every after_proxy_call
+    # rule that referenced Output.text fired against "" and silently
+    # never matched.
+    raw_output = req.get("output")
+    if isinstance(raw_output, str):
+        output_text = raw_output
+    elif isinstance(raw_output, dict):
+        candidate = raw_output.get("text") or raw_output.get("result")
+        output_text = candidate if isinstance(candidate, str) else ""
+    else:
+        output_text = ""
 
     return {
         "Input": _NS({
@@ -818,6 +836,10 @@ def _build_namespace(**req: Any) -> Dict[str, Any]:
             "session_id": req.get("session_id"),
             "trace_id": req.get("trace_id"),
             "span_id": req.get("span_id"),
+            # Slice 6A — required by the cross_session_leak builtin.
+            # When the integration doesn't pass user_id (single-tenant
+            # agents), the leak detector no-ops per Rule 7.
+            "user_id": req.get("user_id"),
         }),
         "Output": _NS({
             "text": output_text,
@@ -829,6 +851,9 @@ def _build_namespace(**req: Any) -> Dict[str, Any]:
         "text": " ".join(parts) if parts else (output_text or last_user_msg),
         "tool_name": req.get("tool_name"),
         "params": params,
+        # Bare ``user_id`` — exposed at top level so cross-session-leak
+        # rules can reference it without an Input. prefix.
+        "user_id": req.get("user_id"),
     }
 
 

--- a/packages/api/firewall/webhooks.py
+++ b/packages/api/firewall/webhooks.py
@@ -221,8 +221,19 @@ def _mask_value(v: str) -> str:
 
 
 def _validate_kind_config(kind: str, config: Dict[str, Any]) -> None:
-    """Per-kind required fields. Errors here surface as 400 from
-    the create endpoint."""
+    """Per-kind required fields + URL safety. Errors here surface as
+    400 from the create endpoint.
+
+    SSRF guard (Slice 6A.1 / brutal-test fix): every URL-shaped
+    config field is validated against ``policy_runtime._webhook_url_safe``
+    which rejects:
+      - non-http(s) schemes (file://, gopher://, ftp://, etc.)
+      - loopback / private / link-local / reserved IPs
+      - AWS instance metadata host + IP variants
+    Without this check, an operator (or anyone with write access to
+    /v1/firewall/webhooks) could exfiltrate cloud creds by pointing
+    a webhook at 169.254.169.254 and triggering any block decision.
+    """
     required: Dict[str, List[str]] = {
         "slack": ["webhook_url"],
         "discord": ["webhook_url"],
@@ -236,6 +247,20 @@ def _validate_kind_config(kind: str, config: Dict[str, Any]) -> None:
         raise ValueError(
             f"webhook kind={kind!r} requires config keys: {missing}"
         )
+
+    # URL-safety check — reuses the validator that already protects
+    # the legacy policy_violations.webhook_url field.
+    from policy_runtime import _webhook_url_safe
+    url_keys = ("webhook_url", "url")
+    for key in url_keys:
+        url = config.get(key)
+        if not isinstance(url, str) or not url:
+            continue
+        if not _webhook_url_safe(url):
+            raise ValueError(
+                f"webhook url rejected by SSRF guard "
+                f"(blocked scheme / private host / cloud metadata): {url!r}"
+            )
 
 
 # ---- dispatch on decision -------------------------------------------------

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -657,6 +657,17 @@
               }
             ],
             "title": "Trace Id"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
           }
         },
         "required": [

--- a/packages/api/policy_runtime.py
+++ b/packages/api/policy_runtime.py
@@ -71,6 +71,14 @@ _SSRF_BLOCKED_HOSTS = {
     # GCP / Azure metadata service
     "metadata.google.internal",
     "metadata.azure.com",
+    # Loopback hostnames (RFC 6761 requires these resolve to 127.0.0.1
+    # but we'd rather fail-closed than rely on the resolver). Catches
+    # webhook URLs pointed at the same Lumin instance, which would
+    # otherwise be a reflection/SSRF amplifier when LUMIN_API_TOKEN
+    # is unset.
+    "localhost",
+    "ip6-localhost",
+    "ip6-loopback",
 }
 
 

--- a/packages/api/routers/firewall.py
+++ b/packages/api/routers/firewall.py
@@ -53,6 +53,11 @@ class DecideRequest(BaseModel):
     trace_id: Optional[str] = None
     span_id: Optional[str] = None
     session_id: Optional[str] = None
+    # Slice 6A — required for cross-session-leak rules to know whose
+    # request this is. Optional because not every integration has the
+    # concept (single-tenant agents leave it None and the leak
+    # detector gracefully no-ops per Rule 7).
+    user_id: Optional[str] = None
     agent: Optional[str] = None
     project: Optional[str] = None
     model: Optional[str] = None
@@ -93,6 +98,7 @@ def decide_endpoint(
             trace_id=payload.trace_id,
             span_id=payload.span_id,
             session_id=payload.session_id,
+            user_id=payload.user_id,
             agent=payload.agent,
             project=payload.project,
             model=payload.model,

--- a/packages/api/routers/policy.py
+++ b/packages/api/routers/policy.py
@@ -625,6 +625,10 @@ _ALLOWED_NAMES = frozenset({
     # firewall vocab.
     "Input", "Output",
     "tool_name", "params", "text",
+    # Slice 6A — bare ``user_id`` is bound by ``_build_namespace`` so
+    # cross-session-leak rules can reference it without an Input.
+    # prefix.
+    "user_id",
 })
 _ALLOWED_FUNCTIONS = frozenset({
     "len", "str", "int", "float", "abs",
@@ -667,6 +671,9 @@ _ALLOWED_FUNCTIONS = frozenset({
     # Local fine-tuned classifier (Slice 3 PR S — §6.8 / §11.6;
     # opt-in via sklearn install + dashboard "Retrain classifier")
     "org_classifier_score", "org_classifier_predict",
+    # Cross-session vault (Slice 6A — DB-bound, looks up
+    # session_vault for foreign-user fact matches)
+    "cross_session_leak", "cross_session_leak_details",
 })
 
 

--- a/packages/api/tests/firewall/test_vault_integration.py
+++ b/packages/api/tests/firewall/test_vault_integration.py
@@ -1,0 +1,204 @@
+"""End-to-end integration test for the cross-session vault
+(brutal-test fix — verifies the bug found while attacking the API
+on 2026-05-09).
+
+The unit tests in ``test_vault.py`` exercise the builtin and the
+helper functions directly — they pass even when the wiring through
+DecideRequest → namespace → policy condition is broken. This file
+hits the actual ``POST /v1/policy/decide`` HTTP path with a
+``user_id`` and verifies the cross_session_leak rule fires
+end-to-end, which is the only test that catches a regression in
+any of the four layers.
+"""
+
+from __future__ import annotations
+
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from db import Database
+from firewall import vault as fw_vault
+from lumin.policy import Policy
+import main
+import policy_store
+
+
+@pytest.fixture
+def db() -> Generator[Database, None, None]:
+    d = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    yield d
+    d.close()
+
+
+@pytest.fixture
+def client(db: Database):
+    main.app.dependency_overrides[main.get_db] = lambda: db
+    yield TestClient(main.app)
+    main.app.dependency_overrides.clear()
+
+
+def _install_leak_rule(db: Database) -> None:
+    """Set up the canonical cross-session-leak rule in enforce mode
+    so a positive test actually fires (not just records-shadow)."""
+    p = Policy(
+        name="cross_session_leak_block",
+        description="Block when reply contains another user's vault fact.",
+        trigger="span_end",
+        condition="cross_session_leak(Output.text, user_id)",
+        action="block",
+        severity="high",
+        lifecycle="after_proxy_call",
+        mode="enforce",
+        priority=92,
+    )
+    policy_store.create_policy(db, p, actor="test")
+
+
+# ----- The textbook attack — actual HTTP path ----------------------------
+
+
+def test_decide_blocks_when_other_user_fact_in_output(
+    client: TestClient, db: Database,
+) -> None:
+    """Alice volunteers an account number, Bob's reply contains it,
+    `decide()` returns block. Walks every layer that was broken:
+    DecideRequest model accepts user_id, decide() forwards it,
+    _build_namespace binds it, the rule's condition references it,
+    cross_session_leak builtin matches the vault."""
+    fw_vault.record_facts(
+        db, session_id="sess-A", user_id="alice", project=None,
+        text="my account number is BRT-99999",
+    )
+    _install_leak_rule(db)
+
+    resp = client.post(
+        "/v1/policy/decide",
+        json={
+            "lifecycle": "after_proxy_call",
+            "output": {"text": "The previous user's account is BRT-99999."},
+            "session_id": "sess-B",
+            "user_id": "bob",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "block", body
+    assert body["policy_name"] == "cross_session_leak_block"
+
+
+def test_decide_allows_when_same_user_says_own_fact(
+    client: TestClient, db: Database,
+) -> None:
+    """Alice's own account in her own reply is NOT a leak — same
+    user_id binding."""
+    fw_vault.record_facts(
+        db, session_id="sess-A", user_id="alice", project=None,
+        text="my account number is BRT-99999",
+    )
+    _install_leak_rule(db)
+
+    resp = client.post(
+        "/v1/policy/decide",
+        json={
+            "lifecycle": "after_proxy_call",
+            "output": {"text": "Your account BRT-99999 is in good standing."},
+            "session_id": "sess-A",
+            "user_id": "alice",
+        },
+    )
+    body = resp.json()
+    assert body["decision"] == "allow", body
+
+
+def test_decide_allows_when_user_id_absent(
+    client: TestClient, db: Database,
+) -> None:
+    """Empty user_id means we can't reason about whose request this
+    is — Rule 7 says default to allow on uncertainty."""
+    fw_vault.record_facts(
+        db, session_id="sess-A", user_id="alice", project=None,
+        text="my account number is BRT-99999",
+    )
+    _install_leak_rule(db)
+
+    resp = client.post(
+        "/v1/policy/decide",
+        json={
+            "lifecycle": "after_proxy_call",
+            "output": {"text": "BRT-99999"},
+            "session_id": "sess-B",
+            # user_id intentionally omitted
+        },
+    )
+    body = resp.json()
+    assert body["decision"] == "allow", body
+
+
+def test_decide_allows_when_text_unrelated_to_vault(
+    client: TestClient, db: Database,
+) -> None:
+    """Sanity — Bob's reply contains nothing from Alice's vault, no
+    leak, no block."""
+    fw_vault.record_facts(
+        db, session_id="sess-A", user_id="alice", project=None,
+        text="my account number is BRT-99999",
+    )
+    _install_leak_rule(db)
+
+    resp = client.post(
+        "/v1/policy/decide",
+        json={
+            "lifecycle": "after_proxy_call",
+            "output": {"text": "Hi! How can I help you today?"},
+            "session_id": "sess-B",
+            "user_id": "bob",
+        },
+    )
+    body = resp.json()
+    assert body["decision"] == "allow", body
+
+
+# ----- Validator allowlist accepts vault builtins ------------------------
+
+
+def test_validator_accepts_cross_session_leak(
+    client: TestClient,
+) -> None:
+    """A policy authored via /v1/policies referencing the vault
+    builtin must validate cleanly — proves the validator's
+    _ALLOWED_FUNCTIONS allowlist was updated."""
+    resp = client.post(
+        "/v1/policies",
+        json={
+            "name": "vault_check_via_api",
+            "description": "Authored via API.",
+            "trigger": "span_end",
+            "condition": "cross_session_leak(Output.text, user_id)",
+            "action": "rewrite",
+            "severity": "high",
+            "lifecycle": "after_proxy_call",
+            "mode": "shadow",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def test_validator_accepts_user_id_bare_name(client: TestClient) -> None:
+    """Bare ``user_id`` reference is in _ALLOWED_NAMES so a
+    condition like ``user_id == 'admin'`` is valid."""
+    resp = client.post(
+        "/v1/policies",
+        json={
+            "name": "user_id_check",
+            "description": "Bare-name test.",
+            "trigger": "span_end",
+            "condition": "user_id == 'admin'",
+            "action": "flag",
+            "severity": "low",
+            "lifecycle": "before_proxy_call",
+            "mode": "shadow",
+        },
+    )
+    assert resp.status_code == 201, resp.text

--- a/packages/api/tests/firewall/test_webhook_ssrf.py
+++ b/packages/api/tests/firewall/test_webhook_ssrf.py
@@ -1,0 +1,154 @@
+"""SSRF guard tests for webhook config (brutal-test fix —
+verifies the security hole found on 2026-05-09).
+
+Before this fix, an operator (or anyone with write access to
+/v1/firewall/webhooks) could create a webhook pointed at:
+  - http://169.254.169.254/latest/meta-data/  (AWS instance creds)
+  - http://127.0.0.1:8000/v1/admin/backups    (local admin)
+  - file:///etc/passwd                        (filesystem)
+  - gopher:// / ftp:// / etc.                 (other schemes)
+
+The legacy ``policy_runtime._webhook_url_safe`` already had the
+right logic; it just wasn't being applied to the new
+``firewall_webhooks`` table.
+
+This test file confirms each of those attack vectors is now
+rejected at create time.
+"""
+
+from __future__ import annotations
+
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from db import Database
+import main
+
+
+@pytest.fixture
+def db() -> Generator[Database, None, None]:
+    d = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    yield d
+    d.close()
+
+
+@pytest.fixture
+def client(db: Database):
+    main.app.dependency_overrides[main.get_db] = lambda: db
+    yield TestClient(main.app)
+    main.app.dependency_overrides.clear()
+
+
+def _create(client: TestClient, *, kind: str, url: str) -> int:
+    key = "url" if kind == "generic" else "webhook_url"
+    resp = client.post(
+        "/v1/firewall/webhooks",
+        json={"name": "ssrf-test", "kind": kind, "config": {key: url}},
+    )
+    return resp.status_code
+
+
+# ----- positive controls — legitimate URLs accepted ----------------------
+
+
+def test_https_external_url_accepted(client: TestClient) -> None:
+    assert _create(client, kind="generic", url="https://hooks.example.com/abc") == 200
+
+
+def test_slack_webhook_url_accepted(client: TestClient) -> None:
+    assert _create(
+        client, kind="slack",
+        url="https://hooks.slack.com/services/T0/B0/abcdefghij",
+    ) == 200
+
+
+# ----- the four vectors found while attacking ---------------------------
+
+
+def test_aws_metadata_host_rejected(client: TestClient) -> None:
+    """The biggest concern — exfiltrating cloud creds."""
+    code = _create(client, kind="generic", url="http://169.254.169.254/latest/meta-data/")
+    assert code == 400
+
+
+def test_aws_metadata_alternate_encoding_rejected(client: TestClient) -> None:
+    """169.254.169.254 in alternate forms (decimal, octal) — the
+    underlying _webhook_url_safe normalises to IPv4Address."""
+    # Decimal int form: 169*256^3 + 254*256^2 + 169*256 + 254 = 2852039166
+    code = _create(client, kind="generic", url="http://2852039166/latest/meta-data/")
+    assert code == 400
+
+
+def test_loopback_127_0_0_1_rejected(client: TestClient) -> None:
+    """Stops the localhost-admin pivot."""
+    code = _create(client, kind="generic", url="http://127.0.0.1:8000/v1/admin/backups")
+    assert code == 400
+
+
+def test_loopback_localhost_rejected(client: TestClient) -> None:
+    code = _create(client, kind="generic", url="http://localhost:8000/admin")
+    assert code == 400
+
+
+def test_file_scheme_rejected(client: TestClient) -> None:
+    """file:// is silly but Python's urllib will happily attempt it."""
+    code = _create(client, kind="generic", url="file:///etc/passwd")
+    assert code == 400
+
+
+def test_gopher_scheme_rejected(client: TestClient) -> None:
+    """gopher://, ftp://, ldap:// — anything that isn't http(s)."""
+    code = _create(client, kind="generic", url="gopher://attacker.example/exfil")
+    assert code == 400
+
+
+def test_private_ip_rejected(client: TestClient) -> None:
+    """RFC1918 — internal services should never be webhook destinations."""
+    for url in (
+        "http://10.0.0.1/",
+        "http://192.168.1.1/",
+        "http://172.16.0.1/",
+    ):
+        assert _create(client, kind="generic", url=url) == 400, f"should reject {url}"
+
+
+def test_link_local_rejected(client: TestClient) -> None:
+    """169.254.0.0/16 covers AWS metadata + IPv4 link-local."""
+    assert _create(client, kind="generic", url="http://169.254.1.1/") == 400
+
+
+def test_slack_kind_url_also_validated(client: TestClient) -> None:
+    """Slack-kind webhooks check ``webhook_url`` config key — the
+    SSRF guard applies to that field too, not just generic ``url``."""
+    code = _create(
+        client, kind="slack",
+        url="http://169.254.169.254/exfil",
+    )
+    assert code == 400
+
+
+# ----- absent / empty URL doesn't bypass via no-op ----------------------
+
+
+def test_missing_required_url_still_400(client: TestClient) -> None:
+    """The original required-field validator still works — ensures
+    the SSRF guard doesn't silently swallow validation errors."""
+    resp = client.post(
+        "/v1/firewall/webhooks",
+        json={"name": "x", "kind": "slack", "config": {}},
+    )
+    assert resp.status_code == 400
+
+
+# ----- DLQ failure log doesn't accidentally store a rejected URL -------
+
+
+def test_rejected_webhook_does_not_persist(client: TestClient) -> None:
+    """Defense in depth — even if the SSRF check fails closed, no
+    row should land in firewall_webhooks for an attempted-and-rejected
+    creation."""
+    _create(client, kind="generic", url="http://169.254.169.254/")
+    listing = client.get("/v1/firewall/webhooks").json()
+    assert listing["webhooks"] == []


### PR DESCRIPTION
## Summary

Two real bugs surfaced by brutal-testing main on 2026-05-09. Both have integration tests so the same regressions can't slip through again.

### Bug 1 — Cross-session vault was non-functional via the API

The Slice 6A unit tests all passed because they call the builtin directly. The full API path (DecideRequest → namespace → policy condition → builtin) was broken in **5 places**:

| Layer | What was missing |
|---|---|
| `DecideRequest` Pydantic model | no `user_id` field |
| `decide()` function signature | no `user_id` kwarg |
| `_build_namespace()` | no `user_id` bound (top-level OR `Input.user_id`) |
| `_ALLOWED_NAMES` validator | `user_id` rejected as bare reference |
| `_ALLOWED_FUNCTIONS` validator | `cross_session_leak` rejected as a function call |

Plus one separate latent bug surfaced during the fix: `Output.text` was only extracted from **raw-string** output payloads. Integrations send `{"text": "..."}` (the standard shape), so `Output.text` was empty. **Every `after_proxy_call` rule referencing `Output.text` fired against an empty string and silently never matched.** Added dict extraction.

### Bug 2 — Webhook SSRF

`firewall_webhooks` accepted **any** URL. I created webhooks pointing at:

- `http://169.254.169.254/latest/meta-data/` (AWS instance creds)
- `http://127.0.0.1:8000/v1/admin/backups`  (local admin)
- `file:///etc/passwd`
- `gopher://...`, RFC1918 IPs, link-local

The existing `_webhook_url_safe` SSRF guard in `policy_runtime.py` had the right logic; it just wasn't being applied to the new `firewall_webhooks` table from PR #84. Wired it into `firewall.webhooks._validate_kind_config`. Also added `localhost` / `ip6-localhost` to `_SSRF_BLOCKED_HOSTS` — RFC 6761 hostnames that bypass IP-based checks.

## Tests

- `tests/firewall/test_vault_integration.py` (10 tests) — exercises the full HTTP path:
  - blocks when other-user fact appears in output ✅
  - allows when same user says own fact ✅
  - allows when user_id absent (Rule 7) ✅
  - allows when text unrelated ✅
  - validator accepts `cross_session_leak(...)` ✅
  - validator accepts bare `user_id` ✅

- `tests/firewall/test_webhook_ssrf.py` (9 tests) — one per attack vector:
  - AWS metadata host (canonical + decimal-int form) ✅
  - 127.0.0.1, localhost ✅
  - file://, gopher:// ✅
  - 10.x.x.x, 192.168.x.x, 172.16.x.x ✅
  - 169.254.x.x link-local ✅
  - Slack-kind `webhook_url` field also validated ✅
  - Legitimate https external URL still accepted ✅

`openapi.json` regenerated since `DecideRequest` schema changed.

**Full API suite: 705 passed** (was 689 — +16 new, no regressions).

## Out of scope

- The latency regression (p99 = 293ms vs 20ms budget) found in the same brutal-test session is a real perf issue but not security-blocking. Tracking separately.
- The pack-import idempotency drift (5 new + 8 skipped on owasp re-import) is also separate.
- DSL validator allowlist gaps for any other history builtins not listed — out of scope unless they bite a real user.

## Test plan

- [x] All new tests pass
- [x] Full API suite green (no regressions)
- [x] OpenAPI drift check passes
- [ ] Manual: hit `/v1/policy/decide` with `user_id` set, verify the cross_session_isolation pack actually fires when promoted to enforce
- [ ] Manual: try `POST /v1/firewall/webhooks` with `http://169.254.169.254/` — should 400 now