### PR TITLE
feat(api): safe-by-default — refuse remote clients when no token is set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,13 @@ LUMIN_SMTP_PASSWORD=
 LUMIN_SMTP_FROM=lumin-firewall@localhost
 LUMIN_SMTP_USE_TLS=true
 
-# --- Auth (Slice 5B — not yet wired) ---
-# When set, requires Authorization: Bearer <token> on all /v1/* calls
+# --- Auth ---
+# When set, requires Authorization: Bearer <token> on all /v1/* calls.
+# When UNSET, the API is open to loopback only — non-loopback clients
+# get 403 (so an instance bound to 0.0.0.0 can't leak traces).
 # LUMIN_API_TOKEN=
+# Accept the risk of serving the API to non-loopback clients with no
+# token (trusted private network, or auth terminated at a proxy):
+# LUMIN_ALLOW_INSECURE=1
 # When set, dashboard requires login at /login
 # LUMIN_DASHBOARD_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ docker run -d \
   zistica/lumin:latest
 ```
 
-⚠️ **Public VPS deployment**: the dashboard at `:3000` has **no authentication today**. Bind ports to `127.0.0.1` (as shown) and reach the dashboard via SSH tunnel: `ssh -L 3000:localhost:3000 user@vps`. Auth lands in Slice 5B.
+⚠️ **Public VPS deployment**: the API (`:8000`) is **safe by default** — with no `LUMIN_API_TOKEN` set it serves loopback only and returns `403 remote_access_requires_auth` to non-loopback clients, so an instance accidentally bound to `0.0.0.0` won't leak your traces or the firewall control plane. For real remote access set `LUMIN_API_TOKEN` (then send `Authorization: Bearer <token>`); to deliberately run open on a trusted network set `LUMIN_ALLOW_INSECURE=1`. The dashboard (`:3000`) still has no built-in login — set `LUMIN_DASHBOARD_PASSWORD`, bind to `127.0.0.1` (as shown), and tunnel: `ssh -L 3000:localhost:3000 user@vps`.
 
 ### Smaller image (size-constrained VPS)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,8 +38,13 @@ The bar before we post anywhere. These gate the launch, in order:
       firewall" migration guide.
 - [ ] **Reproducible public benchmark** — Lumin vs. a named prompt-injection
       corpus, numbers + methodology in `/bench`.
-- [ ] **Dashboard auth, on by default for non-localhost binds** — the
-      mechanism exists (`LUMIN_DASHBOARD_PASSWORD`); make safe the default.
+- [x] **API safe-by-default for non-localhost binds** — no token + a
+      non-loopback client → `403 remote_access_requires_auth` (loopback
+      stays zero-friction; `LUMIN_ALLOW_INSECURE=1` to opt out). 729 API
+      tests green.
+- [ ] **Dashboard auth on by default** — same posture for the `:3000`
+      Next.js app (`LUMIN_DASHBOARD_PASSWORD` mechanism exists; mirror the
+      API's loopback-vs-remote default in `middleware.ts`).
 
 ## 🌅 Later — the moat
 

--- a/packages/api/auth.py
+++ b/packages/api/auth.py
@@ -1,9 +1,13 @@
 """Bearer-token authentication middleware (Slice 5B).
 
-Default-off. When ``LUMIN_API_TOKEN`` is unset, the middleware is a
-no-op and the API behaves exactly like it did before — every
-endpoint is reachable without credentials. This preserves the
-zero-friction localhost-dev story.
+Default-off for localhost. When ``LUMIN_API_TOKEN`` is unset, every
+endpoint is reachable without credentials **from loopback** — the
+zero-friction localhost-dev story is unchanged. But an instance with
+no token that is reachable from a non-loopback address refuses remote
+requests (HTTP 403) instead of silently serving every trace, prompt,
+and the firewall control plane to the network. Operators opt back into
+the old wide-open behavior with ``LUMIN_ALLOW_INSECURE=1``; the right
+fix is to set ``LUMIN_API_TOKEN``.
 
 When ``LUMIN_API_TOKEN`` is set, every request to ``/v1/*``,
 ``/ws/*``, and ``/health/admin`` requires:
@@ -38,6 +42,7 @@ fires.
 from __future__ import annotations
 
 import hmac
+import ipaddress
 import logging
 import os
 from typing import Iterable, Optional, Tuple
@@ -47,6 +52,10 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 
 logger = logging.getLogger("lumin.api.auth")
+
+# One-time latch so a remote-exposed-without-auth instance logs its
+# posture once (at the first offending request) instead of every time.
+_warned_insecure_exposure = False
 
 
 # Paths that are ALWAYS reachable without a token. Order doesn't
@@ -73,6 +82,37 @@ def _expected_token() -> Optional[str]:
 
 def auth_enabled() -> bool:
     return _expected_token() is not None
+
+
+def insecure_allowed() -> bool:
+    """Operator escape hatch: ``LUMIN_ALLOW_INSECURE=1`` accepts the
+    risk of serving the API to non-loopback clients without a token
+    (e.g. a trusted private network, or auth terminated at a proxy)."""
+    return os.environ.get("LUMIN_ALLOW_INSECURE", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _client_is_local(request: Request) -> bool:
+    """True when the request's transport peer is loopback.
+
+    This is the socket peer the ASGI server reports — NOT a
+    user-controllable header — so it can't be spoofed by a remote
+    client. Behind a reverse proxy every request looks loopback;
+    those deployments must set ``LUMIN_API_TOKEN`` (the proxy can't
+    be the security boundary for the trace store). Unknown / non-IP
+    peers (Starlette TestClient's ``testclient``, ``localhost``, or a
+    missing client on some ASGI servers) are treated as local so the
+    zero-friction localhost story and the test suite are unaffected.
+    """
+    client = request.client
+    if client is None or not client.host:
+        return True
+    host = client.host
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return host in ("localhost", "testclient")
 
 
 def _is_public_path(path: str) -> bool:
@@ -109,11 +149,48 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
     forget the header?" from "did the rotated token get pushed?"."""
 
     async def dispatch(self, request: Request, call_next):  # type: ignore[no-untyped-def]
-        expected = _expected_token()
-        if expected is None:
-            return await call_next(request)
-
         path = request.url.path
+        expected = _expected_token()
+
+        if expected is None:
+            # No token configured. Localhost keeps the zero-friction
+            # story (open, exactly as before). But a Lumin bound to a
+            # public interface with no token would serve every trace,
+            # prompt, and the firewall control plane to the world —
+            # refuse non-loopback clients unless the operator has
+            # explicitly accepted the risk. Public paths (healthcheck,
+            # spec) stay open so probes and the container healthcheck
+            # don't break.
+            if (
+                _is_public_path(path)
+                or _client_is_local(request)
+                or insecure_allowed()
+            ):
+                return await call_next(request)
+            global _warned_insecure_exposure
+            if not _warned_insecure_exposure:
+                _warned_insecure_exposure = True
+                logger.warning(
+                    "Refusing non-loopback request from %s with no "
+                    "LUMIN_API_TOKEN set. Set a token to allow remote "
+                    "access, or LUMIN_ALLOW_INSECURE=1 to accept the risk.",
+                    getattr(request.client, "host", "?"),
+                )
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "error": "remote_access_requires_auth",
+                    "detail": (
+                        "This Lumin is reachable from a non-loopback "
+                        "address but has no LUMIN_API_TOKEN set, so it "
+                        "won't serve traces/policies to remote clients. "
+                        "Set LUMIN_API_TOKEN (recommended) and send "
+                        "Authorization: Bearer <token>, or set "
+                        "LUMIN_ALLOW_INSECURE=1 to accept the risk."
+                    ),
+                },
+            )
+
         if _is_public_path(path):
             return await call_next(request)
 
@@ -140,4 +217,8 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-__all__ = ["BearerAuthMiddleware", "auth_enabled"]
+__all__ = [
+    "BearerAuthMiddleware",
+    "auth_enabled",
+    "insecure_allowed",
+]

--- a/packages/api/tests/test_auth.py
+++ b/packages/api/tests/test_auth.py
@@ -172,3 +172,63 @@ def test_constant_time_compare_used(client: TestClient, monkeypatch) -> None:
     assert short.status_code == 403
     assert same_len.status_code == 403
     assert longer.status_code == 403
+
+
+# ----- safe-by-default: remote exposure without a token --------------------
+#
+# No token + loopback = open (unchanged). No token + a non-loopback peer
+# = refuse, so a Lumin accidentally bound to 0.0.0.0 on a VPS doesn't
+# serve every trace + the firewall control plane to the internet.
+
+
+@pytest.fixture
+def remote_client():
+    """A TestClient whose transport peer is a public IP (not loopback)."""
+    db = Database(duckdb_path=":memory:", sqlite_path=":memory:")
+    main.app.dependency_overrides[main.get_db] = lambda: db
+    yield TestClient(main.app, client=("203.0.113.7", 44441))
+    main.app.dependency_overrides.clear()
+    db.close()
+
+
+def test_remote_v1_blocked_when_no_token(remote_client, monkeypatch) -> None:
+    _clear_token(monkeypatch)
+    monkeypatch.delenv("LUMIN_ALLOW_INSECURE", raising=False)
+    resp = remote_client.get("/v1/traces")
+    assert resp.status_code == 403
+    assert resp.json()["error"] == "remote_access_requires_auth"
+
+
+def test_remote_health_still_open_when_no_token(remote_client, monkeypatch) -> None:
+    """Probes / container healthcheck must survive remote exposure."""
+    _clear_token(monkeypatch)
+    monkeypatch.delenv("LUMIN_ALLOW_INSECURE", raising=False)
+    assert remote_client.get("/health").status_code == 200
+
+
+def test_remote_allowed_with_insecure_optin(remote_client, monkeypatch) -> None:
+    _clear_token(monkeypatch)
+    monkeypatch.setenv("LUMIN_ALLOW_INSECURE", "1")
+    resp = remote_client.get("/v1/traces")
+    assert resp.status_code not in (401, 403)
+
+
+def test_remote_allowed_with_token(remote_client, monkeypatch) -> None:
+    """Setting a token is the recommended fix — remote then works
+    with the bearer header, exactly like the localhost case."""
+    _set_token(monkeypatch, "right-token")
+    blocked = remote_client.get("/v1/traces")
+    assert blocked.status_code == 401  # token path, not the remote 403
+    ok = remote_client.get(
+        "/v1/traces", headers={"Authorization": "Bearer right-token"},
+    )
+    assert ok.status_code not in (401, 403)
+
+
+def test_localhost_still_open_when_no_token(client: TestClient, monkeypatch) -> None:
+    """Regression guard: the zero-friction localhost story is intact —
+    the default TestClient peer is treated as local."""
+    _clear_token(monkeypatch)
+    monkeypatch.delenv("LUMIN_ALLOW_INSECURE", raising=False)
+    resp = client.get("/v1/traces")
+    assert resp.status_code not in (401, 403)


### PR DESCRIPTION
Closes the security hole the README itself warned about: a Lumin bound to `0.0.0.0` with no `LUMIN_API_TOKEN` served every trace, prompt, and the firewall control plane to anyone who could reach the port.

### Behavior with **no token configured**
| Caller | Before | After |
|---|---|---|
| loopback (localhost dev) | open | **open (unchanged)** |
| `/health`, `/openapi.json`, `/docs` | open | **open** (probes/healthcheck survive) |
| any non-loopback peer | **open (leak)** | **403 `remote_access_requires_auth`** + one-time server warning |
| non-loopback + `LUMIN_ALLOW_INSECURE=1` | open | open (explicit opt-out) |

Token-set behavior is **unchanged**. The peer is judged by the ASGI transport socket, not a spoofable header; reverse-proxy deployments must set a token (documented in the docstring + README).

### Verification
- Full API suite: **729 passed, 12 skipped, 0 failed** — no regression from the global middleware change.
- New tests drive a **real** Starlette client scope (`TestClient(app, client=("203.0.113.7", …))`), not a mock: remote-blocked, health-still-open, insecure-opt-in, token-works-remote, localhost-still-open.
- `auth.py` docstring, README VPS note, `.env.example`, ROADMAP updated.

### Scope / honesty
The dashboard (`:3000` Next.js) still has no built-in login — mirroring this posture in `middleware.ts` is a **separate PR** (different language + risk surface), tracked in ROADMAP. This PR makes the *data + control plane* (the API) safe by default, which is the real exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)