### PR TITLE
fix(ci): npm + clawhub jobs skip on workflow_dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,7 +137,11 @@ jobs:
   npm:
     name: Publish ${{ matrix.package }} to npm
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    # Run on tag-push AND on manual workflow_dispatch. The original
+    # ``== 'push'`` guard silently SKIPPED this whole matrix when an
+    # operator re-ran the workflow manually (e.g. to retry ClawHub
+    # after fixing a secret). Caught 2026-05-10 — see PR/run #25605688207.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: publish  # docker first; if image fails, npm shouldn't ship either
     permissions:
       contents: read
@@ -211,7 +215,8 @@ jobs:
   clawhub:
     name: Publish lumin-diagnostics to ClawHub
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    # Same fix as the npm job above — accept manual re-runs.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: npm
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Caught after PR #100 merged: re-running `gh workflow run "Publish ..."` skipped npm + ClawHub jobs entirely. Only Docker ran. Workflow_dispatch produced an *overall: success* result that was silently incomplete.

## Root cause

```yaml
npm:
  if: github.event_name == 'push'   # ← skipped on workflow_dispatch
clawhub:
  if: github.event_name == 'push'   # ← same
```

The intent was probably "only run on tag push, not every main commit" — but the workflow already restricts `on: push: tags: v*`, so the guard was redundant. Worse, it broke manual re-runs.

## Fix

```yaml
if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
```

## Re-trigger after merge

```bash
gh workflow run "Publish (Docker + npm + ClawHub)" -f tag=0.6.0
```

Now runs Docker → npm → ClawHub in sequence as designed.

## Note

This is the **second** workflow bug found post-tag in 30 minutes. Both were latent — they don't fire until somebody does a manual re-run, which we hadn't needed before. Worth keeping the workflow_dispatch retry path as a real production tool now that we've used it.