### PR TITLE
fix(ci): correct clawhub publish invocation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -237,18 +237,29 @@ jobs:
       - name: Publish to ClawHub
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-        # `clawhub package publish` reads the package metadata from the
-        # working directory (or via positional arg). The CLI authenticates
-        # via CLAWHUB_TOKEN env var; no separate `clawhub login` needed
-        # in CI. `--from-npm` would be cleaner if supported by the CLI;
-        # falling back to the standard publish form.
+        # `clawhub package publish` requires a positional <source>
+        # argument: a folder path, GitHub repo, or URL. Fix
+        # (2026-05-10): the previous form omitted source entirely
+        # ("missing required argument 'source'") and the fallback
+        # pointed at lumin-io/lumin-diagnostics which doesn't exist
+        # — the actual repo is the monorepo. Use the local folder
+        # path so the CLI uploads from the checkout, with a
+        # GitHub-source fallback that uses the right repo + ref +
+        # subpath.
         run: |
           set -e
-          cd packages/integrations/openclaw-diagnostics
-          clawhub package publish --version "${GITHUB_REF_NAME#v}" || {
-            # Some clawhub CLI versions accept the package spec as
-            # positional. Retry that form before giving up.
-            clawhub package publish "lumin-io/lumin-diagnostics@v${GITHUB_REF_NAME#v}"
+          if [ -z "$CLAWHUB_TOKEN" ]; then
+            echo "::error::CLAWHUB_TOKEN secret is not set on this repo"
+            exit 1
+          fi
+          PKG_DIR="packages/integrations/openclaw-diagnostics"
+          # Primary: publish from the local checkout.
+          clawhub package publish "$PKG_DIR" --version "${GITHUB_REF_NAME#v}" || {
+            # Fallback: have ClawHub fetch from the monorepo at the
+            # tagged ref + subpath.
+            clawhub package publish "${GITHUB_REPOSITORY}@${GITHUB_REF_NAME}" \
+              --source-path "$PKG_DIR" \
+              --version "${GITHUB_REF_NAME#v}"
           }
 
       - name: Summary


### PR DESCRIPTION
## Summary

Three compounding bugs in the v0.6.0 publish caused the ClawHub step to fail. **Docker + 4 npm packages all succeeded; ClawHub alone broke.**

## What broke (from the v0.6.0 publish run)

| # | Bug | Symptom in the log |
|---|---|---|
| 1 | `clawhub package publish` missing positional `<source>` arg | `error: missing required argument 'source'` |
| 2 | Fallback pointed at the wrong GitHub repo `lumin-io/lumin-diagnostics` | `GitHub ref not found: lumin-io/lumin-diagnostics@v0.6.0` |
| 3 | Empty `CLAWHUB_TOKEN` secret (compounded with the wrong-repo error) | `CLAWHUB_TOKEN: ` (no value) in the env dump |

## Fix

```yaml
- name: Publish to ClawHub
  run: |
    set -e
    if [ -z "$CLAWHUB_TOKEN" ]; then
      echo "::error::CLAWHUB_TOKEN secret is not set on this repo"
      exit 1
    fi
    PKG_DIR="packages/integrations/openclaw-diagnostics"
    # Primary: publish from local checkout
    clawhub package publish "$PKG_DIR" --version "${GITHUB_REF_NAME#v}" || {
      # Fallback: have ClawHub fetch from the monorepo at the tagged ref + subpath
      clawhub package publish "${GITHUB_REPOSITORY}@${GITHUB_REF_NAME}" \
        --source-path "$PKG_DIR" \
        --version "${GITHUB_REF_NAME#v}"
    }
```

Three changes:
- **Primary form**: explicit `<source>` = local package folder
- **Fallback form**: `${GITHUB_REPOSITORY}` instead of hardcoded `lumin-io/...`, plus `--source-path` to point at the subpath
- **Fail-fast on empty token**: clearer error than "GitHub ref not found"

## Operator action required

**Set the `CLAWHUB_TOKEN` repo secret** before re-running:

```bash
# Locally, get the token
clawhub login            # interactive
clawhub auth print-token # copy this

# In the GitHub UI:
# Settings → Secrets and variables → Actions → New repository secret
# Name: CLAWHUB_TOKEN
# Value: <paste>
```

## Re-publish strategy

Two options after merging this PR + setting the secret:

```bash
# Option A — manual workflow_dispatch (preferred — no new tag)
gh workflow run "Publish (Docker + npm + ClawHub)" -f tag=0.6.0

# Option B — cut a v0.6.1 tag (only works if you also bump versions)
```

Docker + npm are **already at 0.6.0** on their registries; re-running the workflow will no-op those steps (they detect existing artifacts) and only retry ClawHub.

## Test plan

- [x] YAML parses (`yamllint` clean)
- [ ] Set `CLAWHUB_TOKEN` secret
- [ ] Re-trigger publish → ClawHub job goes green
- [ ] Verify: `openclaw plugins search lumin-diagnostics` returns 0.6.0