### PR TITLE
fix(ci): add @lumin-io/sdk to npm publish matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,8 @@ name: Publish (Docker + npm + ClawHub)
 # job is just to push the published bits to:
 #
 #   - Docker Hub  (zistica/lumin image)
-#   - npm         (@lumin-io/{openclaw, mastra, voltagent,
-#                  openclaw-diagnostics})
+#   - npm         (@lumin-io/{sdk, openclaw, openclaw-diagnostics,
+#                  mastra, voltagent})
 #   - ClawHub     (lumin-diagnostics — OpenClaw plugin marketplace)
 #
 # Why tag-triggered (not main-push)?
@@ -128,14 +128,20 @@ jobs:
 
   # ----- npm publish -----------------------------------------------------
   #
-  # Publishes the four `@lumin-io/*` integration packages to npmjs.com.
-  # Each package is built fresh on the runner so the published `dist/`
-  # matches the tagged source — no relying on stale local build state.
-  # Skips workflow_dispatch (manual) runs since lockstep version bumps
-  # only land via tags; a hotfix re-publish via dispatch would push the
-  # same version twice and npm would reject it.
+  # Publishes the five `@lumin-io/*` packages to npmjs.com. Each package
+  # is built fresh on the runner so the published `dist/` matches the
+  # tagged source — no relying on stale local build state. Skips
+  # workflow_dispatch (manual) runs since lockstep version bumps only
+  # land via tags; a hotfix re-publish via dispatch would push the same
+  # version twice and npm would reject it.
+  #
+  # The matrix uses ``include`` (not a flat list) because @lumin-io/sdk
+  # lives at ``packages/sdk-typescript`` while the others live under
+  # ``packages/integrations/*``. Each entry carries the path it ships
+  # from so the working-directory is right per-package without an extra
+  # conditional.
   npm:
-    name: Publish ${{ matrix.package }} to npm
+    name: Publish @lumin-io/${{ matrix.package }} to npm
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     needs: publish  # docker first; if image fails, npm shouldn't ship either
@@ -149,14 +155,20 @@ jobs:
       # can be retried tag-locally.
       fail-fast: false
       matrix:
-        package:
-          - openclaw
-          - openclaw-diagnostics
-          - mastra
-          - voltagent
+        include:
+          - package: sdk
+            dir: packages/sdk-typescript
+          - package: openclaw
+            dir: packages/integrations/openclaw
+          - package: openclaw-diagnostics
+            dir: packages/integrations/openclaw-diagnostics
+          - package: mastra
+            dir: packages/integrations/mastra
+          - package: voltagent
+            dir: packages/integrations/voltagent
     defaults:
       run:
-        working-directory: packages/integrations/${{ matrix.package }}
+        working-directory: ${{ matrix.dir }}
     steps:
       - uses: actions/checkout@v4
 
@@ -181,7 +193,7 @@ jobs:
           PKG_VERSION=$(node -p "require('./package.json').version")
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
             echo "::error::package.json version ($PKG_VERSION) does not match git tag ($TAG_VERSION)"
-            echo "Did you forget to bump packages/integrations/${{ matrix.package }}/package.json?"
+            echo "Did you forget to bump ${{ matrix.dir }}/package.json?"
             exit 1
           fi
           echo "version OK: $PKG_VERSION"


### PR DESCRIPTION
## Summary

\`@lumin-io/sdk\` is published on npm at 0.7.0 but **NOT** in the publish workflow's npm matrix. The matrix only covers four packages under \`packages/integrations/*\`:

\`\`\`yaml
matrix:
  package:
    - openclaw
    - openclaw-diagnostics
    - mastra
    - voltagent
\`\`\`

On the next \`v0.7.1\` tag, those four bump to 0.7.1 while \`@lumin-io/sdk\` silently stays at 0.7.0. That breaks the lockstep-versioning rule and confuses users who \`npm install @lumin-io/sdk\` expecting parity with the rest of the family.

## Verified

\`\`\`
=== @lumin-io/sdk on npm ===
  versions published: ['0.7.0']
  latest: 0.7.0

=== other four ===
  @lumin-io/openclaw → latest=0.7.0
  @lumin-io/openclaw-diagnostics → latest=0.7.0
  @lumin-io/mastra → latest=0.7.0
  @lumin-io/voltagent → latest=0.7.0
\`\`\`

All five are at 0.7.0 today, but only four would auto-bump on the next tag.

## Fix

Convert the matrix from a flat \`package: [...]\` list to \`include:\` entries so each package carries its own \`dir\` path. \`@lumin-io/sdk\` lives at \`packages/sdk-typescript\` (not \`packages/integrations/sdk-typescript\`), so the path can't be derived from the package name alone.

Behavior for the existing four packages is unchanged — same names, same install commands, same npm provenance flow.

YAML verified to parse + matrix expands correctly:
\`\`\`
  - package=sdk dir=packages/sdk-typescript
  - package=openclaw dir=packages/integrations/openclaw
  - package=openclaw-diagnostics dir=packages/integrations/openclaw-diagnostics
  - package=mastra dir=packages/integrations/mastra
  - package=voltagent dir=packages/integrations/voltagent
\`\`\`

## Out of scope

**PyPI publishing for \`packages/sdk-python\` is intentionally not in this PR.** The package's PyPI name \`lumin\` is taken by an unrelated project (per the in-repo guidance: *\"The API imports lumin from the sibling packages/sdk-python/, NOT from PyPI (where an unrelated package shares the name)\"*). Publishing would either fail (no permission on \`lumin\`) or worse, silently succeed under a stale namespace. Renaming to e.g. \`lumin-io\` (matching the npm scope) is a breaking decision that warrants its own PR.

## Test plan

- [x] YAML parses cleanly
- [x] Matrix expands to 5 entries with correct dirs
- [x] Existing four packages keep their behavior (same install commands)
- [ ] On the next \`v*\` tag: \`@lumin-io/sdk\` publishes alongside the other four
- [ ] Version-mismatch guard fires correctly if \`packages/sdk-typescript/package.json\` isn't bumped