### PR TITLE
fix(api): surface missing ML detectors in /v1/admin/health + startup logs

### DIFF
--- a/packages/api/main.py
+++ b/packages/api/main.py
@@ -194,6 +194,49 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     except Exception:
         logger.exception("policy engine eager-load failed (continuing)")
 
+    # Detector availability — every optional ML / NER / classifier
+    # detector exposes a module-level ``available: bool``. When the
+    # backing dependency isn't installed it stays False and the
+    # detector silently returns score 0.0, so any policy condition
+    # that references it (``prompt_guard_score(...)``,
+    # ``llama_guard_unsafe(...)``, ``embedding_similar(...)``, ...)
+    # becomes a permanent no-op. The OWASP starter pack ships rules
+    # that depend on these. Without this warning the operator has no
+    # way to know their LLM01 / LLM05 protections aren't actually
+    # running — promote-to-enforce later and they STILL won't fire.
+    # Surface it once at startup; the /v1/admin/health endpoint
+    # exposes the same data for ongoing monitoring.
+    _DETECTOR_INSTALL_HINTS = {
+        "prompt_guard":     "pip install transformers torch",
+        "llama_guard":      "pip install transformers torch accelerate",
+        "embedding":        "pip install sentence-transformers",
+        "local_classifier": "pip install scikit-learn",
+        "presidio":         "pip install presidio-analyzer presidio-anonymizer "
+                            "&& python -m spacy download en_core_web_lg",
+        "llm_judge":        "set LUMIN_LLM_JUDGE_ENDPOINT to an OpenAI-compatible "
+                            "URL (e.g. an Ollama / vLLM endpoint)",
+    }
+    try:
+        from importlib import import_module
+        for _name, _hint in _DETECTOR_INSTALL_HINTS.items():
+            try:
+                _mod = import_module(f"firewall.detectors.{_name}")
+            except Exception:
+                logger.warning(
+                    "detector unavailable: %s — module failed to import "
+                    "(install: %s)",
+                    _name, _hint,
+                )
+                continue
+            if not bool(getattr(_mod, "available", False)):
+                logger.warning(
+                    "detector unavailable: %s — rules referencing it will "
+                    "silently no-op (install: %s)",
+                    _name, _hint,
+                )
+    except Exception:
+        logger.exception("detector availability check failed (continuing)")
+
     # Pull the firewall panic-disable bit forward across restarts so
     # an operator who flipped the kill-switch yesterday isn't surprised
     # by a hot engine after a deploy. Best-effort: a missing table or

--- a/packages/api/routers/admin.py
+++ b/packages/api/routers/admin.py
@@ -174,6 +174,69 @@ def admin_health(db: Database = Depends(get_db)) -> AdminHealth:
             )
         )
 
+    # Detectors — every optional ML / NER / classifier detector exposes
+    # a module-level ``available: bool``. Surfaces in /admin/health so
+    # operators don't get silently no-op'd by a missing transformers /
+    # torch / sentence_transformers install: an OWASP rule that
+    # references ``prompt_guard_score(...)`` returns 0.0 forever and the
+    # rule never fires, even when promoted to enforce. Status is
+    # ``degraded`` (not ``down``) when any optional detector is missing
+    # — most deployments choose to ship without the larger ML deps to
+    # keep the image small, so this is informational not fatal.
+    try:
+        from importlib import import_module
+        _detector_names = (
+            "presidio",
+            "prompt_guard",
+            "llama_guard",
+            "embedding",
+            "local_classifier",
+            "ipi",
+            "llm_judge",
+            "regex_pack",
+        )
+        available_names: list[str] = []
+        missing_names: list[str] = []
+        for _name in _detector_names:
+            try:
+                _mod = import_module(f"firewall.detectors.{_name}")
+            except Exception:
+                missing_names.append(_name)
+                continue
+            if bool(getattr(_mod, "available", False)):
+                available_names.append(_name)
+            else:
+                missing_names.append(_name)
+        if not missing_names:
+            components.append(
+                HealthComponent(
+                    name="detectors",
+                    status="ok",
+                    detail=(
+                        f"{len(available_names)} available: "
+                        f"{', '.join(available_names)}"
+                    ),
+                )
+            )
+        else:
+            components.append(
+                HealthComponent(
+                    name="detectors",
+                    status="degraded",
+                    detail=(
+                        f"{len(available_names)}/{len(_detector_names)} "
+                        f"available; missing: {', '.join(missing_names)} "
+                        f"— rules referencing these silently no-op"
+                    ),
+                )
+            )
+    except Exception as e:
+        components.append(
+            HealthComponent(
+                name="detectors", status="degraded", detail=str(e)[:200],
+            )
+        )
+
     overall = "ok"
     if any(c.status == "down" for c in components):
         overall = "down"


### PR DESCRIPTION
## Summary

Every optional detector (\`prompt_guard\`, \`llama_guard\`, \`embedding\`, \`local_classifier\`, …) exposes a module-level \`available: bool\` that goes False when its dependency isn't installed. The detector then silently returns score \`0.0\` and any policy condition referencing it (\`prompt_guard_score(...) > 0.7\`, \`llama_guard_unsafe(...)\`, etc.) becomes a permanent no-op.

The OWASP starter pack ships two rules with exactly these conditions. On the current dev install (and any default Docker image), \`transformers\` / \`torch\` / \`sentence_transformers\` aren't bundled, so:

- \`owasp_llm01_prompt_injection_ml\` — silently no-op
- \`owasp_harmful_content_ml\` — silently no-op

The operator has **zero** ways to discover this:
- No startup warning
- No mention in \`/v1/admin/health\`
- No banner in the dashboard
- \`/v1/firewall/classifier/models\` returns \`{\"models\":[]}\`
- Promoting the rule to enforce still doesn't make it fire

## Fix

- **\`main.py\`** — log a \`WARN\` at startup for each unavailable detector, including the exact install command.
- **\`routers/admin.py\`** — add a \`detectors\` component to \`/v1/admin/health\` that lists available + missing names and notes that the missing ones silently no-op. \`degraded\` (not \`down\`) because most deployments intentionally skip the heavy ML deps to keep the image small.

Operators still need to install the deps to actually run the protections — this PR just makes the silent failure visible.

## Repro / verification

Before:
\`\`\`json
{ \"name\": \"webhook_dlq\", ... }
{ \"name\": \"backup_dir\", ... }
// no \"detectors\" component
\`\`\`

After (this install):
\`\`\`json
{
  \"name\": \"detectors\",
  \"status\": \"degraded\",
  \"detail\": \"4/8 available; missing: prompt_guard, llama_guard, embedding, local_classifier — rules referencing these silently no-op\"
}
\`\`\`

## Test plan

- [ ] Container rebuild succeeds
- [ ] \`/v1/admin/health\` returns a \`detectors\` component
- [ ] \`docker logs lumin | grep 'detector unavailable'\` shows one line per missing detector with install hint