### PR TITLE
fix(api): /v1/admin/health no longer crashes when policy engine is None

### DIFF
--- a/packages/api/routers/admin.py
+++ b/packages/api/routers/admin.py
@@ -118,17 +118,59 @@ def admin_health(db: Database = Depends(get_db)) -> AdminHealth:
         )
 
     # Firewall engine
+    #
+    # ``policy_runtime.get_engine()`` is documented as Optional — it
+    # returns None when neither YAML nor DB managed to populate the
+    # engine, OR when the engine was first-loaded with an empty DB and
+    # the starter pack inserted rows after that first load without
+    # triggering ``reload_engine()``. The previous check dereferenced
+    # the result unconditionally, so the *health* endpoint crashed in
+    # both of those legitimate states and surfaced raw
+    # ``'NoneType' object has no attribute 'policies'`` to operators
+    # watching for actual problems. Distinguish three cases:
+    #   - engine loaded, rules present  -> ok
+    #   - engine None but DB has rules  -> degraded with remediation hint
+    #     (this is the post-bootstrap-no-reload case)
+    #   - engine None and DB empty       -> ok, no policies configured
     try:
         import policy_runtime
 
-        policies = policy_runtime.get_engine().policies
-        components.append(
-            HealthComponent(
-                name="policy_engine",
-                status="ok",
-                detail=f"{len(policies)} policy(ies) loaded",
+        eng = policy_runtime.get_engine()
+        if eng is not None:
+            components.append(
+                HealthComponent(
+                    name="policy_engine",
+                    status="ok",
+                    detail=f"{len(eng.policies)} policy(ies) loaded",
+                )
             )
-        )
+        else:
+            try:
+                row = db.fetchone(
+                    "SELECT COUNT(*) FROM policies WHERE enabled = TRUE"
+                )
+                db_count = int(row[0]) if row else 0
+            except Exception:
+                db_count = 0
+            if db_count > 0:
+                components.append(
+                    HealthComponent(
+                        name="policy_engine",
+                        status="degraded",
+                        detail=(
+                            f"{db_count} policy(ies) in DB but engine not "
+                            f"loaded; call POST /v1/policy/reload"
+                        ),
+                    )
+                )
+            else:
+                components.append(
+                    HealthComponent(
+                        name="policy_engine",
+                        status="ok",
+                        detail="no policies configured",
+                    )
+                )
     except Exception as e:
         components.append(
             HealthComponent(


### PR DESCRIPTION
## Summary

\`/v1/admin/health\` returns \`status: degraded\` and surfaces \`'NoneType' object has no attribute 'policies'\` as the policy_engine \`detail\` whenever \`policy_runtime.get_engine()\` returns None. It's typed \`Optional[PolicyEngine]\` for a reason — it returns None in real, expected states.

## Repro

\`\`\`bash
curl -s http://localhost:8000/v1/admin/health | jq '.components[] | select(.name==\"policy_engine\")'
\`\`\`
\`\`\`json
{
  \"name\": \"policy_engine\",
  \"status\": \"degraded\",
  \"detail\": \"'NoneType' object has no attribute 'policies'\"
}
\`\`\`

Yet \`/v1/policies\` on the same process returns 13 policies with \`engine_loaded: true\` (because it queries DB directly). So the system is fine — only the health check is broken.

## Root cause

\`policy_runtime.get_engine()\` returns None in two legitimate states:
1. Neither YAML nor DB populated the engine.
2. Engine was first-loaded against an empty DB; starter pack bootstrap then inserted rows but didn't trigger \`reload_engine()\` — so \`_engine\` stays None even though the DB has 13 rows. Repro'd on the current dev install.

In both states the health endpoint dereferenced the None and crashed.

## Fix

Distinguish three cases instead of crashing:
| state | reported |
|---|---|
| engine loaded | \`status: ok, detail: '<N> policy(ies) loaded'\` |
| engine None, DB has rows | \`status: degraded, detail: '<N> policy(ies) in DB but engine not loaded; call POST /v1/policy/reload'\` |
| engine None, DB empty | \`status: ok, detail: 'no policies configured'\` |

## Out of scope

The underlying \"engine is None despite DB rows\" bug — \`reload_engine()\` not being called after starter pack inserts — is real and worth its own PR. This commit just stops the health endpoint from crashing on it.

## Test plan

- [x] Triggers all three branches locally without a crash
- [ ] After container rebuild: \`curl /v1/admin/health\` reports either ok or the degraded-with-remediation message, never an AttributeError