### PR TITLE
chore: lockstep-bump all packages + embedded versions to 0.6.0

### DIFF
--- a/packages/api/main.py
+++ b/packages/api/main.py
@@ -276,7 +276,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     title="Lumin API",
     description="Local-first AI agent observability — ingest and query API",
-    version="0.5.2",
+    version="0.6.0",
     lifespan=lifespan,
 )
 

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -3381,7 +3381,7 @@
   "info": {
     "description": "Local-first AI agent observability \u2014 ingest and query API",
     "title": "Lumin API",
-    "version": "0.5.2"
+    "version": "0.6.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -36,7 +36,7 @@ export const metadata: Metadata = {
   ],
 };
 
-const VERSION = '0.5.2';
+const VERSION = '0.6.0';
 
 export default function RootLayout({
   children,

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumin-dashboard",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/integrations/mastra/package.json
+++ b/packages/integrations/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/mastra",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Lumin exporter for Mastra agents \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/integrations/openclaw-diagnostics/package.json
+++ b/packages/integrations/openclaw-diagnostics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/openclaw-diagnostics",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Lumin observability + Agent Firewall for OpenClaw \u2014 captures prompts, responses, tool I/O, and synchronously enforces firewall policies on every tool call.",
   "homepage": "https://github.com/amitbidlan/zistica-lumin/tree/main/packages/integrations/openclaw-diagnostics",
   "repository": {

--- a/packages/integrations/openclaw/package.json
+++ b/packages/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/openclaw",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Lumin exporter for OpenClaw agents \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/integrations/voltagent/package.json
+++ b/packages/integrations/voltagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/voltagent",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Lumin exporter for VoltAgent \u2014 local-first observability with zero cloud dependency.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lumin"
-version = "0.5.2"
+version = "0.6.0"
 description = "Local-first AI agent observability SDK"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumin-io/sdk",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Local-first AI agent observability SDK (TypeScript)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Lockstep bump from `0.5.2` (and the mismatched `0.5.3` on openclaw-diagnostics) to a single coherent `0.6.0`. **Merge this, then `git tag v0.6.0 && git push origin v0.6.0` to trigger the publish workflow.**

## What ships in 0.6.0 vs 0.5.2

The 18 PRs merged since the last lockstep bump cover four spec slices + three rounds of brutal-test fixes.

### Slice 4 (breadth)
| PR | What |
|---|---|
| #83 | 11 starter packs (was 1) + `/v1/firewall/library` import API |
| #84 | Webhooks: Slack / Discord / PagerDuty / generic+HMAC / email |
| #85 | 6 framework integrations: LangChain, LangGraph, LiteLLM, OpenAI Agents, AutoGen, Pydantic AI |
| #86 | Launch assets: demo script, blog drafts, ClawHub copy |

### Slice 5 (deployment hardening)
| PR | What |
|---|---|
| #87 | `docker-compose.yml` + healthcheck + ops docs |
| #88 | Bearer token auth + dashboard password |
| #89 | Admin endpoints: health / retention / backup / restore |

### Slice 6 (security depth)
| PR | What |
|---|---|
| #90 | Cross-session vault + leak detector + starter pack |
| #91 | Multi-tenant `?project=` filter on read endpoints |
| #92 | Policy version history + one-click rollback |

### Slice 7 (operator UX)
| PR | What |
|---|---|
| #93 | OpenAPI export + curl reference + CI drift check |
| #94 | Telemetry-of-self at `/v1/admin/metrics` |

### Brutal-test fixes
| PR | What |
|---|---|
| #96 | Vault `user_id` wired end-to-end (DecideRequest → namespace → policy) + webhook SSRF guard |
| #97 | Plugin user_id, restore safety, metrics latency wiring |
| #98 | Restore via fresh-connection swap (works on persistent DB) |

## What gets published when you tag

| Surface | Artifact |
|---|---|
| Docker Hub | `zistica/lumin:0.6.0` + `:latest` |
| npm | `@lumin-io/openclaw@0.6.0` |
| npm | `@lumin-io/mastra@0.6.0` |
| npm | `@lumin-io/voltagent@0.6.0` |
| npm | `@lumin-io/openclaw-diagnostics@0.6.0` |
| ClawHub | `lumin-diagnostics@0.6.0` |

## Required repo secrets (already set per .github/workflows/publish.yml)

- `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`
- `NPM_TOKEN`
- `CLAWHUB_TOKEN`

## Test plan

- [x] All 9 version locations reflect 0.6.0
- [x] No 0.5.x references left (`grep -rE "0\.5\.[0-9]" packages` clean except in docs)
- [ ] Merge → tag → workflow succeeds across Docker / npm / ClawHub
- [ ] Post-publish: `openclaw plugins install @lumin-io/openclaw-diagnostics` → installed plugin reports `0.6.0`
- [ ] Post-publish: `docker pull zistica/lumin:0.6.0 && docker run` smoke test

## Note on the test suite

Two pre-existing tests have order-dependent failures unrelated to this bump (`test_drift::test_does_not_re_alert_same_day` and `test_circuit_breaker::test_decide_respects_disabled_auto_trip`). Both pass in isolation. They were passing on main before today's heavy load testing — likely test-isolation issues that bit on the busy CI machine. Tracking separately. **Not caused by the version bump** — this PR only touches version strings.