### PR TITLE
feat(release): publish the SDK to PyPI as `lumin-io` (closes #120)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ name: Publish (Docker + npm + ClawHub)
 #   DOCKERHUB_USERNAME / DOCKERHUB_TOKEN — Docker Hub publish
 #   NPM_TOKEN                            — npm publish (auto-token, public scope)
 #   CLAWHUB_TOKEN                        — ClawHub publish (registry-issued)
+#   PYPI_API_TOKEN                       — PyPI publish for `lumin-io`
+#                                          (or set up PyPI Trusted
+#                                          Publishing and drop the token)
 
 on:
   push:
@@ -196,6 +199,68 @@ jobs:
           echo "### :package: Published \`@lumin-io/${{ matrix.package }}@${GITHUB_REF_NAME#v}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Install with: \`npm install @lumin-io/${{ matrix.package }}@${GITHUB_REF_NAME#v}\`" >> "$GITHUB_STEP_SUMMARY"
+
+
+  # ----- PyPI publish ----------------------------------------------------
+  #
+  # Publishes the Python SDK (`packages/sdk-python`) to PyPI as
+  # `lumin-io`. This is the install on-ramp behind `pip install lumin-io`
+  # → `lumin demo`. Tag-triggered + version-guarded like the npm jobs so
+  # a tag can never ship a wheel whose version disagrees with it.
+  #
+  # Auth: PYPI_API_TOKEN secret (project-scoped token). If you'd rather
+  # not store a token, configure PyPI Trusted Publishing for this repo +
+  # workflow and delete the `password:` line — the OIDC `id-token`
+  # permission below already satisfies it.
+  pypi:
+    name: Publish lumin-io to PyPI
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    needs: publish  # don't ship the SDK if the image build failed
+    permissions:
+      contents: read
+      id-token: write  # PyPI Trusted Publishing (OIDC), if enabled
+    defaults:
+      run:
+        working-directory: packages/sdk-python
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify package version matches tag
+        # Same hard guard as the npm jobs: pyproject version must equal
+        # the git tag, or we'd publish a mislabelled wheel that pip
+        # would resolve wrongly forever (PyPI versions are immutable).
+        run: |
+          set -e
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(python -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::pyproject version ($PKG_VERSION) != git tag ($TAG_VERSION) — bump packages/sdk-python/pyproject.toml"
+            exit 1
+          fi
+          echo "version OK: $PKG_VERSION"
+
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/sdk-python/dist/
+          # Delete this line if you switch to PyPI Trusted Publishing.
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "### :snake: Published \`lumin-io@${GITHUB_REF_NAME#v}\` to PyPI" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Install with: \`pip install lumin-io==${GITHUB_REF_NAME#v}\` then \`lumin demo\`" >> "$GITHUB_STEP_SUMMARY"
 
 
   # ----- ClawHub publish -------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 </p>
 
 ```bash
-pip install "lumin @ git+https://github.com/amitbidlan/zistica-lumin#subdirectory=packages/sdk-python"
+pip install lumin-io        # the PyPI name is lumin-io; the command stays `lumin`
 lumin up && lumin demo
 ```
 
@@ -248,7 +248,7 @@ Compatible with anything that speaks OpenTelemetry (Logfire, Phoenix, Datadog Ge
 The fastest path — the `lumin` CLI wraps Docker, waits for health, opens the dashboard, then fires a real attack demo:
 
 ```bash
-pip install "lumin @ git+https://github.com/amitbidlan/zistica-lumin#subdirectory=packages/sdk-python"
+pip install lumin-io   # PyPI dist is `lumin-io`; the command + import stay `lumin`
 lumin up         # starts the container, opens http://localhost:3000
 lumin demo       # instruments a real agent + watch the firewall block a live attack
 lumin scorecard  # grade your firewall vs the OWASP LLM Top-10 attack suite
@@ -256,7 +256,11 @@ lumin scorecard --target http://localhost:11434/v1  # grade ANY agent → sharea
 lumin doctor     # connectivity + which rules are enforcing
 ```
 
-> The PyPI name `lumin` is held by an unrelated project, so install from Git for now. Securing a distribution name (`lumin-ai`, `pipx`/`uvx`, or a vanity domain) is a pre-Show-HN blocker — see `ROADMAP.md`.
+> The PyPI distribution is **`lumin-io`** (the bare name `lumin` is an unrelated project) — brand-consistent with the `@lumin-io/*` npm scope. The command and import stay `lumin`. Published on each tagged release; to run ahead of a release, install from source:
+>
+> ```bash
+> pip install "lumin-io @ git+https://github.com/amitbidlan/zistica-lumin#subdirectory=packages/sdk-python"
+> ```
 
 Or drive Docker yourself:
 
@@ -441,7 +445,7 @@ Single Docker container runs the API on `:8000` and the Next.js standalone dashb
 
 One-shot installer: creates `packages/api/.venv`, installs the local Python SDK editable, installs API dependencies, runs `npm ci` across all 5 Node packages.
 
-The API imports `lumin` from the sibling `packages/sdk-python/`, NOT from PyPI (where an unrelated package shares the name). Don't `pip install lumin` from PyPI inside this workspace.
+The API imports `lumin` from the sibling `packages/sdk-python/`, NOT from PyPI. Note the bare name `lumin` on PyPI is an unrelated project — the Lumin distribution is `lumin-io` (`pip install lumin-io`, `import lumin`). Inside this workspace always use the local editable install (`./setup.sh`), never `pip install lumin`.
 
 ### Python SDK only
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,10 +12,12 @@ if it's not here, it's not promised.
 
 The bar before we post anywhere. These gate the launch, in order:
 
-- [ ] **Distribution name.** `pip install lumin` resolves to an unrelated PyPI
-      project. Decide and ship one of: a vanity name (`lumin-ai`),
-      `pipx`/`uvx run`, or a one-line installer script. *Frictionless install
-      is the #1 conversion lever — this blocks it.*
+- [x] **Distribution name.** Decided: **`lumin-io`** (brand-consistent with
+      the `@lumin-io/*` npm scope; command + import stay `lumin`). pyproject
+      renamed, README updated, and a tag-triggered PyPI publish job added to
+      `publish.yml`. `pip install lumin-io` works from the next tagged
+      release (set the `PYPI_API_TOKEN` secret, or enable PyPI Trusted
+      Publishing, then push a `v*` tag).
 - [x] **`lumin` CLI** — `lumin up` / `lumin demo` / `lumin doctor`. The demo
       fires a real attack at the live firewall and shows real blocks. No keys.
 - [ ] **One-thing demo GIF (≤15s)** — attack fired → red BLOCK row → trace

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -3,9 +3,13 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "lumin"
+# Distribution name is `lumin-io` (the PyPI name `lumin` is held by an
+# unrelated project). Brand-consistent with the `@lumin-io/*` npm scope.
+# The import package and the CLI command both stay `lumin` —
+# `pip install lumin-io` then `import lumin` / `lumin demo`.
+name = "lumin-io"
 version = "0.7.1"
-description = "Local-first AI agent observability SDK"
+description = "Lumin — local-first observability + firewall for AI agents"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
@@ -26,7 +30,7 @@ dependencies = [
 ]
 
 [project.scripts]
-# `pip install lumin` puts a `lumin` command on PATH:
+# `pip install lumin-io` puts a `lumin` command on PATH:
 #   lumin up      start the container + open the dashboard
 #   lumin demo    fire a real attack at the live firewall
 #   lumin doctor  connectivity + detector check


### PR DESCRIPTION
Resolves the #1 pre-launch blocker (**#120**). The bare PyPI name `lumin` is an unrelated project; **`lumin-io`** is brand-consistent with the existing `@lumin-io/*` npm scope. The command and import stay `lumin`.

### Changes
- `pyproject.toml` → `name = "lumin-io"`. Verified: `importlib.metadata.version('lumin-io') == 0.7.1`, `import lumin`, `lumin` CLI, and all 23 CLI tests still green.
- `publish.yml`: new tag-triggered **`pypi`** job — builds sdist+wheel, version-vs-tag hard guard (mirrors the npm jobs), `pypa/gh-action-pypi-publish`, OIDC `id-token` for optional Trusted Publishing.
- README: `pip install lumin-io` is now the primary command; honest from-source fallback retained; dev note + ROADMAP updated.

### Action required to actually ship to PyPI
Set repo secret **`PYPI_API_TOKEN`** (project-scoped), *or* enable PyPI Trusted Publishing for this repo+workflow and delete the `password:` line. Then a `v*` tag publishes `lumin-io` automatically.

Closes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)