### PR TITLE
fix(dashboard): make badge tags readable in light mode

### DIFF
--- a/packages/dashboard/app/globals.css
+++ b/packages/dashboard/app/globals.css
@@ -333,6 +333,21 @@ textarea.form-input {
 .badge-orange  { background: rgba(249, 115, 22, 0.1); color: #fdba74; border-color: rgba(249, 115, 22, 0.4); }
 .badge-blue    { background: rgba(59, 130, 246, 0.1); color: #93c5fd; border-color: rgba(59, 130, 246, 0.4); }
 .badge-violet  { background: rgba(167, 139, 250, 0.1); color: #c4b5fd; border-color: rgba(167, 139, 250, 0.4); }
+.badge-cyan    { background: rgba(34, 211, 238, 0.10); color: #67e8f9; border-color: rgba(34, 211, 238, 0.4); }
+
+/* Light-mode overrides — the dark-mode palette uses *-300 text on a
+   faint tint, which is pale-on-pale and disappears on near-white. Flip
+   to a *-700 foreground with a slightly stronger border. Same hue
+   family so a "rose" pill still reads as red in both themes. */
+:root[data-theme="light"] .badge-rose    { background: rgba(244, 63, 94, 0.10); color: #b91c1c; border-color: rgba(244, 63, 94, 0.45); }
+:root[data-theme="light"] .badge-amber   { background: rgba(245, 158, 11, 0.12); color: #b45309; border-color: rgba(245, 158, 11, 0.50); }
+:root[data-theme="light"] .badge-emerald { background: rgba(16, 185, 129, 0.10); color: #047857; border-color: rgba(16, 185, 129, 0.45); }
+:root[data-theme="light"] .badge-slate   { background: rgba(100, 116, 139, 0.10); color: #334155; border-color: rgba(100, 116, 139, 0.40); }
+:root[data-theme="light"] .badge-fuchsia { background: rgba(217, 70, 239, 0.10); color: #a21caf; border-color: rgba(217, 70, 239, 0.45); }
+:root[data-theme="light"] .badge-orange  { background: rgba(249, 115, 22, 0.10); color: #c2410c; border-color: rgba(249, 115, 22, 0.45); }
+:root[data-theme="light"] .badge-blue    { background: rgba(59, 130, 246, 0.10); color: #1d4ed8; border-color: rgba(59, 130, 246, 0.45); }
+:root[data-theme="light"] .badge-violet  { background: rgba(167, 139, 250, 0.12); color: #6d28d9; border-color: rgba(139, 92, 246, 0.45); }
+:root[data-theme="light"] .badge-cyan    { background: rgba(34, 211, 238, 0.12); color: #0e7490; border-color: rgba(8, 145, 178, 0.45); }
 
 /* Lifted nav header — sticky with backdrop blur */
 .app-header {

--- a/packages/dashboard/components/TraceDetail.tsx
+++ b/packages/dashboard/components/TraceDetail.tsx
@@ -326,21 +326,17 @@ function ViolationRow({ v }: { v: PolicyViolation }) {
 }
 
 function SeverityBadge({ sev }: { sev: string }) {
-  const styles: Record<string, string> = {
-    low: 'bg-slate-700/40 text-slate-300 border-slate-600',
-    medium: 'bg-amber-900/30 text-amber-300 border-amber-700',
-    high: 'bg-red-900/40 text-red-300 border-red-700',
-    critical: 'bg-fuchsia-900/40 text-fuchsia-200 border-fuchsia-700',
+  // Use the shared `.badge badge-*` system so light/dark variants flip
+  // automatically via the CSS overrides in globals.css. Hardcoded
+  // Tailwind palettes here previously rendered as pale-on-pale and
+  // disappeared in light mode.
+  const cls: Record<string, string> = {
+    low:      'badge badge-slate',
+    medium:   'badge badge-amber',
+    high:     'badge badge-rose',
+    critical: 'badge badge-fuchsia',
   };
-  return (
-    <span
-      className={`inline-block text-[10px] uppercase tracking-wider px-1.5 py-0.5 border rounded ${
-        styles[sev] ?? styles.low
-      }`}
-    >
-      {sev}
-    </span>
-  );
+  return <span className={cls[sev] ?? cls.low}>{sev}</span>;
 }
 
 function Metric({ label, value }: { label: string; value: string }) {


### PR DESCRIPTION
## Summary

The \`.badge-*\` palette in \`globals.css\` uses pale \`*-300\` foregrounds on a 10–12% tinted background. Reads fine in dark mode; renders as pale-on-pale in light mode and effectively disappears against the near-white surface.

Visible at:
- \`/policies\` — every severity / trigger / action / mode / scope pill on each policy card.
- \`/traces/[id]\` (policy tab) — every SeverityBadge on the violations table.
- \`/decisions\`, \`/violations\`, anywhere \`badge badge-*\` is used.

## Fix

- **\`globals.css\`** — add \`:root[data-theme=\"light\"] .badge-*\` overrides for every color (rose, amber, emerald, slate, fuchsia, orange, blue, violet, cyan) with a darker \`*-700\` foreground and a stronger border. Same hue family so the visual mapping (rose=red, amber=yellow, …) carries across themes.
- **\`globals.css\`** — add the missing \`.badge-cyan\` dark-mode rule. Referenced in \`PolicyList\` for \`action=rewrite\` but never defined, so it was inheriting only the base \`.badge\` styles (no color at all).
- **\`TraceDetail.SeverityBadge\`** — drop the hardcoded Tailwind \`bg-*-900/text-*-200\` classes and reuse \`badge badge-{slate,amber,rose,fuchsia}\` so the light-mode flip applies automatically.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npx tsc --noEmit\` clean
- [ ] Light mode: every pill on \`/policies\` (severity, trigger/lifecycle, action, mode, scope) is readable
- [ ] Light mode: SeverityBadge on \`/traces/[id]\` policy tab is readable
- [ ] Dark mode: no regression — pills look identical to before