### PR TITLE
fix(dashboard): sticky window filter across /agents pages + refresh

### DIFF
--- a/packages/dashboard/app/agents/[name]/page.tsx
+++ b/packages/dashboard/app/agents/[name]/page.tsx
@@ -4,6 +4,10 @@ export const metadata = {
   title: 'Agent',
 };
 
+// AgentDetail reads ``?window`` via the URL-state hooks, which requires
+// dynamic rendering. Matches /agents and /agents/framework/[key].
+export const dynamic = 'force-dynamic';
+
 interface PageProps {
   params: { name: string };
 }

--- a/packages/dashboard/components/AgentDetail.tsx
+++ b/packages/dashboard/components/AgentDetail.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
 import useSWR from 'swr';
 import {
   AgentDetail as AgentDetailType,
@@ -14,6 +13,7 @@ import {
   PolicyListResponse,
 } from '@/lib/api';
 import Sparkline from '@/components/Sparkline';
+import { useUrlNumber } from '@/lib/url-state';
 
 const WINDOW_OPTIONS = [
   { hours: 1,  label: '1h'  },
@@ -22,7 +22,12 @@ const WINDOW_OPTIONS = [
 ];
 
 export default function AgentDetail({ name }: { name: string }) {
-  const [window_, setWindow] = useState(24);
+  // Shared with /agents (AgentList) via the same storage key — picking 7d
+  // on the list page and clicking into an agent keeps the window at 7d.
+  // URL still wins when present so deep links render exactly as written.
+  const [window_, setWindow] = useUrlNumber('window', 24, {
+    storageKey: 'lumin.agents.window',
+  });
 
   const params = new URLSearchParams();
   params.set('window_hours', String(window_));
@@ -55,11 +60,15 @@ export default function AgentDetail({ name }: { name: string }) {
     return <div className="card p-8 text-center text-[var(--muted)]">Loading…</div>;
   }
 
+  // Preserve the window pill on the way back to /agents so the round-trip
+  // doesn't flash the default before localStorage rehydrates.
+  const backHref = window_ === 24 ? '/agents' : `/agents?window=${window_}`;
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <Link
-          href="/agents"
+          href={backHref}
           className="text-[var(--muted)] text-xs hover:text-[var(--foreground)] transition-colors"
         >
           ← All agents

--- a/packages/dashboard/components/AgentList.tsx
+++ b/packages/dashboard/components/AgentList.tsx
@@ -81,10 +81,20 @@ export default function AgentList({
   // (route param) takes precedence over the URL ``project`` filter
   // because the dedicated /agents/framework/[key] route IS the
   // hard-narrowed view.
-  const [window_, setWindow] = useUrlNumber('window', 24);
+  // The window pill is shared with /agents/[name] and /agents/framework/*.
+  // Backing it with localStorage means a 7d selection on the list page
+  // survives a click into /agents/openclaw AND a later top-nav return to
+  // /agents (the nav <Link> drops query params).
+  const [window_, setWindow] = useUrlNumber('window', 24, {
+    storageKey: 'lumin.agents.window',
+  });
   const [search, setSearch] = useUrlString('q', '');
-  const [projectFilterRaw, setProjectFilter] = useUrlString('project', 'all');
-  const [providerFilter, setProviderFilter] = useUrlString('provider', 'all');
+  const [projectFilterRaw, setProjectFilter] = useUrlString('project', 'all', {
+    storageKey: 'lumin.agents.project',
+  });
+  const [providerFilter, setProviderFilter] = useUrlString('provider', 'all', {
+    storageKey: 'lumin.agents.provider',
+  });
   const projectFilter = lockedFramework ?? projectFilterRaw;
 
   const params = new URLSearchParams();
@@ -405,6 +415,7 @@ export default function AgentList({
                         key={`${a.project}::${a.name}`}
                         agent={a}
                         liveOverride={liveAgents.has(a.name)}
+                        window_={window_}
                       />
                     ))}
                     {hidden > 0 ? (
@@ -437,17 +448,25 @@ export default function AgentList({
 function AgentCard({
   agent,
   liveOverride = false,
+  window_,
 }: {
   agent: AgentSummary;
   liveOverride?: boolean;
+  /** Current window filter (hours). Forwarded to the detail URL so
+   *  the pill stays in sync without relying on the localStorage flash. */
+  window_: number;
 }) {
   // WS-driven override: a span just landed for this agent → show as
   // "active" immediately, even if the cached server value is stale.
   const activity: ActivityLabel = liveOverride ? 'active' : agent.activity;
   const isThinking = (agent.active_traces ?? 0) > 0 || liveOverride;
+  const href =
+    window_ === 24
+      ? `/agents/${encodeURIComponent(agent.name)}`
+      : `/agents/${encodeURIComponent(agent.name)}?window=${window_}`;
   return (
     <Link
-      href={`/agents/${encodeURIComponent(agent.name)}`}
+      href={href}
       className="card card-interactive block p-5"
     >
       <div className="flex items-start justify-between gap-3">

--- a/packages/dashboard/lib/url-state.ts
+++ b/packages/dashboard/lib/url-state.ts
@@ -25,7 +25,7 @@
  */
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 
 function setOrDelete(
@@ -41,21 +41,55 @@ function setOrDelete(
 }
 
 
+/** Options shared by every URL-state hook. */
+export interface UrlStateOptions {
+  /** Persist the value to ``localStorage[storageKey]`` so the choice
+   *  survives navigation through links that don't carry the URL
+   *  query (e.g. the top nav). Read precedence is URL > localStorage
+   *  > default — explicit deep links always win, so an operator-
+   *  shared link renders exactly what it says. */
+  storageKey?: string;
+}
+
+
 export function useUrlString(
   key: string,
   defaultValue: string,
+  options: UrlStateOptions = {},
 ): [string, (next: string) => void] {
   const router = useRouter();
   const pathname = usePathname();
   const params = useSearchParams();
-  const value = params.get(key) ?? defaultValue;
+  const { storageKey } = options;
+
+  // Hydrate the sticky fallback after mount — reading localStorage on
+  // the first render would diverge from the server-rendered HTML and
+  // trip a hydration warning. Until the useEffect runs the fallback
+  // is null, so the initial paint matches the server.
+  const [sticky, setSticky] = useState<string | null>(null);
+  useEffect(() => {
+    if (!storageKey || typeof window === 'undefined') return;
+    setSticky(window.localStorage.getItem(storageKey));
+  }, [storageKey]);
+
+  const value = params.get(key) ?? sticky ?? defaultValue;
+
   const setValue = useCallback(
     (next: string) => {
       const updated = setOrDelete(params, key, next, defaultValue);
       const qs = updated.toString();
       router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+      if (storageKey && typeof window !== 'undefined') {
+        if (!next || next === defaultValue) {
+          window.localStorage.removeItem(storageKey);
+          setSticky(null);
+        } else {
+          window.localStorage.setItem(storageKey, next);
+          setSticky(next);
+        }
+      }
     },
-    [params, pathname, router, key, defaultValue],
+    [params, pathname, router, key, defaultValue, storageKey],
   );
   return [value, setValue];
 }
@@ -64,8 +98,9 @@ export function useUrlString(
 export function useUrlNumber(
   key: string,
   defaultValue: number,
+  options: UrlStateOptions = {},
 ): [number, (next: number) => void] {
-  const [str, setStr] = useUrlString(key, String(defaultValue));
+  const [str, setStr] = useUrlString(key, String(defaultValue), options);
   const parsed = Number.parseInt(str, 10);
   const value = Number.isFinite(parsed) ? parsed : defaultValue;
   const setValue = useCallback((next: number) => setStr(String(next)), [setStr]);
@@ -76,12 +111,13 @@ export function useUrlNumber(
 export function useUrlBoolean(
   key: string,
   defaultValue: boolean,
+  options: UrlStateOptions = {},
 ): [boolean, (next: boolean) => void] {
   // Encode booleans as "1"/"0" so the URL stays terse. We treat any
   // non-"1" / non-"true" value as false — generous parsing for hand-
   // typed deep links.
   const def = defaultValue ? '1' : '0';
-  const [str, setStr] = useUrlString(key, def);
+  const [str, setStr] = useUrlString(key, def, options);
   const value = str === '1' || str === 'true';
   const setValue = useCallback(
     (next: boolean) => setStr(next ? '1' : '0'),


### PR DESCRIPTION
## Summary

Two bugs on the agents UI:

1. **\`/agents\`** — picking \`7d\` then clicking **Agents** in the top nav (or any nav-link that drops query params) reset the filter to \`24h\`. The URL state was right, but \`<Link href=\"/agents\">\` blew it away.
2. **\`/agents/[name]\`** — the window pill used plain \`useState(24)\`, so neither refresh nor list → detail navigation preserved the operator's choice. Picking \`7d\` on \`/agents\` and clicking into \`/agents/openclaw\` always landed on \`24h\`.

## Fix

- **\`lib/url-state.ts\`** — extend \`useUrlString\` / \`useUrlNumber\` / \`useUrlBoolean\` with an optional \`storageKey\`. When set, value reads **URL > localStorage > default** and writes to both URL and localStorage. localStorage hydrates post-mount to avoid SSR hydration mismatch.
- **\`AgentList\`** — window / project / provider get matching storage keys under \`lumin.agents.*\` so picks survive nav round-trips.
- **\`AgentDetail\`** — swap \`useState(24)\` for the URL-state hook with the **same** \`storageKey\` as the list. Picking \`7d\` on \`/agents\` now carries into \`/agents/openclaw\`.
- **\`AgentCard\` \`<Link>\`** to the detail page and **\`AgentDetail\`'s \"← All agents\"** link now include \`?window=N\` when non-default, so the URL stays consistent and there's no localStorage-rehydration flash.
- **\`app/agents/[name]/page.tsx\`** — adds \`export const dynamic = 'force-dynamic'\` since \`AgentDetail\` now reads \`useSearchParams\` via the URL-state hook.

## Test plan

- [x] \`npm run build\` clean; all three \`/agents/*\` routes show as \`ƒ\` (dynamic)
- [x] \`npx tsc --noEmit\` clean
- [ ] \`/agents\` — pick \`7d\`, refresh → still \`7d\`
- [ ] \`/agents\` — pick \`7d\`, navigate to \`/traces\`, click **Agents** in nav → still \`7d\`
- [ ] \`/agents\` — pick \`7d\`, click an agent card → \`/agents/openclaw?window=168\` opens at \`7d\`
- [ ] \`/agents/openclaw\` — pick \`1h\`, refresh → still \`1h\`
- [ ] \`/agents/openclaw\` at \`7d\` → click \"← All agents\" → \`/agents?window=168\` opens at \`7d\`